### PR TITLE
Fix the trusted-publisher script for npm 12

### DIFF
--- a/scripts/trust-publishers.sh
+++ b/scripts/trust-publishers.sh
@@ -69,6 +69,7 @@ for name in $NAMES; do
   if npm trust github "$name" \
     --repo "$REPO" \
     --file "$WORKFLOW" \
+    --allow-publish \
     --yes
   then
     echo "  trusted   $name"

--- a/scripts/trust-publishers.sh
+++ b/scripts/trust-publishers.sh
@@ -29,6 +29,21 @@ if ! npm whoami >/dev/null 2>&1; then
   exit 1
 fi
 
+# `npm trust` exists before 11.15.0 but sends a payload the registry rejects
+# with a bare 400 ("value must be an array"), once per package and with no
+# indication that the CLI is the problem. Fail up front instead.
+NPM_VERSION=$(npm --version)
+if ! node -e '
+  const [have, want] = [process.argv[1], "11.15.0"].map((v) => v.split(".").map(Number));
+  const ok = have[0] > want[0]
+    || (have[0] === want[0] && (have[1] > want[1] || (have[1] === want[1] && have[2] >= want[2])));
+  process.exit(ok ? 0 : 1);
+' "$NPM_VERSION"; then
+  echo "npm $NPM_VERSION is too old for 'npm trust' (needs >= 11.15.0)." >&2
+  echo "Run: npm install -g npm@latest" >&2
+  exit 1
+fi
+
 ok=0
 skipped=0
 failed=0


### PR DESCRIPTION
Two follow-ups to `scripts/trust-publishers.sh`, both found while actually running it.

**Fail fast on an old npm.** `npm trust` exists in 11.12.1 but sends a payload the registry rejects with a bare `400` and no body, once per package, with nothing indicating the CLI is at fault. Diagnosed by calling the trust endpoint directly, which answers `{"message":"\"value\" must be an array"}`. The version floor is now checked before any package is touched.

**Restore `--allow-publish`.** The flag's status changed across npm versions and I followed the wrong one: it does not exist in 11.12.1 (every call failed `EUSAGE`), and it is mandatory in 12.0.1 (`At least one permission flag is required`). Verified with `npm trust github --dry-run` on npm 12.0.1, which reports `permissions: publish`.

All nine launch packages are now configured, so future releases run through `publish.yml` with no credential and automatic provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrcodkR5m6hfEXewt7t6bL