### PR TITLE
Make the publish backstop prove itself in a dry run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -317,6 +317,43 @@ jobs:
           if-no-files-found: warn
           retention-days: 90
 
+      # The backstop rehearsal, and it sits HERE, above `Rehearse the publish`,
+      # deliberately.
+      #
+      # It used to be the last step in the file. At an already-published version
+      # `Rehearse the publish` correctly fails on npm's immutable-version rule
+      # and everything after it is skipped; at an unpublished version there is
+      # nothing on the registry to install. Between the two, the backstop had
+      # never once executed. That is the same shape as the `npm view` check it
+      # replaced: wired, believed, unproven, which is how 0.1.0 shipped broken.
+      #
+      # Ordering it above that step is enough on its own to make an
+      # already-published dry run exercise it, and `--rehearsal` covers the other
+      # case by retargeting the registry's current `latest` when the requested
+      # version is not published yet. So every dry run installs a real release
+      # from npmjs.com into a project outside the workspace and makes it produce
+      # a real diagnostic and a real AST, whichever version was dispatched.
+      #
+      # Nothing here touches `Rehearse the publish`. That step still runs, still
+      # against npmjs.com, and still fails when the version is taken.
+      #
+      # What the rehearsal proves is the mechanism plus the health of whatever is
+      # already published. It proves nothing about the version being dispatched:
+      # that is the gate directly above, which asserts the nine tarballs and
+      # installs them, and which has to pass before this step is reached.
+      - name: Rehearse the backstop
+        if: inputs.mode == 'dry-run'
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/verify-published-release.mjs \
+            --version "$VERSION" \
+            --order-file publish-order.txt \
+            --attempts 2 \
+            --rehearsal
+
       # Always rehearsed, including in publish mode. Provenance is switched off
       # for the rehearsal only: a dry run has nothing to attest, and asking
       # Sigstore for a signature it will never use adds a failure mode to the
@@ -392,21 +429,3 @@ jobs:
           node scripts/verify-published-release.mjs \
             --version "$VERSION" \
             --order-file publish-order.txt
-
-      # The same backstop in dry-run mode. If this version is not on the
-      # registry it has nothing to install and says so; if it is, a rehearsal
-      # verifies the release that is already out there. Either way the code path
-      # the release depends on is exercised by a dry run rather than only by an
-      # irreversible publish.
-      - name: Rehearse the backstop
-        if: inputs.mode == 'dry-run'
-        shell: bash
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          node scripts/verify-published-release.mjs \
-            --version "$VERSION" \
-            --order-file publish-order.txt \
-            --attempts 2 \
-            --allow-unpublished

--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -33,6 +33,16 @@ jobs:
   # both suites were confirmed green against a build with no wasm artifact at
   # all. The full artifact-and-deploy path stays on push and dispatch, where the
   # bytes it produces are actually used.
+  #
+  # The one thing a pull request does not get: the checks that need the real
+  # engine. "generated WebAssembly executes the real lint, format, and
+  # projection engines" self-skips without the artifact, and the static
+  # verifier runs 113 checks here against 151 on `main`. Everything that binds
+  # the docs to this repository's own source, including the platform-support
+  # drift test, runs in both.
+  #
+  # Cost, measured on this branch: 2m01s here (run 30339461008) against 6m05s
+  # for the build job plus 31s to deploy (run 30338110699).
   site-tests:
     name: Site tests
     if: github.event_name == 'pull_request'

--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -3,6 +3,7 @@ name: Build website artifact
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -10,10 +11,57 @@ permissions:
 
 concurrency:
   group: site-artifact-${{ github.ref }}
-  cancel-in-progress: false
+  # A superseded pull-request run is wasted wall clock. A superseded run on main
+  # is a deploy that never happened, so those still queue.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Pull requests get the site tests and nothing else.
+  #
+  # The drift test that binds docs/reference/platform-support.md to
+  # packages/toolchain/dist/native-targets.js lives in test:site:unit, and this
+  # workflow was the only place that ran it. Triggering on push to main meant a
+  # pull request could diverge the published support matrix from the target list
+  # this project actually builds and only find out after it landed.
+  #
+  # This job exists rather than simply letting `build` run on pull requests
+  # because `build` installs a Rust target and compiles the WebAssembly demo
+  # engine with no cargo cache in this workflow. That is minutes per pull
+  # request to prove something no pull request is asking about. Everything the
+  # site tests need is a plain `docs:build`: the site falls back to the static
+  # demo when the WebAssembly artifact is absent (docs/build.mjs:1743-1750), and
+  # both suites were confirmed green against a build with no wasm artifact at
+  # all. The full artifact-and-deploy path stays on push and dispatch, where the
+  # bytes it produces are actually used.
+  site-tests:
+    name: Site tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out the pull request revision
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install the pinned pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Install Node.js 24.15.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install the locked documentation graph
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Prove the site still builds and its claims still hold
+        run: |
+          pnpm run docs:build
+          pnpm run test:site:unit
+          pnpm run test:site:static
+
   build:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:

--- a/docs/releasing/platform-management-followups.md
+++ b/docs/releasing/platform-management-followups.md
@@ -1,0 +1,249 @@
+# Platform management follow-ups
+
+Five known problems in how this project manages its eight native platforms.
+None of them is broken today. All five are the same shape: machinery that a
+human maintains by hand, with nothing that fails when the hand slips.
+
+They were found while making platform coverage provable (Windows and macOS
+execution on every pull request, the pre-publish gate, the published support
+matrix). They were deliberately left out of that work because each is its own
+piece of engineering, and they are written down here because the working notes
+they came from are not in version control.
+
+Nothing here is urgent. Read this before the next release, or before touching
+the release workflows, whichever comes first.
+
+**Line numbers move.** Every one below was checked on 2026-07-28. If a line
+number does not match, search for the quoted text instead.
+
+---
+
+## 1. Version pins are hand-edited, and one has already drifted
+
+**What is wrong.** There is no bump script. Releasing means editing the version
+in the root manifest, in every workspace manifest, and in the eight cross-pins
+that `oxc-tsrx` uses to reach its platform packages, and then editing the test
+that asserts those pins.
+
+The places a bump touches:
+
+| File | What is pinned |
+| --- | --- |
+| `package.json:3` | the workspace version, `0.1.4` today |
+| `package.json:86` | `@oxc-tsrx/native-darwin-arm64`, a root devDependency, **pinned at `0.1.1`** |
+| `packages/toolchain/package.json:3` | the published version of `oxc-tsrx` |
+| `packages/toolchain/package.json:119-126` | the eight `optionalDependencies`, one per platform |
+| `packages/tsrx-core-compat/package.json` | its own version |
+| `packages/vscode/package.json` | its own version |
+| `tests/packaging/public-package-metadata.test.mjs:46,67-74` | the version literal and all eight pins, asserted |
+
+`package.json:86` is the drift. It pins `@oxc-tsrx/native-darwin-arm64` at
+`0.1.1` in a workspace that is at `0.1.4`.
+
+**Why it matters, and how much.** That particular drift is low severity and you
+should not rush to fix it in isolation: it is a root `devDependency`, nothing
+published depends on it, and the pins that consumers actually resolve are
+asserted at `0.1.4` by `tests/packaging/public-package-metadata.test.mjs`. So
+the published surface is protected. What is not protected is the process that
+produces it. The drift is the visible symptom: a pin went stale for three
+releases and no check anywhere noticed, which is the same failure mode that let
+two out-of-workspace `Cargo.lock` files go stale for two releases.
+
+**Research finding worth keeping.** oxc and rolldown do not hand-edit these
+pins at all. Both *generate* the per-platform `optionalDependencies` with the
+napi CLI as a release step (`napi pre-publish` / `napi create-npm-dirs`; oxc's
+release workflow comments that it "adds optionalDependencies to package_path").
+Hand-editing has no precedent among the projects surveyed. Both projects also
+gate the whole release on an automated version-change detector rather than on a
+human noticing.
+
+**What fixing it would involve.** Either adopt the napi CLI generation step, or
+write a bump script that derives every pin from one source of truth and a test
+that fails when any manifest disagrees with the root version. The test is the
+cheaper half and it is worth landing even without the script: it converts a
+silent drift into a red build. Note that the assertion test itself carries
+literals, so whatever generates the pins should generate its fixture too, or
+the test just becomes another thing to hand-edit.
+
+---
+
+## 2. The eight-target list is hand-duplicated in ten places
+
+**What is wrong.** `packages/toolchain/dist/native-targets.js` is the canonical
+list of the eight targets. Ten other files restate it by hand:
+
+| File | Line | What it restates |
+| --- | --- | --- |
+| `.github/workflows/release-candidate.yml` | 27-77 | the build matrix: target, package suffix, runner, expected platform, arch, libc |
+| `packages/toolchain/package.json` | 119-126 | the eight `optionalDependencies` |
+| `docs/releasing/v0.1.0-launch.json` | 17-27 | the publish order |
+| `tests/packaging/public-package-metadata.test.mjs` | 67-74 | the expected pins |
+| `docs/reference/platform-support.md` | 40-80, the tier lists | the reader-facing matrix |
+| `docs/releasing/platform-abi-policy.md` | 14-21 | target, runner, npm selector, VSIX target |
+| `docs/releasing/publish-runbook.md` | 31, 158, 202 | the nine names, twice as shell commands |
+| `docs/releasing/launch-runbook.md` | 49-57 | the nine names |
+| `docs/releasing/external-prerequisites.md` | 14-17 | the eight scoped names |
+| `docs/archive/tsrx-parser-api.md` | 1824-1831 | an archived matrix, no longer maintained |
+
+**Why it matters.** Adding or removing a target means finding all eleven copies.
+A workflow copy fails loudly when it goes stale. A docs copy does not: it just
+quietly tells a reader their platform is supported, or fails to mention one that
+is. There is precedent for exactly that: the four-name collapse of 2026-07-25
+left several of these lists disagreeing until they were corrected one at a time
+by hand.
+
+**What already covers part of it.** `tests/site/platform-support-matrix.test.mjs`
+binds `docs/reference/platform-support.md` to `native-targets.js` and fails when
+either side gains, loses, or renames a target. That is one copy of ten. It runs
+in `site-artifact.yml`, on pull requests and on `main`.
+
+**What fixing it would involve.** Two separable pieces. The release matrix can
+be generated: a small job emits `native-targets.js` as JSON and the build matrix
+reads it through `fromJSON`, which removes the copy that costs the most when it
+is wrong. The docs copies are better deleted than tested: most of them could
+link to `docs/reference/platform-support.md` instead of restating it, leaving
+two lists in the repository rather than eleven. Extending the drift test to the
+remaining docs copies is the cheap middle option and would take about an hour.
+
+---
+
+## 3. Forty-three hardcoded toolchain literals across the workflows
+
+**What is wrong.** Rust, Node, and Vite+ versions are written out in full at
+every use site.
+
+```sh
+grep -rn "1\.95\.0\|1\.97\.0\|24\.15\.0\|0\.1\.24\|0\.2\.4" .github/workflows | wc -l
+```
+
+That returns 43 today, across five workflow files: `advisory.yml` 11,
+`ci.yml` 16, `publish.yml` 3, `release-candidate.yml` 9, `site-artifact.yml` 4.
+It was 41 when it was first counted a few days earlier, which is itself the
+point: the number moves and nobody is tracking it.
+
+Two Rust versions are in play deliberately, and the split is easy to lose:
+`1.95.0` is the build toolchain for shipped artifacts (`ci.yml:37-40`,
+`ci.yml:174-178`, `release-candidate.yml:112-113`), and `1.97.0` is a
+forward-looking lane plus the SBOM tooling (`ci.yml:43`,
+`release-candidate.yml:249-253`, `advisory.yml:42-46`).
+
+One literal is baked into a **job display name**:
+
+```yaml
+# .github/workflows/ci.yml:255
+name: Clean install / Vite+ 0.1.24 and 0.2.4
+```
+
+**Why it matters.** A toolchain bump is a find-and-replace across five files
+where a missed site does not fail, it just silently keeps building on the old
+version. The display name is worse than the others: it is the string that
+appears in the checks list and in branch protection rules, so it can claim a
+version the job no longer uses, and renaming it breaks any required-check
+configuration that names it.
+
+**What fixing it would involve.** Workflow-level `env` covers most of the sites.
+Be aware of one wrinkle before starting: `jobs.<id>.name` cannot read the `env`
+context, only `github`, `needs`, `strategy`, `matrix`, `vars`, and `inputs`. So
+the display name needs either a repository variable or a rewording that carries
+no version at all, which is probably the right answer. A test that greps the
+workflows for a version literal outside the declared `env` block would keep it
+from growing back.
+
+---
+
+## 4. The image that builds the shipped artifact is never the image that verifies it
+
+**What is wrong.** The two pipelines run on different runner images and
+different Rust versions.
+
+| | `release-candidate.yml` (builds what ships) | `ci.yml` (verifies) |
+| --- | --- | --- |
+| Linux | `ubuntu-22.04`, `ubuntu-22.04-arm` (`:42-60`) | `ubuntu-24.04` (`:29`, `:145`) |
+| Windows | `windows-2025`, `windows-11-arm` (`:66-71`) | `windows-latest` (`:147`) |
+| macOS | `macos-14`, `macos-15-intel` (`:30-36`) | `macos-latest` (`:149`) |
+| Rust | `1.95.0` (`:112-113`), `1.97.0` in the assemble job (`:249-253`) | `1.95.0` (`:174-178`) and `1.97.0` (`:43`) |
+
+**Which half of this is deliberate.** The Linux difference is a decision, not an
+accident: GNU builds use Ubuntu 22.04 to keep the glibc floor low, and
+`release-candidate.yml:150-156` asserts that no shipped binary references a
+symbol newer than `GLIBC_2.35`. That is documented at
+`docs/releasing/platform-abi-policy.md:29-33` and should stay. The rest is
+unexamined. `windows-latest` and `macos-latest` are moving labels, so what CI
+verifies on can change without a commit, and whether it currently matches the
+pinned release image is not something a reader can tell from the file.
+
+**Why it matters.** A defect that only appears on the image the release is built
+on cannot be caught by a lane running on a different image. It is a narrow gap
+rather than a gaping one, because the release candidate does execute a real
+lint, a real format, and live `--lsp` sessions on natively matching runners for
+all eight targets. But that only happens on manual dispatch, so the continuous
+lanes are the ones that would catch a regression early, and they run elsewhere.
+
+**What fixing it would involve.** Cheapest first: pin `windows-latest` and
+`macos-latest` in `ci.yml` to the images the release actually uses, so the two
+sides are readable and a runner-image migration becomes a commit rather than a
+surprise. Aligning Linux is the expensive one and probably not worth it, since
+`ubuntu-24.04` is the right image for a verification lane and `ubuntu-22.04` is
+the right image for a shipped artifact. Write down which differences are
+intentional, next to the assertion that enforces the floor.
+
+---
+
+## 5. The Windows `0xC0000409` fast-fail is external and undiagnosed
+
+**What is wrong.** On Windows runners, an `npm` or `pnpm` child process is
+occasionally killed by Windows itself with exit status `3221226505`
+(`0xC0000409`, `STATUS_STACK_BUFFER_OVERRUN`) part-way through an install.
+
+**The measured rate.** 6 fast-fails in 54 unmodified executions of the Windows
+packaging suite: roughly one in thirty-five package-manager installs, which
+works out to about **11% of runs** because each run performs several installs.
+It is recorded in the test that trips over it, at
+`tests/packaging/released-host-install.test.mjs:112-126`.
+
+**What has been ruled out, with evidence.**
+
+- *This project's own code.* Every install passes `--ignore-scripts`, so no code
+  from this repository is loaded into the process that dies. It hits `npm.cmd`
+  and `pnpm.cmd` identically, at install positions 1, 4 and 5, with no pattern.
+- *A recently added test step.* It reproduced on a fresh machine with the
+  packaging suite moved ahead of the new steps.
+- *Resource pressure or accumulated residue.* It failed on an idle machine with
+  13 GB free memory, 29 GB free disk, zero surviving node processes and no
+  leftover temp directories; eight further runs on that same dirty machine all
+  passed. Handle count stayed flat at ~47k across the job.
+- *Windows Defender.* `RealTimeProtectionEnabled` is `False` on the image.
+- *A Node fatal error.* `--report-on-fatalerror` was armed for every child across
+  24 runs including two that fast-failed, and no report was written, so it is
+  neither an out-of-memory nor a V8 `CHECK`.
+- *Any exception Windows Error Reporting can see.* `WerSvc` running, `LocalDumps`
+  and `SilentProcessExit` both armed for `node.exe`, and both reproductions
+  produced no dump and no Application Error event.
+- *A Node version regression.* 12 runs on 22.12.0 and 12 on 24.15.0, zero
+  fast-fails in either arm.
+
+A process exiting `0xC0000409` while all three of those recorders are armed and
+none of them records anything is not the shape of an ordinary unhandled
+exception. Going further needs a live debugger on a `windows-2025` runner.
+
+**Why it matters.** At about 11% per run, roughly one pull request in nine gets
+a red Windows leg for a reason that has nothing to do with the change. That is
+the rate at which people start ignoring the lane, which is worse than not having
+it. It is also not new: the step it hits pre-dates continuous Windows execution,
+so this was happening before anyone was watching.
+
+**What has already been done.** The assertion now names the status instead of
+printing a bare `3221226505`, so the next person does not have to rediscover
+which of the two readings of that integer applies. Nothing tolerates it: the
+assertion still fails.
+
+**The decision that is still open**, and it belongs to the owner rather than to
+a test:
+
+- a narrowly scoped retry, restricted to this exact status on this exact class
+  of child process, which risks masking a genuine crash of the same shape; or
+- an upstream report to `actions/runner-images` with the measurements above,
+  which costs nothing but fixes nothing on any schedule you control.
+
+Doing both is reasonable. Doing neither means the lane keeps failing at 11% and
+the flake gradually teaches everyone to press rerun.

--- a/docs/releasing/publish-runbook.md
+++ b/docs/releasing/publish-runbook.md
@@ -571,11 +571,33 @@ Verified on darwin-arm64 only:
 
 Not verified anywhere:
 
-- **Any part of the trusted publishing flow.** No publish, dry run, or `npm
-  trust` call in this runbook has been executed against the real registry. The
-  gate and the backstop have both run end to end, the gate over the nine real
-  0.1.4 candidate tarballs and on all three Tier 1 CI lanes, but the publish
-  itself has not happened.
+- **The gate and the backstop in `publish` mode.** Both have run end to end, but
+  neither has run on the same job as a real publish, because both landed after
+  0.1.4 shipped. The gate has run over the nine real 0.1.4 candidate tarballs on
+  the publish runner and on all three Tier 1 CI lanes. The backstop script ran
+  against npmjs.com in dry run
+  [30339428030](https://github.com/markless-dev/oxc-tsrx/actions/runs/30339428030),
+  installing `oxc-tsrx@0.1.4` from the registry and linting and parsing through
+  it. What is still unexercised is the two `if: inputs.mode == 'publish'` steps
+  themselves, which are one condition away from what did run.
+- **The `--rehearsal` retargeting branch, in CI.** Proven locally only. A dry run
+  can only be dispatched at the version the candidate artifacts carry, and that
+  version is currently published, so CI takes the direct path rather than the
+  retarget. The retarget is what the next release's dry run will take, since its
+  version will not be published yet.
+
+Verified, contrary to what earlier revisions of this page said:
+
+- **Trusted publishing.** `oxc-tsrx@0.1.4` was published by
+  `.github/workflows/publish.yml` on `refs/heads/main` in run
+  [30314008255](https://github.com/markless-dev/oxc-tsrx/actions/runs/30314008255),
+  and says so itself: `npm view oxc-tsrx@0.1.4 dist.attestations` resolves a
+  SLSA provenance attestation naming that workflow, that ref, and that run. No
+  laptop publish can produce one. What that run used as its final check was the
+  old `npm view` loop, which is why the backstop exists.
+
+And one thing that is not a gap but reads like one:
+
 - Vite+ cannot be served by a plain install. It resolves the *package* name
   `oxlint`, which a bin cannot satisfy and which this project cannot legitimately
   publish. `npx oxc-tsrx setup` remains the one command that fixes it. Say that

--- a/docs/releasing/publish-runbook.md
+++ b/docs/releasing/publish-runbook.md
@@ -350,7 +350,21 @@ What the workflow checks before it writes anything:
   each pinned to that version;
 - **the gate**, `scripts/check-publish-artifacts.mjs`, over all nine tarballs.
 
-Then it dry-runs all nine, and only then publishes all nine in order.
+Then, in this order:
+
+1. **Rehearse the backstop** (`dry-run` mode only). Installs a real published
+   release from npmjs.com and runs it. See
+   [what a dry run proves](#what-a-dry-run-proves) below.
+2. **Rehearse the publish**. `npm publish --dry-run` against npmjs.com for all
+   nine, which is also the check that the version is still free.
+3. **Publish in launch-contract order** (`publish` mode only).
+4. **Install the published release from the registry and run it** (`publish`
+   mode only). The backstop itself.
+
+The backstop rehearsal sits above the publish rehearsal on purpose. It used to
+be the last step in the file, where it was skipped whenever the publish
+rehearsal correctly refused an already-published version. That is how it reached
+0.1.4 having never executed once.
 
 ### The gate
 
@@ -389,7 +403,36 @@ are.
 One known limit: in `dry-run` mode at a version that is already on npm, the
 separate "Rehearse the publish" step against npmjs.com fails with `You cannot
 publish over the previously published versions`. That is the check working. Use
-an unpublished version if you want a clean dry run end to end.
+an unpublished version if you want a clean dry run end to end. Every step before
+it, including the backstop rehearsal, has already run by then.
+
+### What a dry run proves
+
+A dry run is the only way the post-publish backstop is ever exercised, so it is
+worth being exact about what it does and does not establish.
+
+| Step | In a dry run it | Proves |
+| --- | --- | --- |
+| The gate | runs in full over the nine tarballs you are about to publish | those exact artifacts install and work on this runner |
+| Rehearse the backstop | installs a real release from npmjs.com and lints and parses through it | the backstop mechanism works, and whatever is currently on npm still installs and works |
+| Rehearse the publish | asks npmjs.com to accept all nine | the version is free and npm accepts the tarball shape |
+
+The backstop rehearsal cannot install the version being rehearsed, because that
+version is not published yet. So `scripts/verify-published-release.mjs
+--rehearsal` retargets: if the requested version is not on the registry, it runs
+every stage against the current `latest` of `oxc-tsrx` instead, and says so in
+the log. If the requested version *is* already published, it runs against that.
+Either way the dry run installs something real from the registry into a project
+outside the workspace and makes it produce a real diagnostic and a real AST.
+
+What that does **not** prove is anything about the pending version's artifacts.
+The gate directly above it covers those, on this runner and on all three Tier 1
+platforms in `ci.yml`. Keep the two claims apart when reading the log: the gate
+speaks about the release being made, the rehearsal speaks about the mechanism
+and about the release already out there.
+
+It follows that a failing backstop rehearsal at a version that is already
+published is real news: the release on npm no longer installs and runs.
 
 ### If the publish fails with ENEEDAUTH or E404
 
@@ -438,10 +481,12 @@ Step 2 is the reason a post-publish check survives at all: it is the only place
 that sees npm's own handling of the upload, which no pre-publish check can
 reach.
 
-The same script runs in `dry-run` mode with `--allow-unpublished`, so the code
-path the release depends on is exercised by a rehearsal rather than only by an
-irreversible publish. If the version is not on the registry it says so and
-exits 0.
+The same script runs earlier in the job in `dry-run` mode with `--rehearsal`, so
+the code path the release depends on is exercised by a rehearsal rather than
+only by an irreversible publish. See
+[what a dry run proves](#what-a-dry-run-proves). The only case it skips is a
+package with no published version at all, where there is genuinely nothing to
+install.
 
 ### What is still yours to check by hand
 
@@ -536,6 +581,9 @@ Not verified anywhere:
   publish. `npx oxc-tsrx setup` remains the one command that fixes it. Say that
   plainly in launch copy rather than letting people discover it.
 
-`docs/releasing/external-prerequisites.md` still lists the pre-collapse
-thirteen-name set. It was outside the scope that produced this rewrite; treat
-the nine names above as authoritative.
+`docs/releasing/external-prerequisites.md` has since been corrected and now
+lists the same nine names, with the four folded-in wrappers called out by name.
+The two pages agree. That the eight-target list is written out by hand in ten
+places at all is recorded in
+[platform management follow-ups](platform-management-followups.md), along with
+four other pieces of release machinery nobody checks.

--- a/scripts/verify-published-release.mjs
+++ b/scripts/verify-published-release.mjs
@@ -28,8 +28,25 @@ import { hostPlatformPackage, installAndExerciseRelease } from "./installed-rele
  *                           (default: the eight platform packages plus oxc-tsrx)
  *   --registry <url>        default https://registry.npmjs.org/
  *   --attempts <n>          registry visibility attempts, 10s apart (default 6)
- *   --allow-unpublished     exit 0 when the version is not on the registry,
- *                           which is what a dry-run rehearsal expects
+ *   --rehearsal             dry-run mode: if the requested version is not on the
+ *                           registry, run every stage against the latest version
+ *                           that is, so the rehearsal installs and runs
+ *                           something real instead of no-opping
+ *
+ * On `--rehearsal`. A backstop that has never executed is the same shape as the
+ * `npm view` check it replaced: wired, believed, unproven. A dry run cannot
+ * install the version it is rehearsing, because that version is by definition
+ * not published yet, so a rehearsal that insists on the pending version can only
+ * ever skip. Retargeting the last published release is what makes the dry run
+ * exercise the whole path for real.
+ *
+ * What that proves: this script, the registry read, the install into a project
+ * outside the workspace, the lint and the parse all work on the publish runner
+ * as configured today. What it does not prove: anything whatsoever about the
+ * pending version's artifacts. Those are the pre-publish gate's job, and the
+ * gate runs before this step. It does mean a dry run now also answers "does the
+ * release currently on npm still install and work", which is worth knowing on
+ * its own.
  */
 
 const root = resolve(import.meta.dirname, "..");
@@ -40,12 +57,12 @@ function parseArguments(argv) {
     orderFile: null,
     registry: "https://registry.npmjs.org/",
     attempts: 6,
-    allowUnpublished: false,
+    rehearsal: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
-    if (argument === "--allow-unpublished") {
-      options.allowUnpublished = true;
+    if (argument === "--rehearsal") {
+      options.rehearsal = true;
       continue;
     }
     const value = argv[++index];
@@ -82,24 +99,72 @@ async function publishedNames(options) {
     .filter(Boolean);
 }
 
-/** Whether `name@version` is visible, without spawning npm nine times. */
-async function visible(registry, name, version) {
+/** The abbreviated packument, or null when the name has never been published. */
+async function packument(registry, name) {
   const response = await fetch(new URL(encodeURIComponent(name).replace("%40", "@"), registry), {
     headers: { accept: "application/vnd.npm.install-v1+json" },
   });
-  if (response.status === 404) return false;
+  if (response.status === 404) return null;
   if (!response.ok) throw new Error(`${name}: registry answered ${response.status}`);
-  const packument = await response.json();
-  return Boolean(packument.versions?.[version]);
+  return await response.json();
+}
+
+/** Whether `name@version` is visible, without spawning npm nine times. */
+async function visible(registry, name, version) {
+  return Boolean((await packument(registry, name))?.versions?.[version]);
+}
+
+/** The version behind the `latest` dist-tag, or null when nothing is published. */
+async function latestPublished(registry, name) {
+  const document = await packument(registry, name);
+  const latest = document?.["dist-tags"]?.latest ?? null;
+  return latest && document.versions?.[latest] ? latest : null;
+}
+
+/** The one name in the set that consumers install; the rest are its platforms. */
+function publicPackage(names) {
+  return names.find((name) => !name.startsWith("@oxc-tsrx/native-")) ?? "oxc-tsrx";
 }
 
 async function main() {
   const options = parseArguments(process.argv.slice(2));
   const names = await publishedNames(options);
-  say("Post-publish backstop");
-  say(`  version   ${options.version}`);
+  const publicName = publicPackage(names);
+  const label = options.rehearsal ? "rehearsal" : "backstop";
+
+  // In rehearsal mode the pending version is normally not on the registry yet,
+  // and a check that stops there is a check that never runs. Retarget it at the
+  // release that IS out there, and say so in as many words: the run is proving
+  // the mechanism, not the pending artifacts.
+  let target = options.version;
+  let retargeted = false;
+  if (options.rehearsal && !(await visible(options.registry, publicName, options.version))) {
+    const latest = await latestPublished(options.registry, publicName);
+    if (!latest) {
+      say(`${publicName} has no published version at all, so there is nothing to install.`);
+      say();
+      say("rehearsal: SKIPPED  the registry holds no release of this package yet");
+      return;
+    }
+    target = latest;
+    retargeted = true;
+  }
+
+  say(options.rehearsal ? "Post-publish backstop (rehearsal)" : "Post-publish backstop");
+  say(`  version   ${target}`);
   say(`  registry  ${options.registry}`);
   say(`  packages  ${names.length}`);
+  if (retargeted) {
+    say(`  requested ${options.version}, which is not on the registry yet`);
+    say(
+      `  rehearsing against ${target}, the current \`latest\` of ${publicName}, so every stage ` +
+        "below runs for real",
+    );
+    say(
+      `  this proves the backstop mechanism and the health of ${target}. It proves nothing ` +
+        `about ${options.version}, which the pre-publish gate above already covered.`,
+    );
+  }
   say();
 
   say("[1/2] every published name resolves at this version");
@@ -109,27 +174,20 @@ async function main() {
   // check this replaces and it is still true here.
   for (let attempt = 1; attempt <= options.attempts && missing.size > 0; attempt += 1) {
     for (const name of [...missing]) {
-      if (await visible(options.registry, name, options.version)) missing.delete(name);
+      if (await visible(options.registry, name, target)) missing.delete(name);
     }
     if (missing.size === 0) break;
-    if (options.allowUnpublished && missing.size === names.length) break;
     say(`  ${missing.size} not visible yet (attempt ${attempt}), waiting for the registry`);
     if (attempt < options.attempts) await sleep(10_000);
   }
-  if (missing.size === names.length && options.allowUnpublished) {
-    say(`  ${options.version} is not on the registry, which is what a dry run expects`);
-    say();
-    say("backstop: SKIPPED  nothing is published at this version to install and run");
-    return;
-  }
   if (missing.size > 0) {
-    for (const name of missing) fail(`${name}@${options.version} is not on the registry`);
+    for (const name of missing) fail(`${name}@${target} is not on the registry`);
     say();
-    say(`backstop: FAIL  ${missing.size} of ${names.length} packages did not land`);
+    say(`${label}: FAIL  ${missing.size} of ${names.length} packages did not land at ${target}`);
     process.exitCode = 1;
     return;
   }
-  say(`  all ${names.length} names resolve at ${options.version}`);
+  say(`  all ${names.length} names resolve at ${target}`);
   say();
 
   say("[2/2] install the published release and make it do real work");
@@ -140,21 +198,31 @@ async function main() {
     // the platform package through the published optionalDependencies exactly
     // as a consumer's first install does.
     const installed = await installAndExerciseRelease({
-      specs: [`oxc-tsrx@${options.version}`],
+      specs: [`${publicName}@${target}`],
       registry: options.registry,
-      expectedVersion: options.version,
+      expectedVersion: target,
       log: (line) => say(line),
     });
     say();
     say(
-      `backstop: PASS  oxc-tsrx@${options.version} installed from the registry on ` +
+      `${label}: PASS  ${publicName}@${target} installed from the registry on ` +
         `${host.target.target}, linted ${installed.lint.diagnostics} diagnostics, and parsed through ` +
         "its own addon",
     );
+    if (retargeted) {
+      say(
+        `the code path a ${options.version} publish depends on ran end to end here; ` +
+          `${options.version} itself is gated before publish, not here`,
+      );
+    }
   } catch (error) {
     fail(`the published release does not work when installed from the registry: ${error.message}`);
     say();
-    say("backstop: FAIL  the published artifact is broken; deprecate and patch");
+    say(
+      retargeted
+        ? `rehearsal: FAIL  ${target} is already published and no longer installs and runs`
+        : `${label}: FAIL  the published artifact is broken; deprecate and patch`,
+    );
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
The post-publish backstop in `publish.yml` had never executed. It sat last in the job, after a step that correctly refuses an already-published version, and at an unpublished version it had nothing to install.

- **Part A.** The backstop rehearsal moves above `Rehearse the publish`, which is untouched, and `scripts/verify-published-release.mjs --rehearsal` retargets the registry's current `latest` when the requested version is not published yet. Every dry run now installs a real release from npmjs.com into a project outside the workspace and makes it lint and parse.
- **Part B.** `site-artifact.yml` gains a `pull_request` trigger with a dedicated lightweight job, so the drift test binding `docs/reference/platform-support.md` to `packages/toolchain/dist/native-targets.js` runs before a change lands rather than after.
- **Part C.** `docs/releasing/platform-management-followups.md` records five platform-management problems that were previously only in working notes that are not in version control.

Draft: opened for the pull-request-triggered `site-artifact.yml` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)