### PR TITLE
Fix the two oxc-tsrx defects that block Markless

### DIFF
--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -656,7 +656,8 @@ mod tests {
 
     use super::{
         EMBEDDED_CSS_FORMAT_NS, EMBEDDED_CSS_MODE, EMBEDDED_CSS_PARSE_COUNT,
-        EMBEDDED_CSS_USES_SUBPROCESS, FormatMode, format_text,
+        EMBEDDED_CSS_USES_SUBPROCESS, EngineFormatOptions, FileFormatOptions, FormatMode,
+        format_text, format_text_with_options,
     };
 
     #[test]
@@ -813,5 +814,102 @@ mod tests {
         assert_eq!(first.code.matches("/* raw {label} */").count(), 32);
         let second = format_text(Path::new("Repeated.tsrx"), &first.code).unwrap();
         assert_eq!(second.code, first.code);
+    }
+
+    #[test]
+    fn wide_keyed_header_survives_the_formatter_breaking_its_scaffold_call() {
+        // A `key` expression wide enough that the projected header call cannot fit the
+        // print width. The formatter then breaks that call across lines and writes a
+        // trailing comma after its last argument, which the checked lift has to read
+        // back. Before this was handled the whole file was refused with
+        // "Oxfmt changed TSRX scaffold 0" and left byte-identical.
+        let source = concat!(
+            "export function View({rows}:{rows:Row[]}) @{<ul>",
+            "@for(const row of rows;key row.aVeryLongPropertyNameSegment",
+            "aVeryLongPropertyNameSegmentaVeryLongPropertyNameSegment)",
+            "{<li>{row.label}</li>}</ul>}\n"
+        );
+        let first = format_text(Path::new("Wide.tsrx"), source).unwrap();
+        assert!(
+            first.code.contains(
+                "key row.aVeryLongPropertyNameSegmentaVeryLongPropertyNameSegment\
+                 aVeryLongPropertyNameSegment"
+            ),
+            "{}",
+            first.code
+        );
+        assert!(!first.code.contains("_t"), "{}", first.code);
+        let second = format_text(Path::new("Wide.tsrx"), &first.code).unwrap();
+        assert_eq!(second.code, first.code);
+        assert!(!second.changed);
+    }
+
+    #[test]
+    fn wide_indexed_header_survives_the_formatter_breaking_its_scaffold_call() {
+        let source = concat!(
+            "export function View({rows}:{rows:Row[]}) @{<ul>",
+            "@for(const row of rows;index positionOfThisRowWithinTheCollection",
+            "ThatIsBeingIteratedOverHere)",
+            "{<li>{row.label}</li>}</ul>}\n"
+        );
+        let first = format_text(Path::new("Indexed.tsrx"), source).unwrap();
+        assert!(
+            first.code.contains(
+                "index positionOfThisRowWithinTheCollectionThatIsBeingIteratedOverHere"
+            ),
+            "{}",
+            first.code
+        );
+        let second = format_text(Path::new("Indexed.tsrx"), &first.code).unwrap();
+        assert_eq!(second.code, first.code);
+    }
+
+    #[test]
+    fn keyed_header_inside_a_try_arm_formats_at_a_wider_tab_width() {
+        // The shape three real files hit: a keyed `@for` two element levels inside a
+        // `@try` arm. At the default two-space indent the projected header still fits
+        // the print width; at four the same header runs long, the formatter breaks its
+        // scaffold call, and the lift has to read the break back. Indent width alone
+        // decided whether the file could be formatted at all.
+        let source = concat!(
+            "export default function Page({rows}:{rows:Row[]}) @{\n",
+            "\t<div data-page>\n",
+            "\t\t@try {\n",
+            "\t\t\t<ContextFrame>\n",
+            "\t\t\t\t<ul>\n",
+            "\t\t\t\t\t@for (const row of rows; key row.id) {\n",
+            "\t\t\t\t\t\t<li data-row>{row.label}</li>\n",
+            "\t\t\t\t\t}\n",
+            "\t\t\t\t</ul>\n",
+            "\t\t\t</ContextFrame>\n",
+            "\t\t} @pending {\n",
+            "\t\t\t<p>loading</p>\n",
+            "\t\t} @catch {\n",
+            "\t\t\t<p>failed</p>\n",
+            "\t\t}\n",
+            "\t</div>\n",
+            "}\n",
+        );
+        let options = FileFormatOptions {
+            engine: EngineFormatOptions {
+                use_tabs: Some(true),
+                tab_width: Some(4),
+                ..EngineFormatOptions::default()
+            },
+            insert_final_newline: None,
+        };
+        let first =
+            format_text_with_options(Path::new("Page.tsrx"), source, Some(&options)).unwrap();
+        assert_eq!(first.metadata.mode, FormatMode::Projected);
+        assert!(first.code.contains("@for (const row of rows; key row.id) {"), "{}", first.code);
+        assert!(first.code.contains("} @pending {"), "{}", first.code);
+        assert!(first.code.contains("} @catch {"), "{}", first.code);
+        assert!(first.code.contains("<ContextFrame>"), "{}", first.code);
+        assert!(!first.code.contains("_t"), "{}", first.code);
+
+        let second =
+            format_text_with_options(Path::new("Page.tsrx"), &first.code, Some(&options)).unwrap();
+        assert_eq!(second.code, first.code);
+        assert!(!second.changed);
     }
 }

--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -854,9 +854,9 @@ mod tests {
         );
         let first = format_text(Path::new("Indexed.tsrx"), source).unwrap();
         assert!(
-            first.code.contains(
-                "index positionOfThisRowWithinTheCollectionThatIsBeingIteratedOverHere"
-            ),
+            first
+                .code
+                .contains("index positionOfThisRowWithinTheCollectionThatIsBeingIteratedOverHere"),
             "{}",
             first.code
         );

--- a/crates/tsrx_lint/src/pipeline.rs
+++ b/crates/tsrx_lint/src/pipeline.rs
@@ -189,6 +189,12 @@ pub(crate) fn finish_lint(
         diagnostics,
         number_of_files: 1,
         number_of_rules: session.engine.number_of_rules(),
+        // One file is read, projected, linted, and finished on a single thread, so this half of
+        // the report is always 1. The batch-wide figure is the count of the DISTINCT threads that
+        // reached here, folded by `aggregate_outputs`; recording the thread rather than writing a
+        // number is what keeps that figure measured instead of assumed.
+        threads_count: 1,
+        lint_thread: std::thread::current().id(),
         metadata: Metadata {
             native: true,
             engine: "oxc_linter",

--- a/crates/tsrx_lint/src/report.rs
+++ b/crates/tsrx_lint/src/report.rs
@@ -1,7 +1,9 @@
 //! The serialized shape the CLI, the editor, and the benchmarks all consume, and the aggregation
 //! that folds a whole batch into one of them.
 
+use std::collections::HashSet;
 use std::path::Path;
+use std::thread::{self, ThreadId};
 
 use oxc_adapter::{EngineDiagnostic, OXC_REVISION};
 use serde::Serialize;
@@ -96,6 +98,23 @@ pub struct Output {
     pub diagnostics: Vec<DiagnosticOutput>,
     pub number_of_files: u32,
     pub number_of_rules: usize,
+    /// How many threads this run actually linted on.
+    ///
+    /// Canonical Oxlint closes a report with `Finished in <t> on <n> files with <r> rules using
+    /// <threads> threads.`, and the tools that read Oxlint - Vite+ among them - want the whole
+    /// pair of summary lines. A batch of nothing but `.tsrx` files never reaches canonical Oxlint
+    /// at all, so this is the only half that can supply the number for it, and a report that
+    /// invents one is the class of defect this field exists to remove.
+    ///
+    /// It is counted, never assumed. Every per-file output records the thread that produced it and
+    /// [`aggregate_outputs`] counts the distinct ones, so the value follows the code: today the
+    /// batch is walked sequentially and the answer is 1, and if that walk is ever parallelised the
+    /// report says so without anyone remembering to update it here.
+    pub threads_count: u32,
+    /// The thread this output was produced on, folded into `threads_count` by
+    /// [`aggregate_outputs`] and never serialized - the report carries the count, not the ids.
+    #[serde(skip)]
+    pub(crate) lint_thread: ThreadId,
     #[serde(rename = "oxcTsrx")]
     pub metadata: Metadata,
 }
@@ -114,7 +133,11 @@ pub(crate) fn aggregate_outputs(session: &LintSession, outputs: Vec<Output>) -> 
     let mut fix_counts = FixOutput { applied: 0, rejected: 0 };
     let mut type_aware_files = 0_u32;
     let mut type_aware_processes = 0_u32;
+    // Seeded with the folding thread so a batch that linted nothing still reports the one thread
+    // that ran it, rather than the zero threads a summary line would then have to print.
+    let mut lint_threads = HashSet::from([thread::current().id()]);
     for output in outputs {
+        lint_threads.insert(output.lint_thread);
         number_of_files = number_of_files.saturating_add(output.number_of_files);
         parse_count = parse_count.saturating_add(output.metadata.parse_count);
         reparse_count = reparse_count.saturating_add(output.metadata.reparse_count);
@@ -143,6 +166,8 @@ pub(crate) fn aggregate_outputs(session: &LintSession, outputs: Vec<Output>) -> 
         diagnostics,
         number_of_files,
         number_of_rules: session.engine.number_of_rules(),
+        threads_count: u32::try_from(lint_threads.len()).unwrap_or(u32::MAX),
+        lint_thread: thread::current().id(),
         metadata: Metadata {
             native: true,
             engine: "oxc_linter",
@@ -195,6 +220,8 @@ pub(crate) fn projection_failure_output(
         }],
         number_of_files: 1,
         number_of_rules: session.engine.number_of_rules(),
+        threads_count: 1,
+        lint_thread: thread::current().id(),
         metadata: Metadata {
             native: true,
             engine: "oxc_linter",

--- a/crates/tsrx_syntax/src/projection/lift/scaffold.rs
+++ b/crates/tsrx_syntax/src/projection/lift/scaffold.rs
@@ -483,6 +483,15 @@ fn parse_marker_occurrence(
     Some((ordinal, side, ScaffoldSpan { start: prefix_start - 2, end: digits_end + 5 }))
 }
 
+// A projected `@for` header is one helper call wrapping up to two more:
+// `_H0_(right, _IH0_(index), _KH0_(key), _HE0_)`. Canonical Oxfmt breaks any call
+// whose arguments do not fit the print width, and a broken call gets a trailing
+// comma after its last argument. That happens to the two inner calls exactly when
+// the header sits deep enough to run long, which is why a wide `key` expression or
+// a header nested a couple of element levels inside a `@try` arm reached this code
+// with a comma between the key expression and the inner `)`. Every other scaffold
+// close here already tolerates that comma through `scaffold_call_end`; the two
+// inner header calls are read with it for the same reason.
 fn append_header_edits(
     source: &str,
     manifest: HeaderManifest,
@@ -503,8 +512,7 @@ fn append_header_edits(
         let _ = expect_span_after_whitespace(source, cursor, positions.index_start, index)?;
         let content =
             trimmed_content_range(source, positions.index_start.end, positions.index_end.start)?;
-        cursor = positions.index_end.end;
-        cursor = expect_byte_after_whitespace(source, cursor, b')', index)?;
+        cursor = scaffold_call_end(source, positions.index_end.end, index)?;
         Some(content)
     } else {
         None
@@ -516,8 +524,7 @@ fn append_header_edits(
         let _ = expect_span_after_whitespace(source, cursor, positions.key_start, index)?;
         let content =
             trimmed_content_range(source, positions.key_start.end, positions.key_end.start)?;
-        cursor = positions.key_end.end;
-        cursor = expect_byte_after_whitespace(source, cursor, b')', index)?;
+        cursor = scaffold_call_end(source, positions.key_end.end, index)?;
         Some(content)
     } else {
         None

--- a/crates/tsrx_syntax/tests/format_round_trip.rs
+++ b/crates/tsrx_syntax/tests/format_round_trip.rs
@@ -1,0 +1,151 @@
+//! The checked lift has to survive canonical Oxfmt's line breaking, not just its own
+//! projection text.
+//!
+//! Every test in this crate before this file lifted `projection.source()` verbatim: the
+//! projection exactly as it was built, on one line, with no formatter in between. The
+//! formatter is the whole point of the projection, and it reflows. A call whose arguments
+//! do not fit the print width gets broken across lines, and a broken call gets a trailing
+//! comma after its last argument. That is ordinary, correct Oxfmt output, and the lift has
+//! to read it.
+//!
+//! `reflow_broken_calls` below reproduces that one transformation on the scaffold calls the
+//! lift parses by hand, which is what a deep or wide `@for` header really receives. The
+//! end-to-end proof against the real formatter lives in `tsrx_format`, which owns it; these
+//! tests keep this crate's own contract honest without giving it a formatter dependency.
+
+use tsrx_syntax::{lift_formatted, project_for_format, scan};
+
+/// Inserts the trailing comma canonical Oxfmt writes when it breaks the `@for` header's
+/// inner `index` and `key` helper calls across lines.
+///
+/// Scaffold end markers are spelled `/*_<prefix>_<kind><ordinal>E__*/`, and the inner
+/// helper call closes on the first `)` after one. Only `I` (index) and `K` (key) name an
+/// inner call; `R` (the right-hand expression) and `N` (a wrapper body) sit inside calls
+/// that continue past their marker, so they are left alone.
+fn reflow_broken_calls(projected: &str) -> String {
+    const MARKER_END: &str = "E__*/";
+
+    let bytes = projected.as_bytes();
+    let mut output = String::with_capacity(projected.len() + 64);
+    let mut copied = 0usize;
+    let mut search = 0usize;
+    while let Some(offset) = projected[search..].find(MARKER_END) {
+        let kind_at = search + offset;
+        let marker_end = kind_at + MARKER_END.len();
+        search = marker_end;
+
+        let mut ordinal_start = kind_at;
+        while ordinal_start > 0 && bytes[ordinal_start - 1].is_ascii_digit() {
+            ordinal_start -= 1;
+        }
+        if ordinal_start == kind_at {
+            continue;
+        }
+        if !matches!(bytes.get(ordinal_start - 1), Some(b'I' | b'K')) {
+            continue;
+        }
+
+        let Some(close) = projected[marker_end..].find(')') else { continue };
+        let close = marker_end + close;
+        output.push_str(&projected[copied..close]);
+        output.push_str(",\n          ");
+        copied = close;
+    }
+    output.push_str(&projected[copied..]);
+    output
+}
+
+fn assert_lifts_the_same_broken_or_not(source: &str, controls: usize) {
+    let projection = project_for_format(source, &scan(source).unwrap()).unwrap();
+    let straight = lift_formatted(projection.source(), source, &projection).unwrap();
+
+    let broken = reflow_broken_calls(projection.source());
+    assert_ne!(broken, projection.source(), "the reflow did not change anything to test");
+
+    let lifted = lift_formatted(&broken, source, &projection)
+        .unwrap_or_else(|error| panic!("broken-call lift failed: {error}\n{broken}"));
+
+    assert!(!lifted.contains("_t"), "a scaffold identifier survived the lift: {lifted}");
+    assert_eq!(scan(&lifted).unwrap().control_count(), controls);
+    assert_eq!(
+        lifted.split_ascii_whitespace().collect::<Vec<_>>(),
+        straight.split_ascii_whitespace().collect::<Vec<_>>(),
+        "breaking the scaffold calls changed the lifted program"
+    );
+}
+
+#[test]
+fn keyed_header_lifts_when_its_key_helper_call_is_broken() {
+    assert_lifts_the_same_broken_or_not(
+        "function View() @{<ul>@for(const row of rows;key row.id){<li>{row.label}</li>}</ul>}",
+        1,
+    );
+}
+
+#[test]
+fn indexed_header_lifts_when_its_index_helper_call_is_broken() {
+    assert_lifts_the_same_broken_or_not(
+        "function View() @{<ul>@for(const row of rows;index position){<li>{position}</li>}</ul>}",
+        1,
+    );
+}
+
+#[test]
+fn annotated_header_lifts_when_both_helper_calls_are_broken() {
+    assert_lifts_the_same_broken_or_not(
+        concat!(
+            "function View() @{<ul>@for(const row of rows;index position;key row.id)",
+            "{<li>{position}{row.label}</li>}@empty{<i/>}</ul>}"
+        ),
+        1,
+    );
+}
+
+#[test]
+fn header_inside_a_try_arm_lifts_when_its_helper_calls_are_broken() {
+    // The shape that reached this defect from real code: a keyed `@for` two element
+    // levels inside a `@try` arm. The nesting is what pushes the header past the print
+    // width, so the formatter breaks the inner calls that the lift then has to read.
+    assert_lifts_the_same_broken_or_not(
+        concat!(
+            "function View() @{<div>@try{<Frame><ul>",
+            "@for(const row of rows;key row.id){<li>{row.label}</li>}",
+            "</ul></Frame>}@pending{<p>loading</p>}@catch{<p>failed</p>}</div>}"
+        ),
+        2,
+    );
+}
+
+#[test]
+fn nested_headers_lift_when_every_helper_call_is_broken() {
+    assert_lifts_the_same_broken_or_not(
+        concat!(
+            "function View() @{<main>",
+            "@for(const row of rows;index outer;key row.id){<section>",
+            "@for(const item of row.items;index inner;key item.id){<p>{inner}</p>}",
+            "@empty{<i/>}</section>}@empty{<b/>}</main>}"
+        ),
+        2,
+    );
+}
+
+#[test]
+fn breaking_a_scaffold_call_does_not_make_the_lift_accept_a_changed_scaffold() {
+    // Tolerating the formatter's trailing comma must not weaken the check that makes
+    // oxfmt fail safe. A scaffold whose identity really did change still has to be
+    // rejected, broken across lines or not.
+    let source = "function View() @{<ul>@for(const row of rows;key row.id){<li/>}</ul>}";
+    let projection = project_for_format(source, &scan(source).unwrap()).unwrap();
+    let broken = reflow_broken_calls(projection.source());
+
+    for tampered in [
+        broken.replacen("_KH0_", "_KH9_", 1),
+        broken.replacen("_HE0_", "_HE9_", 1),
+        broken.replacen("_H0_(", "_H9_(", 1),
+    ] {
+        assert!(
+            lift_formatted(&tampered, source, &projection).is_err(),
+            "a changed scaffold lifted anyway: {tampered}"
+        );
+    }
+}

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -198,13 +198,44 @@ before you rely on something:
 ```js
 import { capabilities } from "oxc-tsrx/parser";
 
-capabilities.languages;       // which languages it parses
-capabilities.editorRecovery;  // whether recovery: "editor" works here
-capabilities.oxcRevision;     // the OXC version it was built from
+capabilities.languages;          // which languages it parses
+capabilities.editorRecovery;     // whether recovery: "editor" works here
+capabilities.cssMaterialization; // whether CSS is broken down to its components
+capabilities.oxcRevision;        // the OXC version it was built from
 ```
 
 Asking for something the installed build cannot do throws, rather than parsing
 with less than you asked for and letting you find out later.
+
+Each flag answers a question about **this build**, not about the language. There
+are two builds, a canonical one and a compatibility one, and every flag here is
+the difference between them for one option. So read a `false` narrowly. It tells
+you that one option is off, and nothing more.
+
+`cssMaterialization: false` is the one worth spelling out, because it is easy to
+read as "there is no CSS tree". There is. On the canonical build a `<style>`
+element always comes back with its CSS text on `css`, plus a `StyleSheet` child:
+
+```js
+const { program } = parseSync(
+  "Card.tsrx",
+  'const x = <style>.a, .b > p:hover { color: red }</style>;\n',
+);
+// The <style> element's StyleSheet child holds:
+//   Rule
+//     prelude: SelectorList -> ComplexSelector, ComplexSelector
+//     block:   Block
+// Every one of those carries start/end offsets into the CSS text.
+```
+
+That is enough to find each selector and rewrite it, which is what scoping
+styles needs, and consumers do exactly that today.
+
+What the `false` withholds is the level below. The `ComplexSelector` and `Block`
+nodes arrive with empty `children`, so you get no compound-selector parts and no
+node per declaration. If you need those, read them out of the `source` text on
+the node or hand it to a CSS parser. The compatibility build reports `true` here
+and materializes them for you.
 
 ## What is tested
 

--- a/docs/terminal-transcripts.json
+++ b/docs/terminal-transcripts.json
@@ -7,12 +7,12 @@
         {
           "comment": "Lint .tsrx and ordinary JS/TS with real OXC rules",
           "command": "npx oxlint src/Counter.tsrx src/View.tsx",
-          "output": "src/Counter.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/View.tsx:2:7: warning eslint(no-unused-vars): Variable 'seen' is declared but never used. Unused variables should start with a '_'. help: Consider removing this declaration.\nFound 0 error(s) and 2 warning(s).\n"
+          "output": "src/Counter.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/View.tsx:2:7: warning eslint(no-unused-vars): Variable 'seen' is declared but never used. Unused variables should start with a '_'. help: Consider removing this declaration.\nFound 2 warnings and 0 errors.\nFinished in 109ms on 2 files with 95 rules using 18 threads.\n"
         },
         {
           "comment": "Format .tsrx and ordinary JS/TS with real Oxfmt layout",
           "command": "npx oxfmt --check src/Counter.tsrx src/View.tsx",
-          "output": "Checking formatting...\n\nsrc/View.tsx (0ms)\nsrc/Counter.tsrx (0ms)\n\nFormat issues found in above 2 files. Run without `--check` to fix.\nFinished in 77ms on 2 files using 18 threads.\nNo config found, using defaults. Please add a config file or try `oxfmt --init` if needed.\n"
+          "output": "Checking formatting...\n\nsrc/View.tsx (0ms)\nsrc/Counter.tsrx (0ms)\n\nFormat issues found in above 2 files. Run without `--check` to fix.\nFinished in 97ms on 2 files using 18 threads.\nNo config found, using defaults. Please add a config file or try `oxfmt --init` if needed.\n"
         }
       ]
     },
@@ -162,7 +162,7 @@
         {
           "comment": "The oxlint that oxc-tsrx installs already reads .tsrx",
           "command": "npx oxlint src/TaskList.tsrx",
-          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 0 error(s) and 1 warning(s).\n"
+          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 1 warning and 0 errors.\n"
         }
       ]
     },
@@ -192,7 +192,7 @@
         {
           "comment": "Same plugin, same config, one .tsrx file",
           "command": "npx oxlint src/TaskList.tsrx",
-          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 0 error(s) and 1 warning(s).\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 1 warning and 0 errors.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -202,7 +202,7 @@
         {
           "comment": "Your own rule, reporting on the .tsrx file you wrote",
           "command": "npx oxlint src/TaskFeed.tsrx",
-          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 1 error(s) and 0 warning(s).\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 0 warnings and 1 error.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -212,7 +212,7 @@
         {
           "comment": "Both file types at once, one plugin, one command",
           "command": "npx oxlint src",
-          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nsrc/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/TaskRow.tsx:11:9: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 2 error(s) and 1 warning(s).\noxlint (oxc-tsrx): running JS plugins on 2 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nsrc/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/TaskRow.tsx:11:9: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 1 warning and 2 errors.\nFinished in 86ms on 3 files with 96 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 2 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -242,7 +242,7 @@
         {
           "comment": "One command, one top-level jsPlugins, both file types",
           "command": "node_modules/oxc-tsrx/bin/oxlint src",
-          "output": "src/Greeting.tsrx:5:9: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nsrc/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 0 error(s) and 2 warning(s).\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/Greeting.tsrx:5:9: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nsrc/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 2 warnings and 0 errors.\nFinished in 82ms on 2 files with 96 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -252,7 +252,7 @@
         {
           "comment": "The .tsrx half refuses; exit 2 is the configuration refusal",
           "command": "node_modules/oxc-tsrx/bin/oxlint src",
-          "output": "src/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 0 error(s) and 1 warning(s).\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\noxlint (oxc-tsrx): type-aware tsgolint/type-check mode requires the explicit --type-aware or --type-check opt-in; it is never started or silently disabled by config alone\n"
+          "output": "src/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 1 warning and 0 errors.\nFinished in 101ms on 1 file with 111 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\noxlint (oxc-tsrx): type-aware tsgolint/type-check mode requires the explicit --type-aware or --type-check opt-in; it is never started or silently disabled by config alone\n"
         }
       ]
     },
@@ -287,13 +287,8 @@
       ]
     },
     "parsing-quickstart": {
-      "caption": "Real output, captured at build time, from the file and the script above plus a Broken.tsrx with an unterminated closing tag.",
+      "caption": "Real output, captured at build time, from a Broken.tsrx whose closing tag is unterminated.",
       "transcript": [
-        {
-          "comment": "The script above, run against the file above",
-          "command": "node example.mjs",
-          "output": "errors: 0\nimports: [ './Row' ]\ntop level: [ 'ImportDeclaration', 'ExportNamedDeclaration' ]\nfound: JSXForExpression\nsource.slice gives back exactly what you wrote:\n@for (const item of items; key item.id) {\n"
-        },
         {
           "comment": "Parse errors land in result.errors and point at your file",
           "command": "node errors.mjs",

--- a/docs/terminal-transcripts.json
+++ b/docs/terminal-transcripts.json
@@ -7,12 +7,12 @@
         {
           "comment": "Lint .tsrx and ordinary JS/TS with real OXC rules",
           "command": "npx oxlint src/Counter.tsrx src/View.tsx",
-          "output": "src/Counter.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/View.tsx:2:7: warning eslint(no-unused-vars): Variable 'seen' is declared but never used. Unused variables should start with a '_'. help: Consider removing this declaration.\nFound 2 warnings and 0 errors.\nFinished in 109ms on 2 files with 95 rules using 18 threads.\n"
+          "output": "src/Counter.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/View.tsx:2:7: warning eslint(no-unused-vars): Variable 'seen' is declared but never used. Unused variables should start with a '_'. help: Consider removing this declaration.\nFound 2 warnings and 0 errors.\nFinished in 108ms on 2 files with 95 rules using 18 threads.\n"
         },
         {
           "comment": "Format .tsrx and ordinary JS/TS with real Oxfmt layout",
           "command": "npx oxfmt --check src/Counter.tsrx src/View.tsx",
-          "output": "Checking formatting...\n\nsrc/View.tsx (0ms)\nsrc/Counter.tsrx (0ms)\n\nFormat issues found in above 2 files. Run without `--check` to fix.\nFinished in 97ms on 2 files using 18 threads.\nNo config found, using defaults. Please add a config file or try `oxfmt --init` if needed.\n"
+          "output": "Checking formatting...\n\nsrc/View.tsx (3ms)\nsrc/Counter.tsrx (1ms)\n\nFormat issues found in above 2 files. Run without `--check` to fix.\nFinished in 81ms on 2 files using 18 threads.\nNo config found, using defaults. Please add a config file or try `oxfmt --init` if needed.\n"
         }
       ]
     },
@@ -162,7 +162,7 @@
         {
           "comment": "The oxlint that oxc-tsrx installs already reads .tsrx",
           "command": "npx oxlint src/TaskList.tsrx",
-          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 1 warning and 0 errors.\n"
+          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 1 warning and 0 errors.\nFinished in 38ms on 1 file with 95 rules using 1 thread.\n"
         }
       ]
     },
@@ -192,7 +192,7 @@
         {
           "comment": "Same plugin, same config, one .tsrx file",
           "command": "npx oxlint src/TaskList.tsrx",
-          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 1 warning and 0 errors.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nFound 1 warning and 0 errors.\nFinished in 64ms on 1 file with 95 rules using 1 thread.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -202,7 +202,7 @@
         {
           "comment": "Your own rule, reporting on the .tsrx file you wrote",
           "command": "npx oxlint src/TaskFeed.tsrx",
-          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 0 warnings and 1 error.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 0 warnings and 1 error.\nFinished in 69ms on 1 file with 95 rules using 1 thread.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -212,7 +212,7 @@
         {
           "comment": "Both file types at once, one plugin, one command",
           "command": "npx oxlint src",
-          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nsrc/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/TaskRow.tsx:11:9: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 1 warning and 2 errors.\nFinished in 86ms on 3 files with 96 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 2 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/TaskFeed.tsrx:4:36: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nsrc/TaskList.tsrx:4:3: warning eslint(no-debugger): `debugger` statement is not allowed\nsrc/TaskRow.tsx:11:9: error tsrx-demo(require-keyed-map): JSX returned from .map() should declare a `key` prop.\nFound 1 warning and 2 errors.\nFinished in 79ms on 3 files with 96 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 2 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -242,7 +242,7 @@
         {
           "comment": "One command, one top-level jsPlugins, both file types",
           "command": "node_modules/oxc-tsrx/bin/oxlint src",
-          "output": "src/Greeting.tsrx:5:9: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nsrc/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 2 warnings and 0 errors.\nFinished in 82ms on 2 files with 96 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
+          "output": "src/Greeting.tsrx:5:9: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nsrc/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 2 warnings and 0 errors.\nFinished in 74ms on 2 files with 96 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\n"
         }
       ]
     },
@@ -252,7 +252,7 @@
         {
           "comment": "The .tsrx half refuses; exit 2 is the configuration refusal",
           "command": "node_modules/oxc-tsrx/bin/oxlint src",
-          "output": "src/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 1 warning and 0 errors.\nFinished in 101ms on 1 file with 111 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\noxlint (oxc-tsrx): type-aware tsgolint/type-check mode requires the explicit --type-aware or --type-check opt-in; it is never started or silently disabled by config alone\n"
+          "output": "src/Panel.tsx:2:19: warning house-rules(no-inline-style-object): Inline `style={{ ... }}` object. Use a class instead.\nFound 1 warning and 0 errors.\nFinished in 99ms on 1 file with 111 rules using 18 threads.\noxlint (oxc-tsrx): running JS plugins on 1 .tsrx file(s) by linting the TSX projection; this parses each of those files once more. Disable with \"settings\": { \"oxcTsrx\": { \"jsPluginsOnTsrx\": false } }.\noxlint (oxc-tsrx): type-aware tsgolint/type-check mode requires the explicit --type-aware or --type-check opt-in; it is never started or silently disabled by config alone\n"
         }
       ]
     },

--- a/packages/toolchain/dist/lint-cli.js
+++ b/packages/toolchain/dist/lint-cli.js
@@ -267,6 +267,17 @@ function combine(upstream, native) {
     diagnostics: [...(upstream.diagnostics ?? []), ...(native.diagnostics ?? [])],
     number_of_files: (upstream.number_of_files ?? 0) + (native.number_of_files ?? 0),
     number_of_rules: Math.max(upstream.number_of_rules ?? 0, native.number_of_rules ?? 0),
+    // A batch whose every positional was a `.tsrx` path never starts canonical
+    // Oxlint, and canonical Oxlint used to be the only half reporting a thread
+    // count - so that one shape lost the whole second summary line, and with it
+    // lost `vp check` to `error: Linting could not start`. It is exactly the
+    // shape a `staged: {'*': 'vp check --fix'}` pre-commit hook produces when a
+    // commit stages only `.tsrx` files. The native leaf now counts the threads
+    // it really linted on, so this fallback is a measured number and not one
+    // invented to fill the line. Canonical Oxlint still wins whenever it ran:
+    // it owns the thread pool that did the work, which also leaves the mixed
+    // and TypeScript-only shapes printing exactly what they printed before.
+    threads_count: upstream.threads_count ?? native.threads_count,
     oxcTsrx: native.oxcTsrx,
   };
 }
@@ -407,11 +418,13 @@ function summaryLines(result, elapsedMilliseconds) {
   const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
   const warnings = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
   const lines = [`Found ${plural(warnings, "warning")} and ${plural(errors, "error")}.`];
-  // Canonical Oxlint is the only half that reports a thread count, so a batch
-  // it never ran in - every positional was a `.tsrx` path - has no measured
-  // number to print here. Leaving the line out is the only alternative to
-  // inventing one, and an invented count in a report is the defect this file
-  // is being changed to remove, not one to add.
+  // Both halves report a thread count now - canonical Oxlint for its own pool,
+  // the native leaf by counting the threads it actually linted on - so
+  // `combine()` has a measured number for every invocation shape and this line
+  // is always printed. The guard stays because it is what makes the number a
+  // measurement: a report that arrives without one, from a native binary older
+  // than this file, prints one honest line rather than a second line filled in
+  // with a count nobody took.
   if (typeof result.threads_count === "number") {
     const files = plural(result.number_of_files ?? 0, "file");
     const rules = plural(result.number_of_rules ?? 0, "rule");

--- a/packages/toolchain/dist/lint-cli.js
+++ b/packages/toolchain/dist/lint-cli.js
@@ -349,9 +349,8 @@ function sortedDiagnostics(result) {
   });
 }
 
-function renderCompact(result, cwd) {
+function renderCompact(result, cwd, elapsedMilliseconds) {
   const diagnostics = sortedDiagnostics(result);
-  if (diagnostics.length === 0) return "";
   const lines = diagnostics.map((diagnostic) => {
     const location = primaryLocation(diagnostic);
     const filename = relative(cwd, diagnostic.filename) || diagnostic.filename;
@@ -368,14 +367,59 @@ function renderCompact(result, cwd) {
     const prefix = `${filename}:${location.line}:${location.column}: ${diagnostic.severity}`;
     return `${prefix}${code ? ` ${code}` : ""}: ${diagnostic.message}${help}`.trimEnd();
   });
-  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
-  const warnings = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
-  lines.push(`Found ${errors} error(s) and ${warnings} warning(s).`);
+  lines.push(...summaryLines(result, elapsedMilliseconds));
   return `${lines.join("\n")}\n`;
 }
 
 function plural(count, noun) {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+// Canonical Oxlint's own elapsed spelling: whole milliseconds below a second,
+// one decimal of seconds above it.
+function elapsedDisplay(milliseconds) {
+  return milliseconds < 1000
+    ? `${Math.round(milliseconds)}ms`
+    : `${(milliseconds / 1000).toFixed(1)}s`;
+}
+
+// Canonical Oxlint closes a report with TWO lines, not one:
+//
+//   Found 3 warnings and 1 error.
+//   Finished in 92ms on 40 files with 95 rules using 18 threads.
+//
+// and the tools that read Oxlint's output read the pair. Vite+ 0.1.20 prints
+// `error: Linting could not start` and reports the run as failed whenever the
+// second line is missing, however the first one is worded, so a composed batch
+// that stopped after the counts turned every `vp check` in a project that
+// installs this wrapper into a failed check - including runs over nothing but
+// ordinary TypeScript, because only explicit ordinary-file positionals skip
+// composition. Warnings come first and the nouns are pluralised by count:
+// `Found 1 warning and 0 errors.`, never `warning(s)`.
+//
+// This renderer used to stop after the counts on the grounds that the second
+// line reports one process's own run and a composed batch is two processes.
+// Three of its four numbers are already merged across both halves by
+// `combine()`, and the fourth, the elapsed time, is this command's own wall
+// clock over both halves, which is the wait the user actually had.
+function summaryLines(result, elapsedMilliseconds) {
+  const diagnostics = result.diagnostics ?? [];
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
+  const warnings = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
+  const lines = [`Found ${plural(warnings, "warning")} and ${plural(errors, "error")}.`];
+  // Canonical Oxlint is the only half that reports a thread count, so a batch
+  // it never ran in - every positional was a `.tsrx` path - has no measured
+  // number to print here. Leaving the line out is the only alternative to
+  // inventing one, and an invented count in a report is the defect this file
+  // is being changed to remove, not one to add.
+  if (typeof result.threads_count === "number") {
+    const files = plural(result.number_of_files ?? 0, "file");
+    const rules = plural(result.number_of_rules ?? 0, "rule");
+    const threads = plural(result.threads_count, "thread");
+    const elapsed = elapsedDisplay(elapsedMilliseconds);
+    lines.push(`Finished in ${elapsed} on ${files} with ${rules} using ${threads}.`);
+  }
+  return lines;
 }
 
 // A GitHub workflow command, reproduced from canonical Oxlint's own annotation
@@ -387,7 +431,7 @@ function plural(count, noun) {
 // none, which is what canonical Oxlint prints for a parse error. The help text
 // is not part of an annotation. The end position is the label span's end, which
 // this file resolves from `offset + length` the same way it resolves the start.
-function renderGitHub(result, cwd) {
+function renderGitHub(result, cwd, elapsedMilliseconds) {
   const diagnostics = sortedDiagnostics(result);
   const lines = diagnostics.map((diagnostic) => {
     const span = diagnostic.labels?.[0]?.span;
@@ -403,15 +447,10 @@ function renderGitHub(result, cwd) {
     const location = `file=${filename},line=${line},endLine=${endLine},col=${column},endColumn=${endColumn}`;
     return `::${severity} ${location},title=${title}::${diagnostic.message}`;
   });
-  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error").length;
-  const warnings = diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length;
   // Canonical Oxlint separates the annotations from its summary with a blank
-  // line and words it warnings first. Its second summary line, `Finished in
-  // <elapsed> on <n> files with <n> rules using <n> threads.`, reports one
-  // process's own run; a composed batch is two processes, so this renderer
-  // stops after the counts rather than inventing a number for it.
+  // line, and prints the same two summary lines the compact reporter prints.
   if (lines.length > 0) lines.push("");
-  lines.push(`Found ${plural(warnings, "warning")} and ${plural(errors, "error")}.`);
+  lines.push(...summaryLines(result, elapsedMilliseconds));
   return `${lines.join("\n")}\n`;
 }
 
@@ -444,9 +483,9 @@ async function addEndPositions(diagnostics) {
   }
 }
 
-async function renderReport(report, cwd, format) {
+async function renderReport(report, cwd, format, elapsedMilliseconds) {
   if (format === "json") return `${JSON.stringify(report)}\n`;
-  if (format !== "github") return renderCompact(report, cwd);
+  if (format !== "github") return renderCompact(report, cwd, elapsedMilliseconds);
   try {
     await addEndPositions(report.diagnostics ?? []);
   } catch {
@@ -454,7 +493,7 @@ async function renderReport(report, cwd, format) {
     // the failure that produced this report may have made unreadable. An
     // annotation that ends where it starts still points at the right place.
   }
-  return renderGitHub(report, cwd);
+  return renderGitHub(report, cwd, elapsedMilliseconds);
 }
 
 async function delegate(args, cwd) {
@@ -474,6 +513,10 @@ async function delegate(args, cwd) {
 
 export async function runCli(args, options = {}) {
   const cwd = options.cwd ?? process.cwd();
+  // The elapsed time the summary reports. Canonical Oxlint times its own run,
+  // and the run this command's summary describes is everything below: file
+  // discovery, the configuration bridge, and both halves.
+  const startedAt = performance.now();
   if (args.some((argument) => DELEGATE_ONLY.has(argument.split("=")[0]))) {
     return delegate(args, cwd);
   }
@@ -618,7 +661,8 @@ export async function runCli(args, options = {}) {
         upstreamHalf.report && nativeHalf.report
           ? combine(upstreamHalf.report, nativeHalf.report)
           : (upstreamHalf.report ?? nativeHalf.report);
-      const rendered = report === null ? "" : await renderReport(report, cwd, format);
+      const elapsed = performance.now() - startedAt;
+      const rendered = report === null ? "" : await renderReport(report, cwd, format, elapsed);
       process.stdout.write(upstreamHalf.passthrough + nativeHalf.passthrough + rendered);
       process.stderr.write(upstreamResult.stderr + attributeNativeErrors(nativeResult.stderr));
       return Math.max(upstreamResult.status, nativeResult.status);
@@ -668,7 +712,7 @@ export async function runCli(args, options = {}) {
 
     if (!args.includes("--silent")) {
       process.stderr.write(upstreamResult.stderr + attributeNativeErrors(nativeResult.stderr));
-      process.stdout.write(await renderReport(result, cwd, format));
+      process.stdout.write(await renderReport(result, cwd, format, performance.now() - startedAt));
     }
 
     const warnings = result.diagnostics.filter(

--- a/packages/toolchain/dist/parser.d.ts
+++ b/packages/toolchain/dist/parser.d.ts
@@ -143,6 +143,12 @@ export interface ParseResult {
   readonly errors: OxcError[];
 }
 
+/**
+ * What the installed native build supports. Every flag here answers a question
+ * about *this build*, never about the language or the AST in general: the
+ * canonical build and the compatibility build set them differently, and each
+ * flag is the discriminator for one option the two builds disagree about.
+ */
 export interface ParserCapabilities {
   readonly apiVersion: 1;
   readonly languages: readonly Language[];
@@ -152,7 +158,27 @@ export interface ParserCapabilities {
   readonly oxcRevision: string;
   readonly lazy: true;
   readonly async: true;
+  /**
+   * Whether `recovery: "editor"` is available. `false` means that one option is
+   * refused with `ERR_TSRX_CAPABILITY_RECOVERY`; a file that does not parse
+   * still reports every error it found in `result.errors`, as it always does.
+   */
   readonly editorRecovery: boolean;
+  /**
+   * Whether the CSS inside a `<style>` element is materialized down to its
+   * individual components. **`false` does not mean there is no CSS tree.** The
+   * canonical build always gives a `<style>` element a `css` string and a
+   * `StyleSheet` child holding a `Rule` per rule, each with a `SelectorList`
+   * prelude of `ComplexSelector` nodes and a `Block`, all carrying exact
+   * offsets relative to the CSS payload. That is enough to scope selectors, and
+   * consumers do it today.
+   *
+   * What `false` withholds is the level below that: the `ComplexSelector` and
+   * `Block` children arrays are empty, so there are no compound-selector parts
+   * and no per-declaration nodes. Read those out of the `source`/`css` text, or
+   * hand it to a CSS parser. The compatibility build reports `true` and
+   * materializes them.
+   */
   readonly cssMaterialization: false;
   readonly rawTransfer: boolean;
 }

--- a/tests/config/native-lint-config.test.mjs
+++ b/tests/config/native-lint-config.test.mjs
@@ -769,14 +769,38 @@ test("a batch of nothing but .tsrx files still closes with both summary lines", 
 test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-pattern error", async () => {
   const cwd = await mixedProject("report-unmatched");
 
-  // Canonical Oxlint on a nonexistent ordinary file is the precedent: one line
-  // on stdout and exit 1, and no summary at all - it prints its `Found ...` and
-  // `Finished in ...` pair for a run it really made, and this is the invocation
-  // where it made none. A wrapper that answers before starting either half is in
-  // exactly that position, so it must stay silent in exactly the same way. This
-  // used to be compared with the `Finished in ` lines filtered out of both
-  // sides, which would have hidden a summary invented for a run that never
-  // happened; the streams are compared whole instead.
+  // Canonical Oxlint on a nonexistent ordinary file is the precedent: this
+  // message on stdout and exit 1. What it prints *after* the message is its
+  // reporter's business rather than this path's, and the reporters disagree -
+  // `agent` closes with the message alone, while `default` and `github` add
+  // `Finished in <elapsed> on 0 files with <n> rules using <n> threads.` for
+  // the empty run canonical started anyway. That is the same stock 1.74.0
+  // binary on the same machine, so comparing the streams whole compares
+  // whichever reporter the ambient environment happened to pick: green under a
+  // coding agent, red under GITHUB_ACTIONS.
+  //
+  // The streams are therefore compared with the summary held apart from the
+  // message. The message must still match canonical byte for byte, in
+  // canonical's own live wording rather than a sentence copied into this file;
+  // the wrapper's own summary must be empty, and that is asserted directly on
+  // the wrapper instead of by filtering both sides.
+  //
+  // Empty is the point of the test, not a concession to make it pass. This
+  // wrapper answers the invocation before starting either half, so it has no
+  // elapsed run, no rule count and no thread count: a `Found ...` or `Finished
+  // in ...` line here could only be numbers nobody measured, which is exactly
+  // what the rest of this file spends its effort making impossible. Filtering
+  // `Finished in ` out of both streams, as this test once did, would let such a
+  // line through unseen - hence the positive assertion below, which fails on
+  // any summary line at all rather than only on a mismatched one.
+  const summaryOf = (stdout) =>
+    stdout.split("\n").filter((line) => /^(?:Found |Finished in )/u.test(line));
+  const messageOf = (stdout) =>
+    stdout
+      .split("\n")
+      .filter((line) => !/^(?:Found |Finished in )/u.test(line))
+      .join("\n");
+
   const control = await run(cwd, ["src/Missing.ts"], stock);
   assert.equal(control.code, 1, control.stderr || control.stdout);
   assert.match(control.stdout, /No files found to lint/u, control.stdout);
@@ -787,7 +811,12 @@ test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-patter
     control.code,
     `a mistyped .tsrx filename exited ${missing.code} with stdout:\n${missing.stdout}`,
   );
-  assert.equal(missing.stdout, control.stdout);
+  assert.equal(messageOf(missing.stdout), messageOf(control.stdout));
+  assert.deepEqual(
+    summaryOf(missing.stdout),
+    [],
+    `a run that never started summarised itself:\n${missing.stdout}`,
+  );
 
   // The opt-out canonical Oxlint already publishes keeps working.
   const controlAllowed = await run(
@@ -798,7 +827,12 @@ test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-patter
   assert.equal(controlAllowed.code, 0, controlAllowed.stderr || controlAllowed.stdout);
   const allowed = await runCompanion(cwd, ["--no-error-on-unmatched-pattern", "src/Missing.tsrx"]);
   assert.equal(allowed.code, controlAllowed.code, allowed.stderr || allowed.stdout);
-  assert.equal(allowed.stdout, controlAllowed.stdout);
+  assert.equal(messageOf(allowed.stdout), messageOf(controlAllowed.stdout));
+  assert.deepEqual(
+    summaryOf(allowed.stdout),
+    [],
+    `an opted-out run that never started summarised itself:\n${allowed.stdout}`,
+  );
 
   // Canonical Oxlint only errors when the whole invocation matched nothing, so a
   // batch that still has work to do must keep exiting on that work alone.

--- a/tests/config/native-lint-config.test.mjs
+++ b/tests/config/native-lint-config.test.mjs
@@ -733,6 +733,39 @@ test("a .tsrx syntax error is a positioned diagnostic that leaves the rest of th
   assert.doesNotMatch(result.stdout, /warning\(s\)|error\(s\)/u, result.stdout);
 });
 
+test("a batch of nothing but .tsrx files still closes with both summary lines", async () => {
+  const cwd = await mixedProject("report-tsrx-only");
+
+  // The invocation shape that kept the second summary line missing after the
+  // rest of it was fixed. Every positional a `.tsrx` path is the one shape that
+  // never starts canonical Oxlint, and canonical Oxlint was the only half
+  // reporting a thread count, so this batch printed its counts and stopped -
+  // which is exactly the missing line Vite+ answers with `error: Linting could
+  // not start`. It is also the shape a `staged: {'*': 'vp check --fix'}`
+  // pre-commit hook produces on a commit that stages only `.tsrx` files, so it
+  // is the shape the fix mattered most on and the one it reached last.
+  const result = await runCompanion(cwd, ["src/Counter.tsrx"]);
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /^Found 1 warning and 0 errors\.$/mu, result.stdout);
+  const finished =
+    /^Finished in [0-9.]+(?:ms|s) on 1 file with \d+ rules using (\d+) threads?\.$/mu.exec(
+      result.stdout,
+    );
+  assert.ok(
+    finished,
+    `a batch of nothing but .tsrx files stopped after the counts:\n${result.stdout}`,
+  );
+  // The count comes from the native leaf, which counts the threads it really
+  // linted on. Any positive integer is that measurement working; what must
+  // never come back is a batch with no number at all, or a number pinned here
+  // that the leaf never took.
+  assert.ok(
+    Number.parseInt(finished[1], 10) >= 1,
+    `the .tsrx-only batch reported an unmeasured thread count:\n${result.stdout}`,
+  );
+  assert.doesNotMatch(result.stdout, /warning\(s\)|error\(s\)/u, result.stdout);
+});
+
 test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-pattern error", async () => {
   const cwd = await mixedProject("report-unmatched");
 

--- a/tests/config/native-lint-config.test.mjs
+++ b/tests/config/native-lint-config.test.mjs
@@ -716,28 +716,34 @@ test("a .tsrx syntax error is a positioned diagnostic that leaves the rest of th
     `the syntax error did not render as a positioned diagnostic:\n${result.stdout}`,
   );
 
+  // Canonical Oxlint closes a report with two lines, and the tools that read
+  // its output read the pair: Vite+ reports `Linting could not start` and fails
+  // the run whenever the second one is missing, however the first is worded.
+  // Both lines are asserted here, in canonical Oxlint's own spelling - warnings
+  // first, nouns pluralised by count, never `warning(s)` - because a composed
+  // batch that words its summary its own way is a batch no Oxlint consumer can
+  // read. The elapsed time and the counts are this run's own, so the shapes are
+  // pinned and the numbers are not.
+  assert.match(result.stdout, /^Found 3 warnings and 1 error\.$/mu, result.stdout);
   assert.match(
     result.stdout,
-    composedReporter === "github"
-      ? /^Found 3 warnings and 1 error\.$/mu
-      : /^Found 1 error\(s\) and 3 warning\(s\)\.$/mu,
+    /^Finished in [0-9.]+(?:ms|s) on \d+ files? with \d+ rules? using \d+ threads?\.$/mu,
     result.stdout,
   );
+  assert.doesNotMatch(result.stdout, /warning\(s\)|error\(s\)/u, result.stdout);
 });
 
 test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-pattern error", async () => {
   const cwd = await mixedProject("report-unmatched");
 
   // Canonical Oxlint on a nonexistent ordinary file is the precedent: one line
-  // on stdout and exit 1. Its `Finished in <elapsed> on <n> files with <n> rules
-  // using <n> threads.` footer reports the run it did anyway, which a wrapper
-  // that answered before starting either half never had; the message and the
-  // exit code are the contract, so compare those.
-  const withoutTiming = (stdout) =>
-    stdout
-      .split("\n")
-      .filter((line) => !/^Finished in /u.test(line))
-      .join("\n");
+  // on stdout and exit 1, and no summary at all - it prints its `Found ...` and
+  // `Finished in ...` pair for a run it really made, and this is the invocation
+  // where it made none. A wrapper that answers before starting either half is in
+  // exactly that position, so it must stay silent in exactly the same way. This
+  // used to be compared with the `Finished in ` lines filtered out of both
+  // sides, which would have hidden a summary invented for a run that never
+  // happened; the streams are compared whole instead.
   const control = await run(cwd, ["src/Missing.ts"], stock);
   assert.equal(control.code, 1, control.stderr || control.stdout);
   assert.match(control.stdout, /No files found to lint/u, control.stdout);
@@ -748,7 +754,7 @@ test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-patter
     control.code,
     `a mistyped .tsrx filename exited ${missing.code} with stdout:\n${missing.stdout}`,
   );
-  assert.equal(withoutTiming(missing.stdout), withoutTiming(control.stdout));
+  assert.equal(missing.stdout, control.stdout);
 
   // The opt-out canonical Oxlint already publishes keeps working.
   const controlAllowed = await run(
@@ -759,7 +765,7 @@ test("a nonexistent .tsrx positional reports canonical Oxlint's unmatched-patter
   assert.equal(controlAllowed.code, 0, controlAllowed.stderr || controlAllowed.stdout);
   const allowed = await runCompanion(cwd, ["--no-error-on-unmatched-pattern", "src/Missing.tsrx"]);
   assert.equal(allowed.code, controlAllowed.code, allowed.stderr || allowed.stdout);
-  assert.equal(withoutTiming(allowed.stdout), withoutTiming(controlAllowed.stdout));
+  assert.equal(allowed.stdout, controlAllowed.stdout);
 
   // Canonical Oxlint only errors when the whole invocation matched nothing, so a
   // batch that still has work to do must keep exiting on that work alone.

--- a/tests/native-lint.test.mjs
+++ b/tests/native-lint.test.mjs
@@ -185,6 +185,30 @@ test('an unprojectable .tsrx becomes its own diagnostic and the rest of the batc
   );
 });
 
+test('the report carries the number of threads the run really linted on', async () => {
+  // Canonical Oxlint closes every report with `Finished in <t> on <n> files
+  // with <r> rules using <threads> threads.`, and the tools that read Oxlint
+  // want that line. A batch of nothing but `.tsrx` files never reaches
+  // canonical Oxlint at all, so this leaf is the only half that can supply the
+  // thread count for it - which is why the field is here and why the wrapper
+  // stopped after the counts without it.
+  //
+  // The value is counted, not assumed: `aggregate_outputs` folds the distinct
+  // threads its per-file outputs were produced on. So this asserts the shape of
+  // a real measurement rather than the literal 1 today's sequential walk
+  // produces, because a future parallel walk reporting 8 would be this field
+  // working, not this test failing.
+  for (const files of [[tsrxFixture], [tsrxFixture, tsxFixture]]) {
+    const result = await run(['--format=json', ...files]);
+    const output = parseJsonOutput(result);
+    assert.equal(output.number_of_files, files.length, result.stdout);
+    assert.ok(
+      Number.isInteger(output.threads_count) && output.threads_count >= 1,
+      `a ${files.length}-file batch reported no measured thread count:\n${result.stdout}`,
+    );
+  }
+});
+
 test('ordinary TSX bypasses the TSRX scan and projection allocation', async () => {
   const result = await run(['--format=json', '--deny', 'no-debugger', tsxFixture]);
   assert.equal(result.code, 1, result.stderr || result.stdout);


### PR DESCRIPTION
Two independent defects, both found while migrating Markless from `@tsrx/core` to `oxc-tsrx/parser`. Each is fixed here with a before/after captured against the real Markless repo.

## 1. Vite+ printed `error: Linting could not start` on every `vp check`

Vite+ builds its own summary by parsing Oxlint's, and it needs **both** summary lines. Our composed reporter emitted only the first, so Vite+ treated every run as a failed start.

The comment in `lint-cli.js` explained the omission — a composed batch is two processes, so the renderer "stops after the counts rather than inventing a number." That caution turned out to be unnecessary: `combine()` already carries `number_of_files`, `number_of_rules`, `threads_count` and `start_time` from the upstream half, so nothing has to be invented.

Fixed by emitting the full block through a shared `summaryLines()`, and correcting the wording to Oxlint's own (`warnings` first, plural nouns, no `(s)`):

```
Found <W> warnings and <E> errors.
Finished in <elapsed> on <N> files with <R> rules using <T> threads.
```

Two things worth calling out:

- The compact reporter returned an **empty string** on a clean run, which Vite+ also treats as a failed start. So `vp check` complained even when nothing was wrong.
- This was never Markless-specific. `vp check` on a pure-TypeScript directory with zero `.tsrx` files banners too, so this affected every `oxc-tsrx` user on Vite+.

Verified against a controlled harness (a fake `oxlint` whose stdout is driven through the real Vite+ 0.1.20) before touching anything downstream. Reversed noun order, `(s)` suffixes, and a missing second line each still fail, which is how the exact accepted grammar was pinned.

**In Markless**, `vp check --no-fmt packages/bundler/src`:

```
before   stderr: error: Linting could not start
         stdout: ...Found 0 error(s) and 1 warning(s).
                 Linting failed before analysis started

after    stderr: warn: Lint warnings found
         stdout: ...Found 0 errors and 1 warning in 24 files (130ms, 18 threads)
```

Whole repo: `Found 0 errors and 29 warnings in 933 files`, no banner, and all 29 diagnostic lines byte-identical to before.

### The all-`.tsrx` shape, closed here too

The fix above reached every invocation shape except one: a batch whose every positional is a `.tsrx` path. Canonical Oxlint is skipped there and was the only half reporting a thread count, so that batch printed `Found 0 warnings and 0 errors.` and stopped — still a missing second line, still a banner. It is the shape that mattered most, because Markless's pre-commit hook is `staged: {'*': 'vp check --fix'}` and a commit staging only `.tsrx` files hits exactly it.

The native leaf now reports the thread count it really used. Each per-file output records the thread it was produced on and `aggregate_outputs` folds the distinct ones, so the number is measured rather than filled in: the leaf walks its batch sequentially today and says `1`, and a parallel walk would say so on its own without this line changing. `combine()` still prefers canonical Oxlint's count whenever canonical ran, so the mixed and TypeScript-only shapes print exactly what they printed before.

**In Markless**, `vp check --no-fmt` on a `.tsrx` file:

```
before   error: Linting could not start
         Found 0 warnings and 0 errors.

after    pass: Found no warnings or lint errors in 1 file (7ms, 1 threads)
```

The wrapper still refuses to invent a summary for a run it never made. A mistyped `.tsrx` filename never starts either half, so it prints canonical Oxlint's `No files found to lint.` and exits 1 with no summary at all, and `test:config` fails on any `Found ...` or `Finished in ...` line appearing there.

## 2. Oxfmt refused to format `@for` inside `@try`

`Oxfmt changed TSRX scaffold 0` on three real Markless files, which broke that repo's pre-commit hook.

A projected `@for` header is one scaffold call wrapping up to two more:

```
_H0_(right, _IH0_(index), _KH0_(key), _HE0_)
```

Oxfmt breaks any call that exceeds the print width, and gives a broken call a trailing comma. The lift already tolerated that comma on the **outer** call via `scaffold_call_end`, but the two **inner** calls demanded `)` immediately after the index/key end marker. Two lines now read the inner closes the same way.

The `@try` in the repro was a red herring — it only contributed indentation depth. The load-bearing variable is print width, which is why `tabWidth: 4` (not `useTabs`, `printWidth`, or `singleQuote`) is what flipped the real files, and why a sufficiently wide `key` expression reproduces it at default options with no `@try` anywhere.

`crates/tsrx_syntax` had no format round-trip suite at all, which is why this survived. `crates/tsrx_syntax/tests/format_round_trip.rs` is new and fails 5/6 before this change.

**In Markless**, `vp check --fix` on the three files:

```
before   error: Formatting could not complete
         3x "Oxfmt changed TSRX scaffold 0"   (files left byte-identical — it fails safe)

after    pass: Formatting completed for checked files (720ms)
```

Output converges byte-stably across three runs, and the TSRX control skeleton — all 54 `@try`/`@pending`/`@catch`/`@for`/`@if` clauses including every `key` — is byte-identical before and after.

## Capability wording, no value changes

`capabilities.cssMaterialization: false` read to consumers as "there is no CSS tree." There is one — a full `StyleSheet`/`Rule`/`SelectorList` tree that drives Markless's style scoping unmodified. The flag actually discriminates canonical builds from compatibility builds. This misreading nearly caused the Markless migration to be abandoned as impossible, so both capabilities now carry doc comments and `docs/guide/parsing.md` explains what they mean.

**No capability value changed**, and `parser.node.json` is untouched.

## Verification

`test:markless-control` (179-file corpus, format/reparse/converge) green — the strongest no-regression oracle here for a formatter change. Plus `cargo test -p tsrx_syntax` (63), `cargo test -p tsrx_format` (13), `cargo test -p tsrx_lint` (15, covering the thread-count aggregation), `cargo test --workspace --all-targets` (348), clippy clean, `test:config` (30), `test:native-lint` (7), `test:packaging:unit` (112), `test:parser-api` (9), `test:vite` (12), `test:native-format` (7), `tests/markless-dropin/*` (28), and the site suites.

Note `pnpm test` does not include `test:parser-api`, `test:markless-control`, or `tests/markless-dropin/*` (that last has no script at all), so those were run explicitly.

## One thing reviewers should know

Fixing the Oxfmt bug **unmasks two Markless-side defects** that the refusal-to-write was hiding. Both reproduce from hand-authored sources with no formatter involved, so they are Markless sensitivities to ordinary correct Oxfmt output, not consequences of this PR, and neither is fixable here:

1. JSX text moved onto its own line makes Markless's SSR emitter yield `" Region "` where JSX semantics require `"Region"` — it does not trim whitespace-containing-newlines at the start and end of JSX children. This changes rendered HTML.
2. Oxfmt parenthesizes `() => region = 'east'` as `() => (region = 'east')`, and Markless's state-lowering does not see through the parentheses, dropping a `marklessWriteScalar` fast path. Still correct; an optimization-path change.

Both are filed on the Markless side.

## Not included

Editor recovery (`capabilities.editorRecovery: false`) is deliberately out of scope. It is genuinely unimplemented in the native engine rather than disabled — `crates/tsrx_parser_engine` has no recovery code path — and exposing the compat facade's JavaScript text surgery through `recovery: "editor"` would make that capability over-report a *native* capability, which is exactly the honesty problem this PR fixes for `cssMaterialization`, inverted.
