### PR TITLE
fix: chain the site deploy from release mode

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -75,8 +75,13 @@ jobs:
     # rust-cache above only helps on a second run with the same key. 60 was the
     # budget when this job compiled nothing.
     timeout-minutes: 90
+    # `actions: write` is the narrowest grant that lets the last step dispatch
+    # site-artifact.yml; the trap it exists for is written out there. It buys
+    # the ability to start a workflow run in this repository and nothing else,
+    # and it stays on this job rather than at the top of the file.
     permissions:
       contents: write
+      actions: write
     steps:
       # Full history, because the release notes are generated from it and a
       # shallow clone would silently produce a shorter changelog.
@@ -428,6 +433,29 @@ jobs:
           make_latest: ${{ inputs.release_type != 'prerelease' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      # The push above is made with GITHUB_TOKEN, and a token push fires no
+      # `push` event: GitHub suppresses those so a workflow cannot recurse into
+      # itself. site-artifact.yml deploys compiled.run on push to main, so the
+      # release commit lands, no event is delivered, and the site keeps serving
+      # the PREVIOUS release's docs until some unrelated commit happens to
+      # arrive. 0.4.0 was cut that way and compiled.run stayed on 0.3.0.
+      #
+      # An explicit workflow_dispatch is not a suppressed event, so the deploy
+      # is chained by hand here. site-artifact.yml's deploy job gates on
+      # `github.ref_name == 'main'` rather than on the event, so a dispatched
+      # run deploys exactly like a pushed one. `--ref main` is safe to write
+      # literally: this job already refuses to run anywhere but the default
+      # branch.
+      - name: Deploy the site for the release just pushed
+        if: inputs.mode == 'release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run site-artifact.yml --ref main
+          echo "dispatched site-artifact.yml on main; compiled.run rebuilds from the release commit"
 
       # Deliberately the last word in this file. The release exists on GitHub;
       # nothing is on npm yet, and nothing in this workflow can put it there.

--- a/docs/releasing/publish-runbook.md
+++ b/docs/releasing/publish-runbook.md
@@ -88,6 +88,13 @@ default branch. It takes three inputs:
 Run the dry run, read the notes it attaches to the run as an artifact, then run
 it again in `release` mode.
 
+`release` mode also chains the site deploy: once the commit and the tag are
+pushed it dispatches **Build website artifact**
+(`.github/workflows/site-artifact.yml`) on `main`, so compiled.run rebuilds from
+the release commit. That step exists because the release push is made with
+`GITHUB_TOKEN` and a token push fires no `push` event, which used to leave the
+site serving the previous release's docs until an unrelated commit landed.
+
 ### Why the version is not just `bumpp`
 
 `bumpp` rewrites the `version` field of a manifest. That is four files out of

--- a/tests/release/release-path.test.mjs
+++ b/tests/release/release-path.test.mjs
@@ -190,7 +190,9 @@ test("contents: write stays scoped to the single release job", () => {
 
   // Exactly one job, and it is the one that pushes.
   assert.deepEqual(Object.keys(workflow.jobs), ["release"]);
-  assert.deepEqual(job("release").permissions, { contents: "write" });
+  // `actions: write` is only the grant that lets release mode dispatch the
+  // site deploy; it cannot touch the registry, and id-token stays absent.
+  assert.deepEqual(job("release").permissions, { contents: "write", actions: "write" });
 });
 
 test("no id-token: write anywhere, so this workflow cannot publish to npm", () => {


### PR DESCRIPTION
Token pushes fire no push event, so the release-mode push of the version-bump commit never triggered site-artifact.yml — every release left compiled.run serving the previous release's docs (0.4.0 shipped tonight; the site stayed on 0.3.0 until a manual dispatch).

Release mode now dispatches site-artifact.yml on main as its final step, gated on `inputs.mode == 'release'`, under a job-scoped `actions: write` grant. site-artifact.yml's deploy job gates on `ref_name == 'main'`, not the event name, so a dispatched run deploys identically to a pushed one. The release-path contract test now pins the release job's permissions as `{contents: write, actions: write}`; the workflow-level read-only posture, single-job shape, and the no-id-token guard are unchanged, so the workflow still cannot publish to npm.

Runbook's Cutting-a-release section documents the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzQHoCGD244FgQJFJX3cjp