### PR TITLE
docs: install commands say oxc-tsrx@latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ endorsed by, or a product of VoidZero or the OXC team._
 ## Install
 
 ```sh
-npm install --save-dev oxc-tsrx@0.4.0
+npm install --save-dev oxc-tsrx@latest
 ```
 
 That is the whole setup, for the command line and for your editor. There is no

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -23,7 +23,7 @@ dependency:
 
 <!-- pm-install -->
 ```sh
-npm install --save-dev oxc-tsrx@0.4.0
+npm install --save-dev oxc-tsrx@latest
 ```
 
 That is the whole setup. There is no config file and no ignore file to write.
@@ -46,7 +46,7 @@ This is the complete list of things you have to run to lint and format `.tsrx`.
 
 | Where you use it | Steps | What you run |
 | --- | --- | --- |
-| Command line (`oxlint`, `oxfmt`) | 1 | `npm install --save-dev oxc-tsrx@0.4.0` |
+| Command line (`oxlint`, `oxfmt`) | 1 | `npm install --save-dev oxc-tsrx@latest` |
 | Editor, through the released official OXC extension | 1 | the same install, and nothing else |
 | [Vite+](#try-it-with-vite) (`vp lint`, `vp fmt`) | 2 | the same install, then `oxc-tsrx setup` |
 
@@ -64,7 +64,7 @@ both, and the walkthrough above is the rest of the story:
 
 <!-- pm-install -->
 ```sh
-npm install --save-dev vite-plus oxc-tsrx@0.4.0
+npm install --save-dev vite-plus oxc-tsrx@latest
 npx oxc-tsrx setup
 ```
 

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -20,7 +20,7 @@ You need Node.js 20.19 or newer:
 
 <!-- pm-install -->
 ```sh
-npm install oxc-tsrx@0.4.0
+npm install oxc-tsrx@latest
 ```
 
 Like the CLI tools, the parser is native Rust code. Your package manager

--- a/docs/integrations/custom-js-plugins.md
+++ b/docs/integrations/custom-js-plugins.md
@@ -26,7 +26,7 @@ You need Node.js 20.19 or newer, and one install
 
 <!-- pm-install -->
 ```sh
-npm install oxc-tsrx@0.4.0
+npm install oxc-tsrx@latest
 ```
 
 Save this as `src/TaskList.tsrx`:

--- a/docs/integrations/vite-plus.md
+++ b/docs/integrations/vite-plus.md
@@ -42,7 +42,7 @@ What you get is an ordinary React and TypeScript app that knows nothing about
 ## 3. Add the linter and the editor toolchain
 
 ```sh
-vp install -D oxc-tsrx@0.4.0 oxlint-tsgolint@0.24.0 \
+vp install -D oxc-tsrx@latest oxlint-tsgolint@0.24.0 \
   @tsrx/typescript-plugin @tsrx/react
 ```
 
@@ -85,7 +85,7 @@ project's own manager, not a fixed one:
   hands it to npm instead of reading it itself:
 
   ```sh
-  vp install -D oxc-tsrx@0.4.0 oxlint-tsgolint@0.24.0 \
+  vp install -D oxc-tsrx@latest oxlint-tsgolint@0.24.0 \
     @tsrx/typescript-plugin @tsrx/react -- --legacy-peer-deps
   ```
 
@@ -248,7 +248,7 @@ and the walkthrough above is the rest:
 
 <!-- pm-install -->
 ```sh
-npm install --save-dev vite-plus oxc-tsrx@0.4.0
+npm install --save-dev vite-plus oxc-tsrx@latest
 npx oxc-tsrx setup
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -19,7 +19,7 @@ to Vite+. An unsupported option is an error, never an ignored flag.
 
 ## What a plain install puts on your path
 
-`npm install --save-dev oxc-tsrx@0.4.0` is the whole setup for the command line
+`npm install --save-dev oxc-tsrx@latest` is the whole setup for the command line
 and for the editor. Vite+ needs one more command; see
 [the minimum steps per host](/guide/getting-started#the-minimum-steps-per-host).
 The install links seven commands into `node_modules/.bin`:

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -145,9 +145,6 @@ const DEP_SINGLE_QUOTED = () => slot(String.raw`'oxc-tsrx':\s*'<V>'`);
 const CLI_SPEC_IN_REGEX = () =>
   slot(String.raw`oxc-tsrx@<V>`, SPELLINGS.regexEscaped);
 
-/** `oxc-tsrx@1.0.0` — the install spec a docs page tells a reader to run. */
-const INSTALL_SPEC = () => slot(String.raw`oxc-tsrx@<V>`);
-
 /** `assert.equal(manifest.dependencies["oxc-tsrx"], "1.0.0")` */
 const ASSERT_DEP = () => slot(String.raw`dependencies\["oxc-tsrx"\],\s*"<V>"`);
 
@@ -334,15 +331,11 @@ const textTargets: any[] = [
   { file: "tests/packaging/vscode-artifact.test.mjs", slots: [[ASSERT_VERSION, 1]] },
   { file: "tests/plugins/custom-js-plugins-doc.test.mjs", slots: [[DEP, 1]] },
   { file: "tests/vite/physical-consumer.mjs", slots: [[DEP, 1]] },
-  // Docs install commands pin an exact version on purpose: pnpm 11 holds a
-  // fresh release back for about a day by default and resolves `@latest` to
-  // the previous version, silently. A named version skips the holdback.
-  { file: "README.md", slots: [[INSTALL_SPEC, 1]] },
-  { file: "docs/guide/getting-started.md", slots: [[INSTALL_SPEC, 3]] },
-  { file: "docs/guide/parsing.md", slots: [[INSTALL_SPEC, 1]] },
-  { file: "docs/integrations/vite-plus.md", slots: [[INSTALL_SPEC, 3]] },
-  { file: "docs/integrations/custom-js-plugins.md", slots: [[INSTALL_SPEC, 1]] },
-  { file: "docs/reference/cli.md", slots: [[INSTALL_SPEC, 1]] },
+  // Docs and README install commands say `oxc-tsrx@latest` (owner decision,
+  // 2026-08-14) and are no longer declared here. The trade this accepts is
+  // pnpm's release-age hold: for about a day after a publish, `@latest`
+  // resolves the previous release. tests/site/documented-version-pin.test.mjs
+  // enforces the dist-tag form so stale pins cannot creep back in.
 ];
 
 // ---------------------------------------------------------------------------

--- a/tests/site/documented-version-pin.test.mjs
+++ b/tests/site/documented-version-pin.test.mjs
@@ -1,23 +1,26 @@
-// Install commands in the documentation are deliberately unpinned. `npm
-// install --save-dev oxc-tsrx` is what every comparable project prints, and it
-// is what a reader expects to copy.
+// Install commands in the documentation say `oxc-tsrx@latest` (owner decision,
+// 2026-08-14). This policy has now flipped in each direction more than once,
+// so here is the whole history in one place:
 //
-// Pinning was tried and reverted. It was added when an unpinned install on
-// pnpm 11 could resolve the broken 0.1.0, because that resolver holds a new
-// release back for its first day and 0.1.0 was the only version old enough to
-// clear the bar. That hazard aged out: the fallback is now a working version.
-// What the pin left behind was thirteen literal version strings across six
-// files that no build step touches, all of which quietly point at the previous
-// release the moment a new one ships.
+// - Unpinned (`npm install --save-dev oxc-tsrx`) is what comparable projects
+//   print, but pnpm 11's release-age hold once resolved a bare install to the
+//   broken 0.1.0, which forced the first flip to exact pins.
+// - Exact pins never rot in-repo (scripts/sync-version.ts rewrote them each
+//   cut), but they DO rot on the deployed site between a release and the next
+//   deploy, and the owner judged that churn not worth it (2026-08-14, after
+//   0.4.0 shipped while the site still showed 0.3.0).
+// - `@latest` is the current policy, chosen with the known trade: pnpm applies
+//   its release-age hold to the `latest` tag too — measured 2026-08-01, an
+//   hour after 0.2.0 shipped, pnpm 11.18 installed 0.1.5 and printed only
+//   "(0.2.0 is available)". A day-one reader on pnpm gets the previous
+//   release. The owner accepted that in exchange for install lines that never
+//   need a doc edit or a redeploy again.
 //
-// `@latest` is not a fix for the same problem. pnpm 11 applies its release-age
-// hold to the `latest` tag too, so `oxc-tsrx@latest` resolves to exactly what
-// writing nothing resolves to, while looking like a guarantee it does not make.
-//
-// So no pin is required. But a pin that someone adds on purpose, in a
-// migration note or a reproduction, must still name a version that exists and
-// agree with what this repository ships. That is what is asserted here, and it
-// costs nothing when there are no pins at all.
+// What is asserted now: every documented install command uses the `@latest`
+// dist-tag (so stale exact pins cannot creep back in without flipping this
+// test deliberately), and any exact pin someone adds on purpose elsewhere — a
+// migration note, a reproduction — must agree with the version this
+// repository ships. The second check costs nothing when there are no pins.
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -54,31 +57,15 @@ test("any documented oxc-tsrx version pin names the version this repository ship
   }
 });
 
-test("the documented install commands pin an exact version, never a dist-tag", async () => {
-  // This policy has flipped once, deliberately, in each direction; here is the
-  // whole trade so it does not flip again by accident.
-  //
-  // Dist-tags survive a release without an edit, which is why the site once
-  // required them. But pnpm applies its release-age hold to the `latest` tag
-  // itself, so for about a day after every publish `oxc-tsrx@latest` silently
-  // resolves the PREVIOUS release — measured 2026-08-01, an hour after 0.2.0
-  // shipped: pnpm 11.18 installed 0.1.5 and printed only "(0.2.0 is
-  // available)". The reader who follows the docs the day a release is
-  // announced is exactly the reader the docs most need to serve.
-  //
-  // A named version skips the holdback on every package manager, and staleness
-  // is no longer the price: scripts/sync-version.ts declares every one of
-  // these pins as a slot, rewrites them at each cut, and `--check` gates CI,
-  // while the sibling test above proves the pinned version is the one this
-  // repository ships.
+test("the documented install commands use the @latest dist-tag, never an exact pin", async () => {
   const installLine = /(?:npm install|pnpm add|yarn add|bun add|vp install)[^\n`]*\boxc-tsrx@([^\s`]+)/g;
   for (const relativePath of readerFacingSources) {
     const source = await readFile(join(root, relativePath), "utf8");
     for (const match of source.matchAll(installLine)) {
-      assert.match(
+      assert.equal(
         match[1],
-        /^\d+\.\d+\.\d+$/,
-        `${relativePath} sends readers to oxc-tsrx@${match[1]}; name the exact shipped version — dist-tags resolve a day behind under pnpm's release-age hold`,
+        "latest",
+        `${relativePath} sends readers to oxc-tsrx@${match[1]}; the documented install form is oxc-tsrx@latest — flipping back to pins is a policy change that starts in this file's header`,
       );
     }
   }


### PR DESCRIPTION
Per owner decision: install commands in README and docs now read `oxc-tsrx@latest` instead of an exact synced pin, so a release never leaves the deployed site telling readers to install the previous version.

- 10 install lines across README + 5 doc pages switched to `@latest` (the paired `oxlint-tsgolint@0.24.0` pin stays — the type-aware adapter only accepts the exact version it was built against until the TS7 migration lands).
- The six `INSTALL_SPEC` slots leave `scripts/sync-version.ts` (`--check` green at 75 locations / 26 files).
- `tests/site/documented-version-pin.test.mjs` flips to enforce the `@latest` form so exact pins cannot creep back without a deliberate policy change; its header records the full flip history including the measured pnpm release-age-hold trade (day-one pnpm readers resolve the previous release) that this decision accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzQHoCGD244FgQJFJX3cjp