### PR TITLE
Restore Guessless docs as static files to fix /guessless 404

### DIFF
--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -101,6 +101,20 @@ jobs:
           node tests/site/verify-static.mjs --require-wasm
           pnpm run docs:check
 
+      - name: Fetch and embed Guessless docs
+        run: |
+          set -euo pipefail
+          # Fetch the Guessless docs from compiled-run/guessless and copy them
+          # into docs/dist/guessless/ so they ship in the same Vercel deploy.
+          echo "Fetching Guessless docs from compiled-run/guessless..."
+          TEMP_DIR="$(mktemp -d)"
+          git clone --depth 1 --branch main https://github.com/compiled-run/guessless.git "${TEMP_DIR}"
+          mkdir -p docs/dist/guessless
+          cp -r "${TEMP_DIR}/site/guessless/." docs/dist/guessless/
+          rm -rf "${TEMP_DIR}"
+          echo "Guessless docs copied to docs/dist/guessless/"
+          ls -la docs/dist/guessless/ | head -20
+
       - name: Upload the exact Vercel-shaped static artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -187,31 +201,29 @@ jobs:
           fi
           echo "production is serving this run's build (${built})"
 
-      - name: Prove Guessless is still accessible
+      - name: Prove Guessless docs are accessible
         run: |
           set -euo pipefail
-          # Verify that the Guessless project (https://github.com/compiled-run/guessless)
-          # is still accessible after this oxc-tsrx deploy. The rewrite rule in
-          # vercel.json proxies /guessless to https://guessless.vercel.app to prevent
-          # oxc-tsrx deploys from wiping out the separate Guessless deployment.
+          # Verify that the Guessless docs (from https://github.com/compiled-run/guessless)
+          # are accessible after this oxc-tsrx deploy. The docs are now embedded as
+          # static files under /guessless/ in the artifact.
           origin="https://oxc-tsrx-docs.vercel.app/guessless"
           echo "Checking that ${origin} is accessible..."
           for attempt in 1 2 3 4 5; do
-            # Guessless redirects to /login, so follow redirects and check for non-404
-            status_code="$(curl -fsS -o /dev/null -w '%{http_code}' -L "${origin}" || echo "000")"
+            status_code="$(curl -fsS -o /dev/null -w '%{http_code}' "${origin}" || echo "000")"
             if [ "${status_code}" = "200" ]; then
-              echo "✓ Guessless is accessible (HTTP ${status_code})"
+              echo "✓ Guessless docs are accessible (HTTP ${status_code})"
               break
             fi
             if [ "${status_code}" = "404" ]; then
-              echo "::error::Guessless returned 404! The oxc-tsrx deploy broke the Guessless proxy."
+              echo "::error::Guessless returned 404! The static docs were not embedded."
               exit 1
             fi
             echo "attempt ${attempt}: got HTTP ${status_code}, retrying..."
             sleep 5
           done
           if [ "${status_code}" != "200" ]; then
-            echo "::error::Could not verify Guessless accessibility after 5 attempts"
+            echo "::error::Could not verify Guessless docs accessibility after 5 attempts"
             exit 1
           fi
           
@@ -219,9 +231,9 @@ jobs:
           custom_origin="https://compiled.run/guessless"
           echo "Checking that ${custom_origin} is accessible..."
           for attempt in 1 2 3 4 5; do
-            custom_status="$(curl -fsS -o /dev/null -w '%{http_code}' -L "${custom_origin}" || echo "000")"
+            custom_status="$(curl -fsS -o /dev/null -w '%{http_code}' "${custom_origin}" || echo "000")"
             if [ "${custom_status}" = "200" ]; then
-              echo "✓ Guessless is accessible via custom domain (HTTP ${custom_status})"
+              echo "✓ Guessless docs accessible via custom domain (HTTP ${custom_status})"
               exit 0
             fi
             if [ "${custom_status}" = "404" ]; then

--- a/docs/build.mjs
+++ b/docs/build.mjs
@@ -2644,19 +2644,10 @@ async function build() {
       // README published in oxc-tsrx@0.1.5 links that path, and an npm tarball
       // is immutable, so the path itself has to keep resolving.
       redirects: [],
-      // Preserve /guessless: proxy requests to the separate Guessless deployment
-      // so oxc-tsrx deploys cannot wipe it out. Guessless lives in
-      // https://github.com/compiled-run/guessless and deploys independently.
-      rewrites: [
-        {
-          source: '/guessless',
-          destination: 'https://guessless.vercel.app/',
-        },
-        {
-          source: '/guessless/:path*',
-          destination: 'https://guessless.vercel.app/:path*',
-        },
-      ],
+      // Guessless docs are now embedded as static files under /guessless/ during
+      // the site build (see .github/workflows/site-artifact.yml), so no rewrites
+      // are needed. Vercel's cleanUrls handles /guessless -> /guessless/index.html.
+      rewrites: [],
       headers: [
         {
           source: '/(.*)',

--- a/tests/site/launch-build.test.mjs
+++ b/tests/site/launch-build.test.mjs
@@ -233,16 +233,10 @@ test("static launch build has a scoped base, crawl metadata, and no internal des
       ],
     },
   ]);
-  // Verify the Guessless proxy rewrite is present to prevent oxc-tsrx deploys
-  // from wiping out the separate Guessless deployment.
+  // Guessless docs are now embedded as static files during the build, so no
+  // external rewrite is needed. Verify the rewrites array is empty.
   assert.ok(Array.isArray(vercel.rewrites), "vercel.json should have rewrites array");
-  const guesslessRewrite = vercel.rewrites.find((r) => r.source === "/guessless/:path*");
-  assert.ok(guesslessRewrite, "vercel.json should have /guessless rewrite rule");
-  assert.equal(
-    guesslessRewrite.destination,
-    "https://guessless.vercel.app/:path*",
-    "Guessless rewrite should proxy to guessless.vercel.app",
-  );
+  assert.equal(vercel.rewrites.length, 0, "vercel.json should have no rewrites");
 });
 
 test("launch build fails closed when the browser WebAssembly artifact is required", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production at https://compiled.run/guessless returns 404. PR #15 added Vercel rewrites to https://guessless.vercel.app, but:
1. That destination is **the wrong app** (a different GuessLess login app, not the docs)
2. The rewrite source `/guessless/:path*` doesn't match `/guessless` itself
3. The oxc-tsrx site artifact deploys `docs/dist` as the entire Vercel project, wiping anything not in the artifact

## Solution

This PR embeds the actual Guessless **documentation** as static files in the oxc-tsrx build artifact, so they ship together and `/guessless` serves real content.

### Changes

1. **Workflow**: Added a build step in `.github/workflows/site-artifact.yml` that:
   - Clones `compiled-run/guessless` repo (main branch)
   - Copies `site/guessless/` into `docs/dist/guessless/`
   - Runs after `docs:build` but before artifact upload

2. **Build config**: Updated `docs/build.mjs`:
   - Removed the broken Vercel rewrites to `guessless.vercel.app`
   - Added comment explaining static files approach
   - Vercel's `cleanUrls: true` handles `/guessless` → `/guessless/index.html`

3. **Tests**: Updated `tests/site/launch-build.test.mjs`:
   - Removed assertion for the external rewrite
   - Now expects empty `rewrites` array

4. **Deploy verification**: Updated the workflow's Guessless check:
   - Now verifies static docs return 200
   - Updated comments to reflect static file approach

## Success Criteria

After this PR merges and the site-artifact workflow deploys to production:
- ✅ https://compiled.run/guessless returns 200 with Guessless docs
- ✅ https://compiled.run/oxc-tsrx continues to work (OXC for TSRX docs)
- ✅ Site tests pass (verified locally)

## Testing

Local test run:
```
pnpm run test:site:unit
# ✓ 35 pass, 0 fail, 1 skip
```

The workflow will run full site tests on this PR, including the real build with WebAssembly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41bd8247-6f5e-4f8a-8f6b-ef32e77fb25d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41bd8247-6f5e-4f8a-8f6b-ef32e77fb25d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guessless is now included as static content under `/guessless/`.
  * Guessless pages support clean URLs without relying on a proxy.

* **Bug Fixes**
  * Improved deployment verification to detect missing embedded documentation directly.
  * Removed redirect-dependent checks that could incorrectly report deployment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->