### PR TITLE
Fix Manual Release consistency gate: remove 'vercel deploy' from build job comment

### DIFF
--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -181,7 +181,7 @@ jobs:
           set -euo pipefail
           # Fetch the Guessless docs from compiled-run/guessless via tarball
           # (faster than full git clone) and copy them into docs/dist/guessless/
-          # so they ship in the same Vercel deploy.
+          # so they ship in the same artifact.
           echo "Fetching Guessless docs from compiled-run/guessless..."
           TEMP_DIR="$(mktemp -d)"
           curl -fsSL "https://github.com/compiled-run/guessless/archive/refs/heads/main.tar.gz" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Manual Release #20 (0.5.0 minor) failed on the "Prove the cut is internally consistent" step, specifically in `pnpm run test:release`.

The test `launch manifest names every byte set and keeps external actions approval-gated` checks that the build job in `.github/workflows/site-artifact.yml` does NOT contain deployment-related terms (`VERCEL_TOKEN` or `vercel deploy`) to ensure proper isolation between build and deploy jobs.

The build job contained a comment that inadvertently triggered this check:
```yaml
# so they ship in the same Vercel deploy.
```

## Fix

Changed the comment to:
```yaml
# so they ship in the same artifact.
```

This preserves the meaning while avoiding the forbidden phrase. The test now passes.

## Verification

Reproduced the failure locally by simulating the Manual Release sequence:
1. `bumpp package.json --release minor` (0.4.0 → 0.5.0)
2. `node scripts/sync-version.ts && node scripts/sync-version.ts --check`
3. `cargo update -w && pnpm install --lockfile-only`
4. `cargo metadata` on docs tools
5. `pnpm run licenses:generate`
6. `pnpm run test:release` — **failed** before fix, **passes** after fix

All consistency checks now pass:
- ✅ `node scripts/sync-version.ts --check`
- ✅ `pnpm run test:release` (13/13 tests pass)
- ✅ `node --test tests/site/documented-version-pin.test.mjs`
- ✅ `pnpm run licenses:check`

The next Manual Release (minor + release) will succeed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa9e05f3-e8b6-441e-868b-19e211cfdb23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa9e05f3-e8b6-441e-868b-19e211cfdb23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that Guessless is included in the generated site artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->