### PR TITLE
docs: serve yuku-tsrx under compiled.run/yuku-tsrx

### DIFF
--- a/docs/build.mjs
+++ b/docs/build.mjs
@@ -2644,13 +2644,23 @@ async function build() {
       // README published in oxc-tsrx@0.1.5 links that path, and an npm tarball
       // is immutable, so the path itself has to keep resolving.
       redirects: [],
-      // Guessless docs are now embedded as static files under /guessless/ during
-      // the site build (see .github/workflows/site-artifact.yml), so no rewrites
-      // are needed. Vercel's cleanUrls handles /guessless -> /guessless/index.html.
-      rewrites: [],
+      // Guessless docs are embedded as static files under /guessless/ during the
+      // site build (see .github/workflows/site-artifact.yml), so they need no
+      // rewrite: Vercel's cleanUrls handles /guessless -> /guessless/index.html.
+      // The yuku-tsrx docs are a separate Vercel project (yuku-tsrx-docs) served
+      // under this domain at /yuku-tsrx, so they are proxied instead. Both sources
+      // are needed because ':path*' does not match the bare path.
+      rewrites: [
+        { source: '/yuku-tsrx', destination: 'https://yuku-tsrx-docs.vercel.app/yuku-tsrx' },
+        {
+          source: '/yuku-tsrx/:path*',
+          destination: 'https://yuku-tsrx-docs.vercel.app/yuku-tsrx/:path*',
+        },
+      ],
       headers: [
         {
-          source: '/(.*)',
+          // The proxied yuku-tsrx pages need no cross-origin isolation.
+          source: '/((?!yuku-tsrx).*)',
           headers: [
             { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
             { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
@@ -2705,6 +2715,7 @@ a:hover { border-color: #888; }
 <main>
 <h1>${host}</h1>
 <a href="${trimmedBase}">${escapeHtml(config.title)} &rarr;</a>
+<a href="/yuku-tsrx">yuku-tsrx &rarr;</a>
 </main>
 </body>
 </html>

--- a/tests/site/launch-build.test.mjs
+++ b/tests/site/launch-build.test.mjs
@@ -226,17 +226,23 @@ test("static launch build has a scoped base, crawl metadata, and no internal des
   assert.equal(vercel.trailingSlash, false);
   assert.deepEqual(vercel.headers, [
     {
-      source: "/(.*)",
+      source: "/((?!yuku-tsrx).*)",
       headers: [
         { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
         { key: "Cross-Origin-Embedder-Policy", value: "require-corp" },
       ],
     },
   ]);
-  // Guessless docs are now embedded as static files during the build, so no
-  // external rewrite is needed. Verify the rewrites array is empty.
-  assert.ok(Array.isArray(vercel.rewrites), "vercel.json should have rewrites array");
-  assert.equal(vercel.rewrites.length, 0, "vercel.json should have no rewrites");
+  // Guessless docs are embedded as static files during the build, so they need
+  // no external rewrite; the yuku-tsrx docs are a separate Vercel project proxied
+  // under /yuku-tsrx, which takes one rewrite per source shape.
+  assert.deepEqual(vercel.rewrites, [
+    { source: "/yuku-tsrx", destination: "https://yuku-tsrx-docs.vercel.app/yuku-tsrx" },
+    {
+      source: "/yuku-tsrx/:path*",
+      destination: "https://yuku-tsrx-docs.vercel.app/yuku-tsrx/:path*",
+    },
+  ]);
 });
 
 test("launch build fails closed when the browser WebAssembly artifact is required", async () => {


### PR DESCRIPTION
Adds a proxy rewrite pair in the emitted vercel.json that serves the yuku-tsrx-docs Vercel project under /yuku-tsrx on this domain; both a bare-path and a :path* source are needed because ':path*' does not match the bare path. The COOP/COEP header source now excludes /yuku-tsrx, since the proxied pages need no cross-origin isolation, and the landing page gains a link to it. The yuku-tsrx site is already built under base /yuku-tsrx/, so no changes are needed on that side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to Yuku TS RX documentation at `/yuku-tsrx`.
  * Yuku TS RX pages and nested paths are now served from the dedicated documentation site.
  * Updated the base-path landing page with a link to the documentation.

* **Bug Fixes**
  * Preserved cross-origin isolation behavior for other site routes while excluding proxied documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->