### PR TITLE
feat(format): support Oxfmt sortImports and jsdoc for .tsrx files

### DIFF
--- a/crates/oxc_adapter/src/toolchain/format.rs
+++ b/crates/oxc_adapter/src/toolchain/format.rs
@@ -1,12 +1,13 @@
 //! The canonical Oxfmt formatting lane and the project-owned options it is driven by.
 
-use std::{error::Error, fmt, str::FromStr, time::Instant};
+use std::{collections::HashSet, error::Error, fmt, str::FromStr, time::Instant};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::{
     ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
-    EmbeddedLanguageFormatting, Expand, JsFormatOptions, JsdocOptions, LineWrappingStyle,
-    QuoteProperties, QuoteStyle, Semicolons, TrailingCommas, format_program, parse_for_format,
+    CustomGroupDefinition, EmbeddedLanguageFormatting, Expand, GroupEntry, ImportModifier,
+    ImportSelector, JsFormatOptions, JsdocOptions, LineWrappingStyle, QuoteProperties, QuoteStyle,
+    Semicolons, SortImportsOptions, SortOrder, TrailingCommas, format_program, parse_for_format,
 };
 use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
 use serde::Deserialize;
@@ -139,6 +140,8 @@ pub struct FormatOptions {
     pub html_whitespace_sensitivity: Option<String>,
     /// Oxfmt's `jsdoc` option, parsed by [`FormatOptions::set_jsdoc`].
     pub jsdoc: Option<JsdocSetting>,
+    /// Oxfmt's `sortImports` option, parsed by [`FormatOptions::set_sort_imports`].
+    pub sort_imports: Option<SortImportsSetting>,
 }
 
 /// Whether one configuration scope turns `jsdoc` comment formatting on, and with which
@@ -174,7 +177,120 @@ pub struct JsdocConfig {
     pub keep_unparsable_example_indent: Option<bool>,
 }
 
+/// Whether one configuration scope turns import sorting on, and with which sub-options.
+///
+/// Canonical Oxfmt spells this option `true`, `false`, or an object, under either `sortImports` or
+/// its `experimentalSortImports` alias. The disabled form stays a value rather than an absent
+/// option so one `overrides` entry can turn sorting back off for the files it matches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SortImportsSetting {
+    Disabled,
+    Enabled(SortImportsConfig),
+}
+
+/// The sub-options canonical Oxfmt reads out of a `sortImports` object.
+///
+/// Every field stays `None` when the author did not write it, so the pinned formatter's own
+/// defaults decide. Names inside `groups` and `customGroups` are parsed and cross-checked where
+/// every other named option is, in [`js_format_options`], and unknown fields are refused rather
+/// than silently ignored.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SortImportsConfig {
+    pub partition_by_newline: Option<bool>,
+    pub partition_by_comment: Option<bool>,
+    pub sort_side_effects: Option<bool>,
+    pub order: Option<SortImportsOrder>,
+    pub ignore_case: Option<bool>,
+    pub newlines_between: Option<bool>,
+    pub internal_pattern: Option<Vec<String>>,
+    pub groups: Option<Vec<SortImportsGroup>>,
+    pub custom_groups: Option<Vec<SortImportsCustomGroup>>,
+}
+
+/// Whether imports sort A-Z or Z-A, spelled the way canonical Oxfmt spells it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortImportsOrder {
+    Asc,
+    Desc,
+}
+
+/// One entry of the `groups` list.
+///
+/// Canonical Oxfmt accepts a single group name, an array of names sorted as one group, or a
+/// `{ "newlinesBetween": bool }` marker that overrides the blank line at one group boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum SortImportsGroup {
+    NewlinesBetween(NewlinesBetweenMarker),
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl SortImportsGroup {
+    /// The group names this entry contributes, which is nothing for a boundary marker.
+    fn names(&self) -> &[String] {
+        match self {
+            Self::Single(name) => std::slice::from_ref(name),
+            Self::Multiple(names) => names,
+            Self::NewlinesBetween(_) => &[],
+        }
+    }
+}
+
+/// The `{ "newlinesBetween": bool }` marker one `groups` entry can be.
+///
+/// A misspelled key is refused rather than read as a group name, so a typo cannot silently turn
+/// into an undefined custom group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct NewlinesBetweenMarker {
+    pub newlines_between: bool,
+}
+
+/// One `customGroups` entry: a name usable in `groups`, plus what it matches.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct SortImportsCustomGroup {
+    pub group_name: String,
+    pub element_name_pattern: Vec<String>,
+    pub selector: Option<String>,
+    pub modifiers: Option<Vec<String>>,
+}
+
 impl FormatOptions {
+    /// Reads Oxfmt's `sortImports` option out of one JSON configuration value.
+    ///
+    /// Callers hand over the raw JSON for the same reason [`FormatOptions::set_jsdoc`] does: the
+    /// parsed shape is this adapter's own, so the `true | false | object` form canonical Oxfmt
+    /// documents stays in the one module allowed to know how the pinned formatter spells it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatOptionError`] when the value is neither a boolean nor an object of the
+    /// sub-options canonical Oxfmt accepts.
+    pub fn set_sort_imports(&mut self, value: &Value) -> Result<(), FormatOptionError> {
+        let setting = match value {
+            Value::Bool(false) => SortImportsSetting::Disabled,
+            Value::Bool(true) => SortImportsSetting::Enabled(SortImportsConfig::default()),
+            Value::Object(_) => {
+                SortImportsSetting::Enabled(serde_json::from_value(value.clone()).map_err(
+                    |error| FormatOptionError::named("sortImports", &value.to_string(), error),
+                )?)
+            }
+            other => {
+                return Err(FormatOptionError::named(
+                    "sortImports",
+                    &other.to_string(),
+                    "expected `true`, `false`, or an object of import-sorting options",
+                ));
+            }
+        };
+        self.sort_imports = Some(setting);
+        Ok(())
+    }
+
     /// Reads Oxfmt's `jsdoc` option out of one JSON configuration value.
     ///
     /// Callers hand over the raw JSON because the parsed shape is this adapter's own, which keeps
@@ -334,7 +450,165 @@ fn js_format_options(options: &FormatOptions) -> Result<JsFormatOptions, FormatO
     if let Some(setting) = &options.jsdoc {
         resolved.jsdoc = jsdoc_options(setting)?;
     }
+    if let Some(setting) = &options.sort_imports {
+        resolved.sort_imports = sort_imports_options(setting)?;
+    }
     Ok(resolved)
+}
+
+/// One unusable `sortImports` value, reported in canonical Oxfmt's own wording.
+///
+/// Canonical prefixes each of these sentences with ``Invalid `sortImports` configuration:``; this
+/// error type already names the option, so only the sentence itself is carried.
+fn sort_imports_error(value: &str, detail: impl fmt::Display) -> FormatOptionError {
+    FormatOptionError::named("sortImports", value, detail)
+}
+
+/// Maps the project-owned `sortImports` option onto the pinned formatter's own options.
+///
+/// `customGroups` is resolved before `groups`, because a `groups` entry that names none of the
+/// predefined groups is only legal when a custom group defines that name.
+fn sort_imports_options(
+    setting: &SortImportsSetting,
+) -> Result<Option<SortImportsOptions>, FormatOptionError> {
+    let SortImportsSetting::Enabled(config) = setting else {
+        return Ok(None);
+    };
+    let mut resolved = SortImportsOptions::default();
+    if let Some(value) = config.partition_by_newline {
+        resolved.partition_by_newline = value;
+    }
+    if let Some(value) = config.partition_by_comment {
+        resolved.partition_by_comment = value;
+    }
+    if let Some(value) = config.sort_side_effects {
+        resolved.sort_side_effects = value;
+    }
+    if let Some(value) = config.order {
+        resolved.order = match value {
+            SortImportsOrder::Asc => SortOrder::Asc,
+            SortImportsOrder::Desc => SortOrder::Desc,
+        };
+    }
+    if let Some(value) = config.ignore_case {
+        resolved.ignore_case = value;
+    }
+    if let Some(value) = config.newlines_between {
+        resolved.newlines_between = value;
+    }
+    if let Some(value) = &config.internal_pattern {
+        resolved.internal_pattern.clone_from(value);
+    }
+    if let Some(groups) = &config.custom_groups {
+        resolved.custom_groups = custom_group_definitions(groups)?;
+    }
+    if let Some(entries) = &config.groups {
+        let (groups, overrides) = group_entries(entries, &resolved.custom_groups)?;
+        resolved.groups = groups;
+        resolved.newline_boundary_overrides = overrides;
+    }
+    resolved.validate().map_err(|error| sort_imports_error("options", error))?;
+    Ok(Some(resolved))
+}
+
+/// Parses every `customGroups` entry's selector and modifiers into the pinned formatter's own.
+fn custom_group_definitions(
+    groups: &[SortImportsCustomGroup],
+) -> Result<Vec<CustomGroupDefinition>, FormatOptionError> {
+    let mut resolved = Vec::with_capacity(groups.len());
+    for group in groups {
+        let name = group.group_name.as_str();
+        let selector = match group.selector.as_deref() {
+            Some(selector) => Some(ImportSelector::parse(selector).ok_or_else(|| {
+                sort_imports_error(
+                    selector,
+                    format!("unknown selector: `{selector}` in customGroups: `{name}`"),
+                )
+            })?),
+            None => None,
+        };
+        let raw_modifiers = group.modifiers.as_deref().unwrap_or_default();
+        let mut modifiers = Vec::with_capacity(raw_modifiers.len());
+        for modifier in raw_modifiers {
+            modifiers.push(ImportModifier::parse(modifier).ok_or_else(|| {
+                sort_imports_error(
+                    modifier,
+                    format!("unknown modifier: `{modifier}` in customGroups: `{name}`"),
+                )
+            })?);
+        }
+        resolved.push(CustomGroupDefinition {
+            group_name: group.group_name.clone(),
+            element_name_pattern: group.element_name_pattern.clone(),
+            selector,
+            modifiers,
+        });
+    }
+    Ok(resolved)
+}
+
+/// The pinned formatter's `groups` list paired with its per-boundary `newlinesBetween` overrides.
+///
+/// `overrides[i]` covers the boundary between `groups[i]` and `groups[i + 1]`, and `None` there
+/// means the global `newlinesBetween` decides.
+type ResolvedGroups = (Vec<Vec<GroupEntry>>, Vec<Option<bool>>);
+
+/// Splits the authored `groups` list into the pinned formatter's groups and its per-boundary
+/// `newlinesBetween` overrides.
+///
+/// A marker sits *between* two groups, so one at either end of the list, or two in a row, names a
+/// boundary that does not exist and is refused the way canonical Oxfmt refuses it.
+fn group_entries(
+    entries: &[SortImportsGroup],
+    custom_groups: &[CustomGroupDefinition],
+) -> Result<ResolvedGroups, FormatOptionError> {
+    let defined: HashSet<&str> =
+        custom_groups.iter().map(|group| group.group_name.as_str()).collect();
+    let mut groups: Vec<Vec<GroupEntry>> = Vec::new();
+    let mut boundary_overrides: Vec<Option<bool>> = Vec::new();
+    let mut pending: Option<bool> = None;
+    for entry in entries {
+        if let SortImportsGroup::NewlinesBetween(marker) = entry {
+            if groups.is_empty() {
+                return Err(sort_imports_error(
+                    "groups",
+                    "`{ \"newlinesBetween\" }` marker cannot appear at the start of `groups`",
+                ));
+            }
+            if pending.is_some() {
+                return Err(sort_imports_error(
+                    "groups",
+                    "consecutive `{ \"newlinesBetween\" }` markers are not allowed in `groups`",
+                ));
+            }
+            pending = Some(marker.newlines_between);
+            continue;
+        }
+        if !groups.is_empty() {
+            boundary_overrides.push(pending.take());
+        }
+        let mut parsed = Vec::new();
+        for name in entry.names() {
+            let group = GroupEntry::parse(name);
+            if let GroupEntry::Custom(custom) = &group
+                && !defined.contains(custom.as_str())
+            {
+                return Err(sort_imports_error(
+                    name,
+                    format!("unknown group name `{name}` in `groups`"),
+                ));
+            }
+            parsed.push(group);
+        }
+        groups.push(parsed);
+    }
+    if pending.is_some() {
+        return Err(sort_imports_error(
+            "groups",
+            "`{ \"newlinesBetween\" }` marker cannot appear at the end of `groups`",
+        ));
+    }
+    Ok((groups, boundary_overrides))
 }
 
 /// Maps the project-owned `jsdoc` option onto the pinned formatter's own options.

--- a/crates/oxc_adapter/src/toolchain/format.rs
+++ b/crates/oxc_adapter/src/toolchain/format.rs
@@ -250,12 +250,23 @@ pub struct NewlinesBetweenMarker {
 }
 
 /// One `customGroups` entry: a name usable in `groups`, plus what it matches.
+///
+/// `groupName` is required. A container-level `default` would let an entry omit it, read the
+/// entry as the empty name, and then let a `groups` entry of `""` resolve against it, so a typo
+/// would define a group instead of being refused.
+///
+/// `elementNamePattern` stays optional because canonical Oxfmt reads an empty pattern list as
+/// "matches every import", which is how a group selected purely by `selector` or `modifiers` is
+/// written; its own `custom_groups_selector_modifiers` fixture authors one that way.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SortImportsCustomGroup {
     pub group_name: String,
+    #[serde(default)]
     pub element_name_pattern: Vec<String>,
+    #[serde(default)]
     pub selector: Option<String>,
+    #[serde(default)]
     pub modifiers: Option<Vec<String>>,
 }
 
@@ -679,7 +690,12 @@ fn jsdoc_options(setting: &JsdocSetting) -> Result<Option<JsdocOptions>, FormatO
 
 #[cfg(test)]
 mod tests {
-    use super::{DynamicTagContract, FormatError, FormatRequest, SourceKind, format};
+    use serde_json::json;
+
+    use super::{
+        DynamicTagContract, FormatError, FormatOptions, FormatRequest, SourceKind, Value, format,
+        sort_imports_options,
+    };
 
     fn format_dynamic(expression: &str) -> Result<String, FormatError> {
         let source = format!("const value = <_t0_D0 _t0_A0_={{{expression}}} _t0_Z0_={{null}} />;");
@@ -740,5 +756,42 @@ mod tests {
             assert!(error.contains("dynamic tag"), "{expression}: {error}");
             assert!(error.contains("source byte 0"), "{expression}: {error}");
         }
+    }
+
+    /// One authored `sortImports` value taken all the way to the pinned formatter's own options,
+    /// which is where a `groups` entry is checked against the custom groups that define it.
+    fn resolve_sort_imports(value: &Value) -> Result<(), String> {
+        let mut options = FormatOptions::default();
+        options.set_sort_imports(value).map_err(|error| error.to_string())?;
+        let setting = options.sort_imports.as_ref().expect("a sortImports setting");
+        sort_imports_options(setting).map(|_| ()).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn a_custom_group_without_a_group_name_is_refused() {
+        // Omitting `groupName` names no group at all, so it is refused by name rather than read
+        // as the empty name.
+        let missing = resolve_sort_imports(&json!({
+            "customGroups": [{ "elementNamePattern": ["~/stores/*"] }],
+            "groups": ["stores", "unknown"],
+        }))
+        .unwrap_err();
+        assert!(missing.contains("missing field `groupName`"), "{missing}");
+
+        // With that entry refused, the empty name it used to define resolves in no `groups` list.
+        let empty = resolve_sort_imports(&json!({
+            "customGroups": [{ "groupName": "stores", "elementNamePattern": ["~/stores/*"] }],
+            "groups": ["", "unknown"],
+        }))
+        .unwrap_err();
+        assert!(empty.contains("unknown group name `` in `groups`"), "{empty}");
+
+        // A group matched purely by selector is what canonical Oxfmt's own fixture authors, so an
+        // entry without `elementNamePattern` is still accepted.
+        resolve_sort_imports(&json!({
+            "customGroups": [{ "groupName": "externals", "selector": "external" }],
+            "groups": ["externals", "unknown"],
+        }))
+        .expect("a selector-only custom group");
     }
 }

--- a/crates/oxc_adapter/src/toolchain/format.rs
+++ b/crates/oxc_adapter/src/toolchain/format.rs
@@ -4,11 +4,13 @@ use std::{error::Error, fmt, str::FromStr, time::Instant};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::{
-    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing,
-    EmbeddedLanguageFormatting, Expand, JsFormatOptions, QuoteProperties, QuoteStyle, Semicolons,
-    TrailingCommas, format_program, parse_for_format,
+    ArrowParentheses, AttributePosition, BracketSameLine, BracketSpacing, CommentLineStrategy,
+    EmbeddedLanguageFormatting, Expand, JsFormatOptions, JsdocOptions, LineWrappingStyle,
+    QuoteProperties, QuoteStyle, Semicolons, TrailingCommas, format_program, parse_for_format,
 };
 use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use serde::Deserialize;
+use serde_json::Value;
 
 use super::timings::{FormatEngineTimings, elapsed_ns};
 use crate::{DynamicTagContract, DynamicTagError, SourceKind, validate_dynamic_tags};
@@ -135,6 +137,74 @@ pub struct FormatOptions {
     pub single_attribute_per_line: Option<bool>,
     pub embedded_language_formatting: Option<String>,
     pub html_whitespace_sensitivity: Option<String>,
+    /// Oxfmt's `jsdoc` option, parsed by [`FormatOptions::set_jsdoc`].
+    pub jsdoc: Option<JsdocSetting>,
+}
+
+/// Whether one configuration scope turns `jsdoc` comment formatting on, and with which
+/// sub-options.
+///
+/// Canonical Oxfmt spells this option `true`, `false`, or an object. The disabled form stays a
+/// value rather than an absent option so one `overrides` entry can turn the option back off for
+/// the files it matches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsdocSetting {
+    Disabled,
+    Enabled(JsdocConfig),
+}
+
+/// The sub-options canonical Oxfmt reads out of a `jsdoc` object.
+///
+/// Every field stays `None` when the author did not write it, so the pinned formatter's own
+/// defaults decide. The two string fields are validated where every other named option is, in
+/// [`js_format_options`], and unknown fields are refused rather than silently ignored.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct JsdocConfig {
+    pub capitalize_descriptions: Option<bool>,
+    pub description_with_dot: Option<bool>,
+    pub add_default_to_description: Option<bool>,
+    pub prefer_code_fences: Option<bool>,
+    pub line_wrapping_style: Option<String>,
+    pub comment_line_strategy: Option<String>,
+    pub separate_tag_groups: Option<bool>,
+    pub separate_returns_from_param: Option<bool>,
+    pub bracket_spacing: Option<bool>,
+    pub description_tag: Option<bool>,
+    pub keep_unparsable_example_indent: Option<bool>,
+}
+
+impl FormatOptions {
+    /// Reads Oxfmt's `jsdoc` option out of one JSON configuration value.
+    ///
+    /// Callers hand over the raw JSON because the parsed shape is this adapter's own, which keeps
+    /// the `true | false | object` form canonical Oxfmt documents in the one module allowed to
+    /// know how the pinned formatter spells it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatOptionError`] when the value is neither a boolean nor an object of the
+    /// sub-options canonical Oxfmt accepts.
+    pub fn set_jsdoc(&mut self, value: &Value) -> Result<(), FormatOptionError> {
+        let setting = match value {
+            Value::Bool(false) => JsdocSetting::Disabled,
+            Value::Bool(true) => JsdocSetting::Enabled(JsdocConfig::default()),
+            Value::Object(_) => {
+                JsdocSetting::Enabled(serde_json::from_value(value.clone()).map_err(|error| {
+                    FormatOptionError::named("jsdoc", &value.to_string(), error)
+                })?)
+            }
+            other => {
+                return Err(FormatOptionError::named(
+                    "jsdoc",
+                    &other.to_string(),
+                    "expected `true`, `false`, or an object of JSDoc options",
+                ));
+            }
+        };
+        self.jsdoc = Some(setting);
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
@@ -261,7 +331,76 @@ fn js_format_options(options: &FormatOptions) -> Result<JsFormatOptions, FormatO
             _ => return Err(FormatOptionError::unrecognized("htmlWhitespaceSensitivity", value)),
         };
     }
+    if let Some(setting) = &options.jsdoc {
+        resolved.jsdoc = jsdoc_options(setting)?;
+    }
     Ok(resolved)
+}
+
+/// Maps the project-owned `jsdoc` option onto the pinned formatter's own options.
+///
+/// The two string sub-options quote canonical Oxfmt's wording for an invalid value, the way every
+/// other named option here does.
+fn jsdoc_options(setting: &JsdocSetting) -> Result<Option<JsdocOptions>, FormatOptionError> {
+    let JsdocSetting::Enabled(config) = setting else {
+        return Ok(None);
+    };
+    let mut resolved = JsdocOptions::default();
+    if let Some(value) = config.capitalize_descriptions {
+        resolved.capitalize_descriptions = value;
+    }
+    if let Some(value) = config.description_with_dot {
+        resolved.description_with_dot = value;
+    }
+    if let Some(value) = config.add_default_to_description {
+        resolved.add_default_to_description = value;
+    }
+    if let Some(value) = config.prefer_code_fences {
+        resolved.prefer_code_fences = value;
+    }
+    if let Some(value) = &config.line_wrapping_style {
+        resolved.line_wrapping_style = match value.as_str() {
+            "greedy" => LineWrappingStyle::Greedy,
+            "balance" => LineWrappingStyle::Balance,
+            _ => {
+                return Err(FormatOptionError::named(
+                    "jsdoc lineWrappingStyle",
+                    value,
+                    "Expected \"greedy\" or \"balance\".",
+                ));
+            }
+        };
+    }
+    if let Some(value) = &config.comment_line_strategy {
+        resolved.comment_line_strategy = match value.as_str() {
+            "singleLine" => CommentLineStrategy::SingleLine,
+            "multiline" => CommentLineStrategy::Multiline,
+            "keep" => CommentLineStrategy::Keep,
+            _ => {
+                return Err(FormatOptionError::named(
+                    "jsdoc commentLineStrategy",
+                    value,
+                    "Expected \"singleLine\", \"multiline\", or \"keep\".",
+                ));
+            }
+        };
+    }
+    if let Some(value) = config.separate_tag_groups {
+        resolved.separate_tag_groups = value;
+    }
+    if let Some(value) = config.separate_returns_from_param {
+        resolved.separate_returns_from_param = value;
+    }
+    if let Some(value) = config.bracket_spacing {
+        resolved.bracket_spacing = value;
+    }
+    if let Some(value) = config.description_tag {
+        resolved.description_tag = value;
+    }
+    if let Some(value) = config.keep_unparsable_example_indent {
+        resolved.keep_unparsable_example_indent = value;
+    }
+    Ok(Some(resolved))
 }
 
 #[cfg(test)]

--- a/crates/tsrx_format/src/error.rs
+++ b/crates/tsrx_format/src/error.rs
@@ -72,8 +72,9 @@ pub enum FormatError {
     UnknownOption { option: String, scope: ConfigScope },
     /// A known Oxfmt option that needs a surface outside the pinned formatter boundary.
     ///
-    /// `sortImports` and `sortTailwindcss` still reach this; `jsdoc` no longer does, because the
-    /// pinned formatter takes it through the adapter's own options.
+    /// Only `sortTailwindcss` still reaches this, because it needs canonical Oxfmt's Tailwind
+    /// callback. `jsdoc` and `sortImports` no longer do: the pinned formatter takes both of them
+    /// through the adapter's own options.
     UnavailableOption { option: &'static str, scope: ConfigScope },
     /// `embeddedLanguageFormatting`, which needs canonical embedded-language callbacks.
     EmbeddedLanguageFormattingUnavailable { scope: ConfigScope },

--- a/crates/tsrx_format/src/error.rs
+++ b/crates/tsrx_format/src/error.rs
@@ -71,6 +71,9 @@ pub enum FormatError {
     /// An option name this formatter does not recognize, which it never ignores silently.
     UnknownOption { option: String, scope: ConfigScope },
     /// A known Oxfmt option that needs a surface outside the pinned formatter boundary.
+    ///
+    /// `sortImports` and `sortTailwindcss` still reach this; `jsdoc` no longer does, because the
+    /// pinned formatter takes it through the adapter's own options.
     UnavailableOption { option: &'static str, scope: ConfigScope },
     /// `embeddedLanguageFormatting`, which needs canonical embedded-language callbacks.
     EmbeddedLanguageFormattingUnavailable { scope: ConfigScope },

--- a/crates/tsrx_format/src/error.rs
+++ b/crates/tsrx_format/src/error.rs
@@ -80,6 +80,12 @@ pub enum FormatError {
     EmbeddedLanguageFormattingUnavailable { scope: ConfigScope },
     /// An `experimental*` option the pinned formatter does not implement.
     ExperimentalOptions { scope: ConfigScope },
+    /// A `jsdoc` or `sortImports` value the adapter parses and rejects.
+    ///
+    /// The adapter's own wording already names the option and the value it refused; this variant
+    /// carries the block it was authored in, so the same bad value in `overrides[3]` does not read
+    /// exactly like one in the root block.
+    InvalidOptionValue { scope: ConfigScope, detail: String },
     /// An override declares no `files` patterns, so it could never match.
     OverrideWithoutFiles { index: usize },
     /// One override glob is not a valid pattern.
@@ -105,6 +111,11 @@ pub enum FormatError {
 impl FormatError {
     pub(crate) fn unreadable_config(path: &Path, error: io::Error) -> Self {
         Self::UnreadableConfig { path: path.to_path_buf(), error }
+    }
+
+    /// Keeps the adapter's wording for a refused option value and names the block it came from.
+    pub(crate) fn invalid_option_value(scope: ConfigScope, detail: impl fmt::Display) -> Self {
+        Self::InvalidOptionValue { scope, detail: detail.to_string() }
     }
 }
 
@@ -159,6 +170,9 @@ impl fmt::Display for FormatError {
                 formatter,
                 "experimental Oxfmt options are not supported by the pinned formatter in {scope}"
             ),
+            Self::InvalidOptionValue { scope, detail } => {
+                write!(formatter, "{detail} in {scope}")
+            }
             Self::OverrideWithoutFiles { index } => {
                 write!(formatter, "Oxfmt override {index} requires at least one files pattern")
             }

--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -391,14 +391,17 @@ impl RawFormatOptions {
             sort_imports: None,
         };
         // The adapter owns both of these options' shapes, so an unusable value is reported in the
-        // same wording a bad value for any other Oxfmt option gets.
+        // same wording a bad value for any other Oxfmt option gets, and named with the block it
+        // was authored in the way every other refusal here is.
         if let Some(jsdoc) = jsdoc {
-            engine.set_jsdoc(&jsdoc).map_err(|error| FormatError::Engine(error.into()))?;
+            engine
+                .set_jsdoc(&jsdoc)
+                .map_err(|error| FormatError::invalid_option_value(scope, error))?;
         }
         if let Some(sort_imports) = sort_imports {
             engine
                 .set_sort_imports(&sort_imports)
-                .map_err(|error| FormatError::Engine(error.into()))?;
+                .map_err(|error| FormatError::invalid_option_value(scope, error))?;
         }
         Ok(FileFormatOptions { engine, insert_final_newline })
     }
@@ -703,13 +706,18 @@ mod tests {
             .expect("a usable Oxfmt configuration")
     }
 
-    /// The error one authored root configuration is refused with.
-    fn root_error(config: &Value) -> String {
+    /// The error one authored options block is refused with, in the scope it was authored in.
+    fn scoped_error(config: &Value, scope: ConfigScope) -> String {
         serde_json::from_value::<RawFormatOptions>(config.clone())
             .expect("a readable Oxfmt configuration")
-            .resolve(ConfigScope::Root)
+            .resolve(scope)
             .expect_err("an unusable Oxfmt configuration")
             .to_string()
+    }
+
+    /// The error one authored root configuration is refused with.
+    fn root_error(config: &Value) -> String {
+        scoped_error(config, ConfigScope::Root)
     }
 
     #[test]
@@ -943,6 +951,28 @@ mod tests {
         // The one option still outside the pinned formatter boundary is refused exactly as before.
         let refused = root_error(&json!({ "sortTailwindcss": true }));
         assert!(refused.contains("`sortTailwindcss` is not available for TSRX"), "{refused}");
+    }
+
+    #[test]
+    fn an_unusable_sort_imports_or_jsdoc_value_names_the_block_it_was_authored_in() {
+        // The same bad value has to read differently depending on where it was written, the way
+        // every other refusal in this crate already does.
+        let sort_imports = json!({ "sortImports": { "order": "up" } });
+        let at_root = root_error(&sort_imports);
+        let in_override = scoped_error(&sort_imports, ConfigScope::Override { index: 3 });
+        assert!(at_root.contains("invalid Oxfmt sortImports"), "{at_root}");
+        assert!(at_root.contains("expected `asc` or `desc`"), "{at_root}");
+        assert!(at_root.ends_with(" in root Oxfmt config"), "{at_root}");
+        assert!(in_override.ends_with(" in Oxfmt override 3"), "{in_override}");
+        assert_ne!(at_root, in_override);
+
+        // A misspelled `jsdoc` sub-option travels the same path.
+        let jsdoc = json!({ "jsdoc": { "commentlinestrategy": "multiline" } });
+        let jsdoc_at_root = root_error(&jsdoc);
+        let jsdoc_in_override = scoped_error(&jsdoc, ConfigScope::Override { index: 0 });
+        assert!(jsdoc_at_root.contains("unknown field `commentlinestrategy`"), "{jsdoc_at_root}");
+        assert!(jsdoc_at_root.ends_with(" in root Oxfmt config"), "{jsdoc_at_root}");
+        assert!(jsdoc_in_override.ends_with(" in Oxfmt override 0"), "{jsdoc_in_override}");
     }
 
     #[test]

--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -132,6 +132,10 @@ struct RawFormatOptions {
     embedded_language_formatting: Option<String>,
     html_whitespace_sensitivity: Option<String>,
     insert_final_newline: Option<bool>,
+    /// Oxfmt's `true | false | object` import-sorting option, kept as JSON until the adapter
+    /// parses it into its own revision-independent shape. Canonical Oxfmt still accepts the
+    /// original `experimentalSortImports` spelling, so this reads both.
+    #[serde(alias = "experimentalSortImports")]
     sort_imports: Option<Value>,
     sort_tailwindcss: Option<Value>,
     /// Oxfmt's `true | false | object` doc-comment option, kept as JSON until the adapter parses
@@ -300,6 +304,7 @@ impl FileFormatOptions {
             embedded_language_formatting,
             html_whitespace_sensitivity,
             jsdoc,
+            sort_imports,
         );
         if other.insert_final_newline.is_some() {
             self.insert_final_newline = other.insert_final_newline;
@@ -358,7 +363,6 @@ impl RawFormatOptions {
         if let Some((option, _)) = unknown.into_iter().next() {
             return Err(FormatError::UnknownOption { option, scope });
         }
-        reject_enabled_value(scope, "sortImports", sort_imports)?;
         reject_enabled_value(scope, "sortTailwindcss", sort_tailwindcss)?;
         if embedded_language_formatting.is_some() {
             return Err(FormatError::EmbeddedLanguageFormattingUnavailable { scope });
@@ -384,11 +388,17 @@ impl RawFormatOptions {
             embedded_language_formatting: None,
             html_whitespace_sensitivity,
             jsdoc: None,
+            sort_imports: None,
         };
-        // The adapter owns this option's shape, so an unusable `jsdoc` value is reported in the
+        // The adapter owns both of these options' shapes, so an unusable value is reported in the
         // same wording a bad value for any other Oxfmt option gets.
         if let Some(jsdoc) = jsdoc {
             engine.set_jsdoc(&jsdoc).map_err(|error| FormatError::Engine(error.into()))?;
+        }
+        if let Some(sort_imports) = sort_imports {
+            engine
+                .set_sort_imports(&sort_imports)
+                .map_err(|error| FormatError::Engine(error.into()))?;
         }
         Ok(FileFormatOptions { engine, insert_final_newline })
     }
@@ -663,9 +673,9 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::{
-        EMBEDDED_CSS_FORMAT_NS, EMBEDDED_CSS_MODE, EMBEDDED_CSS_PARSE_COUNT,
+        ConfigScope, EMBEDDED_CSS_FORMAT_NS, EMBEDDED_CSS_MODE, EMBEDDED_CSS_PARSE_COUNT,
         EMBEDDED_CSS_USES_SUBPROCESS, EngineFormatOptions, FileFormatOptions, FormatMode,
-        format_text, format_text_with_options,
+        RawFormatOptions, format_text, format_text_with_options,
     };
 
     /// The options one `.oxfmtrc.json` carrying only a `jsdoc` value resolves to.
@@ -673,6 +683,266 @@ mod tests {
         let mut engine = EngineFormatOptions::default();
         engine.set_jsdoc(value).expect("a usable jsdoc option");
         FileFormatOptions { engine, insert_final_newline: None }
+    }
+
+    /// The options one `.oxfmtrc.json` carrying only a `sortImports` value resolves to.
+    fn sort_imports_options(value: &Value) -> FileFormatOptions {
+        let mut engine = EngineFormatOptions::default();
+        engine.set_sort_imports(value).expect("a usable sortImports option");
+        FileFormatOptions { engine, insert_final_newline: None }
+    }
+
+    /// The options one whole authored root configuration resolves to.
+    ///
+    /// This goes through the same deserialize-then-resolve path a discovered `.oxfmtrc.json`
+    /// takes, so a test can pin how several options compose rather than how one behaves alone.
+    fn root_options(config: &Value) -> FileFormatOptions {
+        serde_json::from_value::<RawFormatOptions>(config.clone())
+            .expect("a readable Oxfmt configuration")
+            .resolve(ConfigScope::Root)
+            .expect("a usable Oxfmt configuration")
+    }
+
+    /// The error one authored root configuration is refused with.
+    fn root_error(config: &Value) -> String {
+        serde_json::from_value::<RawFormatOptions>(config.clone())
+            .expect("a readable Oxfmt configuration")
+            .resolve(ConfigScope::Root)
+            .expect_err("an unusable Oxfmt configuration")
+            .to_string()
+    }
+
+    #[test]
+    fn sort_imports_orders_a_tsrx_import_chunk_and_converges() {
+        let source = concat!(
+            "import { z } from \"zebra\";\n",
+            "// this note belongs to apple\n",
+            "import { a } from \"apple\";\n",
+            "export function Card() @{<p>{a}{z}</p>}\n",
+        );
+        let options = sort_imports_options(&json!(true));
+        let first =
+            format_text_with_options(Path::new("Card.tsrx"), source, Some(&options)).unwrap();
+        assert_eq!(first.metadata.mode, FormatMode::Projected);
+        assert_eq!(first.metadata.parse_count, 1);
+        // The comment is attached to the import it was authored above, so it travels with it.
+        assert!(
+            first.code.starts_with(concat!(
+                "// this note belongs to apple\n",
+                "import { a } from \"apple\";\n",
+                "import { z } from \"zebra\";\n",
+            )),
+            "{}",
+            first.code
+        );
+        // The projection markers are gone and the component body survived the reorder.
+        assert!(!first.code.contains("_t"), "{}", first.code);
+        assert!(first.code.contains("export function Card() @{"), "{}", first.code);
+
+        let second =
+            format_text_with_options(Path::new("Card.tsrx"), &first.code, Some(&options)).unwrap();
+        assert_eq!(second.code, first.code);
+        assert!(!second.changed);
+
+        // Without the option the authored order is left exactly as it was written.
+        let untouched = format_text(Path::new("Card.tsrx"), source).unwrap();
+        assert!(untouched.code.starts_with("import { z } from \"zebra\";\n"), "{}", untouched.code);
+    }
+
+    #[test]
+    fn sort_imports_reorders_each_import_chunk_between_components_on_its_own() {
+        let source = concat!(
+            "import { z } from \"zebra\";\n",
+            "import { a } from \"apple\";\n",
+            "export function Card() @{<p>{a}{z}</p>}\n",
+            "import { m } from \"middle\";\n",
+            "import { b } from \"beta\";\n",
+            "export function Other() @{<p>{m}{b}</p>}\n",
+        );
+        let options = sort_imports_options(&json!(true));
+        let formatted =
+            format_text_with_options(Path::new("Two.tsrx"), source, Some(&options)).unwrap();
+        // Each run of consecutive imports sorts within itself; the second run never climbs above
+        // the component authored between them.
+        assert!(
+            formatted.code.starts_with(concat!(
+                "import { a } from \"apple\";\n",
+                "import { z } from \"zebra\";\n",
+                "export function Card() @{\n",
+            )),
+            "{}",
+            formatted.code
+        );
+        assert!(
+            formatted.code.contains(concat!(
+                "}\n",
+                "import { b } from \"beta\";\n",
+                "import { m } from \"middle\";\n",
+                "export function Other() @{\n",
+            )),
+            "{}",
+            formatted.code
+        );
+        assert!(!formatted.code.contains("_t"), "{}", formatted.code);
+
+        let again =
+            format_text_with_options(Path::new("Two.tsrx"), &formatted.code, Some(&options))
+                .unwrap();
+        assert_eq!(again.code, formatted.code);
+    }
+
+    #[test]
+    fn sort_imports_leaves_side_effect_imports_anchored_and_groups_type_imports() {
+        let source = concat!(
+            "import \"./reset.css\";\n",
+            "import type { Shape } from \"./shape\";\n",
+            "import { z } from \"zebra\";\n",
+            "import { a } from \"apple\";\n",
+            "export function Card() @{<p>{a}{z}</p>}\n",
+        );
+        let options = sort_imports_options(&json!(true));
+        let formatted =
+            format_text_with_options(Path::new("Side.tsrx"), source, Some(&options)).unwrap();
+        // Side-effect imports are not sorted by default, so the stylesheet keeps its authored
+        // position while the value imports sort and the type import lands in its own group.
+        assert!(
+            formatted.code.starts_with(concat!(
+                "import \"./reset.css\";\n",
+                "import { a } from \"apple\";\n",
+                "import { z } from \"zebra\";\n",
+                "\n",
+                "import type { Shape } from \"./shape\";\n",
+            )),
+            "{}",
+            formatted.code
+        );
+        assert!(!formatted.code.contains("_t"), "{}", formatted.code);
+
+        let again =
+            format_text_with_options(Path::new("Side.tsrx"), &formatted.code, Some(&options))
+                .unwrap();
+        assert_eq!(again.code, formatted.code);
+    }
+
+    #[test]
+    fn the_sort_imports_object_form_selects_sub_options_and_reports_unusable_ones() {
+        let source = concat!(
+            "import { B } from \"Beta\";\n",
+            "import { a } from \"alpha\";\n",
+            "export function Card() @{<p>{a}{B}</p>}\n",
+        );
+        // Case-sensitive descending order with one flat group and no blank line between groups.
+        let tuned = format_text_with_options(
+            Path::new("Case.tsrx"),
+            source,
+            Some(&sort_imports_options(&json!({
+                "ignoreCase": false,
+                "newlinesBetween": false,
+                "groups": ["external", "unknown"],
+            }))),
+        )
+        .unwrap();
+        assert!(
+            tuned.code.starts_with(concat!(
+                "import { B } from \"Beta\";\n",
+                "import { a } from \"alpha\";\n",
+            )),
+            "{}",
+            tuned.code
+        );
+
+        // `false` is a value, not an absent option, so it leaves the authored order alone.
+        let disabled = format_text_with_options(
+            Path::new("Case.tsrx"),
+            source,
+            Some(&sort_imports_options(&json!(false))),
+        )
+        .unwrap();
+        assert!(disabled.code.starts_with("import { B } from \"Beta\";\n"), "{}", disabled.code);
+
+        // Every refusal quotes canonical Oxfmt's own sentence for the same configuration.
+        let unusable = |value: Value| {
+            format_text_with_options(
+                Path::new("Case.tsrx"),
+                source,
+                Some(&sort_imports_options(&value)),
+            )
+            .unwrap_err()
+            .to_string()
+        };
+        assert!(
+            unusable(json!({ "groups": ["nope"] }))
+                .contains("unknown group name `nope` in `groups`"),
+            "{}",
+            unusable(json!({ "groups": ["nope"] }))
+        );
+        let marker_first = unusable(json!({ "groups": [{ "newlinesBetween": true }, "external"] }));
+        assert!(marker_first.contains("cannot appear at the start of `groups`"), "{marker_first}");
+        let marker_last = unusable(json!({ "groups": ["external", { "newlinesBetween": true }] }));
+        assert!(marker_last.contains("cannot appear at the end of `groups`"), "{marker_last}");
+        let incompatible = unusable(json!({ "partitionByNewline": true }));
+        assert!(
+            incompatible.contains(
+                "`partitionByNewline: true` and `newlinesBetween: true` cannot be used together"
+            ),
+            "{incompatible}"
+        );
+        let selector = unusable(
+            json!({ "customGroups": [{ "groupName": "mine", "elementNamePattern": ["x"], "selector": "nope" }] }),
+        );
+        assert!(
+            selector.contains("unknown selector: `nope` in customGroups: `mine`"),
+            "{selector}"
+        );
+
+        // A misspelled sub-option and a value of the wrong shape are refused rather than ignored.
+        let mut engine = EngineFormatOptions::default();
+        let misspelled =
+            engine.set_sort_imports(&json!({ "ignorecase": true })).unwrap_err().to_string();
+        assert!(misspelled.contains("unknown field `ignorecase`"), "{misspelled}");
+        let bad_order = engine.set_sort_imports(&json!({ "order": "up" })).unwrap_err().to_string();
+        assert!(bad_order.contains("expected `asc` or `desc`"), "{bad_order}");
+        let bad_shape = engine.set_sort_imports(&json!("always")).unwrap_err().to_string();
+        assert!(bad_shape.contains("sortImports"), "{bad_shape}");
+    }
+
+    #[test]
+    fn a_root_config_composes_sort_imports_with_jsdoc_and_semi_and_still_refuses_tailwind() {
+        // The configuration the issue reports as failing: three options at once, one of which was
+        // refused outright before either of them was implemented.
+        let options = root_options(&json!({ "semi": false, "sortImports": true, "jsdoc": true }));
+        let source = concat!(
+            "import { z } from \"zebra\";\n",
+            "import { a } from \"apple\";\n",
+            "/**    counts   things   */\n",
+            "export function Card({ok}:{ok:boolean}) @{@if(ok){<p>{a}{z}</p>}}\n",
+        );
+        let first =
+            format_text_with_options(Path::new("Card.tsrx"), source, Some(&options)).unwrap();
+        assert!(
+            first.code.starts_with(concat!(
+                "import { a } from \"apple\"\n",
+                "import { z } from \"zebra\"\n",
+                "/** Counts things */\n",
+            )),
+            "{}",
+            first.code
+        );
+        assert!(first.code.contains("@if (ok) {"), "{}", first.code);
+        assert!(!first.code.contains("_t"), "{}", first.code);
+        let second =
+            format_text_with_options(Path::new("Card.tsrx"), &first.code, Some(&options)).unwrap();
+        assert_eq!(second.code, first.code);
+
+        // Canonical Oxfmt's original spelling of the option reaches the same engine.
+        let aliased = root_options(&json!({ "semi": false, "experimentalSortImports": true }));
+        let via_alias =
+            format_text_with_options(Path::new("Card.tsrx"), source, Some(&aliased)).unwrap();
+        assert!(via_alias.code.starts_with("import { a } from \"apple\"\n"), "{}", via_alias.code);
+
+        // The one option still outside the pinned formatter boundary is refused exactly as before.
+        let refused = root_error(&json!({ "sortTailwindcss": true }));
+        assert!(refused.contains("`sortTailwindcss` is not available for TSRX"), "{refused}");
     }
 
     #[test]

--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -134,6 +134,8 @@ struct RawFormatOptions {
     insert_final_newline: Option<bool>,
     sort_imports: Option<Value>,
     sort_tailwindcss: Option<Value>,
+    /// Oxfmt's `true | false | object` doc-comment option, kept as JSON until the adapter parses
+    /// it into its own revision-independent shape.
     jsdoc: Option<Value>,
     experimental_operator_position: Option<Value>,
     experimental_ternaries: Option<Value>,
@@ -297,6 +299,7 @@ impl FileFormatOptions {
             single_attribute_per_line,
             embedded_language_formatting,
             html_whitespace_sensitivity,
+            jsdoc,
         );
         if other.insert_final_newline.is_some() {
             self.insert_final_newline = other.insert_final_newline;
@@ -357,34 +360,37 @@ impl RawFormatOptions {
         }
         reject_enabled_value(scope, "sortImports", sort_imports)?;
         reject_enabled_value(scope, "sortTailwindcss", sort_tailwindcss)?;
-        reject_enabled_value(scope, "jsdoc", jsdoc)?;
         if embedded_language_formatting.is_some() {
             return Err(FormatError::EmbeddedLanguageFormattingUnavailable { scope });
         }
         if experimental_operator_position.is_some() || experimental_ternaries.is_some() {
             return Err(FormatError::ExperimentalOptions { scope });
         }
-        Ok(FileFormatOptions {
-            engine: EngineFormatOptions {
-                use_tabs,
-                tab_width,
-                end_of_line,
-                print_width,
-                single_quote,
-                jsx_single_quote,
-                quote_props,
-                trailing_comma,
-                semi,
-                arrow_parens,
-                bracket_spacing,
-                bracket_same_line,
-                object_wrap,
-                single_attribute_per_line,
-                embedded_language_formatting: None,
-                html_whitespace_sensitivity,
-            },
-            insert_final_newline,
-        })
+        let mut engine = EngineFormatOptions {
+            use_tabs,
+            tab_width,
+            end_of_line,
+            print_width,
+            single_quote,
+            jsx_single_quote,
+            quote_props,
+            trailing_comma,
+            semi,
+            arrow_parens,
+            bracket_spacing,
+            bracket_same_line,
+            object_wrap,
+            single_attribute_per_line,
+            embedded_language_formatting: None,
+            html_whitespace_sensitivity,
+            jsdoc: None,
+        };
+        // The adapter owns this option's shape, so an unusable `jsdoc` value is reported in the
+        // same wording a bad value for any other Oxfmt option gets.
+        if let Some(jsdoc) = jsdoc {
+            engine.set_jsdoc(&jsdoc).map_err(|error| FormatError::Engine(error.into()))?;
+        }
+        Ok(FileFormatOptions { engine, insert_final_newline })
     }
 }
 
@@ -654,11 +660,152 @@ fn elapsed_ns(started: Instant) -> u64 {
 mod tests {
     use std::path::Path;
 
+    use serde_json::{Value, json};
+
     use super::{
         EMBEDDED_CSS_FORMAT_NS, EMBEDDED_CSS_MODE, EMBEDDED_CSS_PARSE_COUNT,
         EMBEDDED_CSS_USES_SUBPROCESS, EngineFormatOptions, FileFormatOptions, FormatMode,
         format_text, format_text_with_options,
     };
+
+    /// The options one `.oxfmtrc.json` carrying only a `jsdoc` value resolves to.
+    fn jsdoc_options(value: &Value) -> FileFormatOptions {
+        let mut engine = EngineFormatOptions::default();
+        engine.set_jsdoc(value).expect("a usable jsdoc option");
+        FileFormatOptions { engine, insert_final_newline: None }
+    }
+
+    #[test]
+    fn jsdoc_reflows_a_doc_comment_over_tsrx_control_flow_and_converges() {
+        let source = concat!(
+            "/**\n",
+            "*    counts   things\n",
+            "*   @param {number}   start    the first value\n",
+            "* @returns {number} the next value\n",
+            "*/\n",
+            "export function View({start,ready}:{start:number;ready:boolean}) @{",
+            "@if(ready){<p>{start}</p>}@else{<span>no</span>}}\n",
+        );
+        let options = jsdoc_options(&json!(true));
+        let first =
+            format_text_with_options(Path::new("Doc.tsrx"), source, Some(&options)).unwrap();
+        assert_eq!(first.metadata.mode, FormatMode::Projected);
+        assert_eq!(first.metadata.parse_count, 1);
+        assert!(
+            first.code.contains(concat!(
+                "/**\n",
+                " * Counts things\n",
+                " *\n",
+                " * @param {number} start The first value\n",
+                " * @returns {number} The next value\n",
+                " */\n",
+            )),
+            "{}",
+            first.code
+        );
+        assert!(first.code.contains("@if (ready) {"), "{}", first.code);
+        assert!(first.code.contains("} @else {"), "{}", first.code);
+        assert!(!first.code.contains("_t"), "{}", first.code);
+
+        let second =
+            format_text_with_options(Path::new("Doc.tsrx"), &first.code, Some(&options)).unwrap();
+        assert_eq!(second.code, first.code);
+        assert!(!second.changed);
+
+        // Without the option the same comment is left exactly as it was authored.
+        let untouched = format_text(Path::new("Doc.tsrx"), source).unwrap();
+        assert!(untouched.code.contains("counts   things"), "{}", untouched.code);
+    }
+
+    #[test]
+    fn the_jsdoc_object_form_selects_sub_options_and_reports_unusable_ones() {
+        let source = "/**    counts   things   */\nexport function View() @{<p>hi</p>}\n";
+        let dotted = format_text_with_options(
+            Path::new("Doc.tsrx"),
+            source,
+            Some(&jsdoc_options(&json!({ "descriptionWithDot": true }))),
+        )
+        .unwrap();
+        assert!(dotted.code.starts_with("/** Counts things. */"), "{}", dotted.code);
+
+        let multiline = format_text_with_options(
+            Path::new("Doc.tsrx"),
+            source,
+            Some(&jsdoc_options(&json!({ "commentLineStrategy": "multiline" }))),
+        )
+        .unwrap();
+        assert!(multiline.code.starts_with("/**\n * Counts things\n */"), "{}", multiline.code);
+
+        let disabled = format_text_with_options(
+            Path::new("Doc.tsrx"),
+            source,
+            Some(&jsdoc_options(&json!(false))),
+        )
+        .unwrap();
+        assert!(disabled.code.starts_with("/**    counts   things   */"), "{}", disabled.code);
+
+        // An unusable enum string is reported in canonical Oxfmt's own wording.
+        let error = format_text_with_options(
+            Path::new("Doc.tsrx"),
+            source,
+            Some(&jsdoc_options(&json!({ "lineWrappingStyle": "wrap" }))),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("jsdoc lineWrappingStyle `wrap`"), "{error}");
+        assert!(error.contains("greedy"), "{error}");
+        assert!(error.contains("balance"), "{error}");
+
+        // A misspelled sub-option is refused rather than silently ignored.
+        let mut engine = EngineFormatOptions::default();
+        let rejected =
+            engine.set_jsdoc(&json!({ "capitalizeDescription": true })).unwrap_err().to_string();
+        assert!(rejected.contains("capitalizeDescription"), "{rejected}");
+        let rejected = engine.set_jsdoc(&json!("always")).unwrap_err().to_string();
+        assert!(rejected.contains("jsdoc"), "{rejected}");
+    }
+
+    #[test]
+    fn jsdoc_leaves_projection_markers_and_raw_style_payloads_alone() {
+        let payload = "/**   raw   doc  */ .card{color:red}";
+        let source = format!(
+            "export function View({{ok}}:{{ok:boolean}}) @{{<main><style>{payload}</style>\
+             @if(ok){{<p>hi</p>}}</main>}}\n"
+        );
+        let options = jsdoc_options(&json!(true));
+        let first =
+            format_text_with_options(Path::new("Style.tsrx"), &source, Some(&options)).unwrap();
+        assert_eq!(first.metadata.style_count, 1);
+        assert_eq!(first.metadata.embedded_parse_count, 0);
+        // The style payload is a checked opaque region, so a JSDoc-shaped comment inside it is
+        // still not code and stays byte-identical.
+        assert!(first.code.contains(payload), "{}", first.code);
+        assert!(!first.code.contains("_t"), "{}", first.code);
+
+        let second =
+            format_text_with_options(Path::new("Style.tsrx"), &first.code, Some(&options)).unwrap();
+        assert_eq!(second.code, first.code);
+    }
+
+    #[test]
+    fn jsdoc_keeps_a_dynamic_tag_region_byte_identical() {
+        let source = concat!(
+            "export function View({Tag,ok}:{Tag:string;ok:boolean}) @{",
+            "<main>@if(ok){<{Tag}>hi</{Tag /**   inner   doc  */}>}</main>}\n",
+        );
+        let first = format_text_with_options(
+            Path::new("Dyn.tsrx"),
+            source,
+            Some(&jsdoc_options(&json!(true))),
+        )
+        .unwrap();
+        // The lift restores a dynamic-tag region from the authored bytes, so the comment written
+        // inside its braces comes back exactly as authored rather than reflowed.
+        assert_eq!(first.code.matches("/**   inner   doc  */").count(), 1, "{}", first.code);
+        assert!(first.code.contains("<{Tag}>"), "{}", first.code);
+        assert!(first.code.contains("</{Tag}>"), "{}", first.code);
+        assert!(!first.code.contains("_t"), "{}", first.code);
+    }
 
     #[test]
     fn embedded_css_boundary_is_keep_raw_without_hidden_work() {

--- a/docs/guide/formatting.md
+++ b/docs/guide/formatting.md
@@ -76,8 +76,41 @@ already use all apply: `printWidth`, `singleQuote`, `semi`, `tabWidth`,
 
 A few options are refused with a clear error before anything is written,
 because they would change `.tsrx` output in ways this project cannot yet
-guarantee: `sortImports`, `jsdoc`, embedded-language formatting, experimental
+guarantee: `sortTailwindcss`, embedded-language formatting, experimental
 flags, `.editorconfig`, and JS or TS config files.
+
+### Sorting imports and formatting JSDoc
+
+`sortImports` and `jsdoc` both work on `.tsrx`, with the same values Oxfmt
+already takes: `true`, `false`, or an object of sub-options.
+
+`sortImports` reorders your import statements. It sorts each run of
+back-to-back imports on its own, so a run that sits below a component never
+climbs above it. `true` gets Oxfmt's defaults, and the object form takes
+`groups`, `customGroups`, `newlinesBetween`, `order`, `ignoreCase`,
+`internalPattern`, and the rest. Oxfmt's older `experimentalSortImports`
+spelling is read as an alias for the same option.
+
+`jsdoc` reflows your `/** ... */` doc comments: it collapses runs of spaces,
+capitalizes descriptions, and lines up `@param` and `@returns` tags. `true`
+gets Oxfmt's defaults, and the object form takes `commentLineStrategy`,
+`lineWrappingStyle`, `descriptionWithDot`, `separateTagGroups`, and the rest.
+
+```json
+{
+  "sortImports": true,
+  "jsdoc": { "commentLineStrategy": "multiline" }
+}
+```
+
+Both options work the same way on `.ts` and `.tsx` files, where the output is
+byte-for-byte what stock Oxfmt produces. A misspelled sub-option or an
+unusable value is refused with an error rather than quietly ignored.
+
+One caveat for `jsdoc`. A dynamic tag's region is restored from the bytes you
+wrote, not reprinted, so a doc comment written inside one comes back exactly as
+you authored it instead of being reflowed. Everything outside those regions is
+formatted normally.
 
 ## CSS inside `<style>` is preserved, not formatted
 

--- a/docs/guide/formatting.md
+++ b/docs/guide/formatting.md
@@ -77,7 +77,8 @@ already use all apply: `printWidth`, `singleQuote`, `semi`, `tabWidth`,
 A few options are refused with a clear error before anything is written,
 because they would change `.tsrx` output in ways this project cannot yet
 guarantee: `sortTailwindcss`, embedded-language formatting, experimental
-flags, `.editorconfig`, and JS or TS config files.
+flags apart from the `experimentalSortImports` alias, `.editorconfig`,
+and JS or TS config files.
 
 ### Sorting imports and formatting JSDoc
 

--- a/docs/integrations/configuration.md
+++ b/docs/integrations/configuration.md
@@ -193,6 +193,39 @@ and also `config/format.json`; both sample files still use double quotes, so
 
 <!-- terminal-demo:configuration-format -->
 
+### `sortImports` and `jsdoc`
+
+These two go beyond layout, and both apply to `.tsrx`. Each takes the values
+Oxfmt already documents: `true` for its defaults, `false` to turn it off, or an
+object naming sub-options.
+
+| Option | What it does | Object sub-options |
+| --- | --- | --- |
+| `sortImports` | Reorders imports, one back-to-back run at a time, so a run below a component never moves above it. | `groups`, `customGroups`, `newlinesBetween`, `order`, `ignoreCase`, `internalPattern`, `partitionByNewline`, `partitionByComment`, `sortSideEffects` |
+| `jsdoc` | Reflows `/** ... */` comments: collapses runs of spaces, capitalizes descriptions, lines up `@param` and `@returns`. | `commentLineStrategy`, `lineWrappingStyle`, `descriptionWithDot`, `capitalizeDescriptions`, `separateTagGroups`, `separateReturnsFromParam`, `preferCodeFences`, `bracketSpacing`, and the rest |
+
+```json
+{
+  "semi": false,
+  "sortImports": { "newlinesBetween": false, "groups": ["external", "unknown"] },
+  "jsdoc": true
+}
+```
+
+Oxfmt's older `experimentalSortImports` spelling is read as an alias for
+`sortImports`, so a config that still uses it keeps working. It is the one
+`experimental*` key that is not refused.
+
+Both keys also work inside `overrides`, so one entry can turn either option off
+for the files it matches. A misspelled sub-option or a value the formatter
+cannot use is refused with an error rather than quietly ignored, the same as any
+other named Oxfmt option.
+
+On `.ts` and `.tsx` files both options behave exactly as stock Oxfmt does, byte
+for byte. On `.tsrx`, one thing is carried over rather than reformatted: a
+dynamic tag's region is restored from the bytes you wrote, so a doc comment
+written inside one comes back as you authored it instead of being reflowed.
+
 ## What is refused
 
 Everything below stops the command with an error before anything is parsed,
@@ -208,9 +241,10 @@ Linting refuses:
 Formatting refuses:
 
 - a config written as a JavaScript or TypeScript module, and `.editorconfig`;
-- `sortImports`, `sortTailwindcss`, `jsdoc`, and `embeddedLanguageFormatting`
-  when they are switched on;
-- experimental options, and unknown keys that would affect `.tsrx`.
+- `sortTailwindcss` and `embeddedLanguageFormatting` when they are switched on,
+  because both need a callback surface outside the pinned formatter;
+- experimental options apart from the `experimentalSortImports` alias, and
+  unknown keys that would affect `.tsrx`.
 
 The standalone binaries are deliberately small: they take named files and print
 JSON, and nothing else. Directories, globs, the ordinary report format, and

--- a/tests/config/native-format-config.test.mjs
+++ b/tests/config/native-format-config.test.mjs
@@ -509,6 +509,48 @@ test("ignorePatterns leave ignored files byte-identical while formatting the res
   assert.equal(await readFile(ignored, "utf8"), source);
 });
 
+test("a discovered jsdoc config formats .tsrx files, and one override turns it back off", async () => {
+  // Overrides match the path an authored file has under the config root, so this directory is
+  // resolved through its real path the way every other override test here does.
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), "oxc-tsrx-format-jsdoc-")));
+  await mkdir(join(cwd, "legacy"), { recursive: true });
+  const authored =
+    '/**    counts   things   */\nexport function View() @{const value="hello";<p>{value}</p>}\n';
+  const documented = join(cwd, "View.tsrx");
+  const legacy = join(cwd, "legacy", "View.tsrx");
+  await writeFile(
+    join(cwd, ".oxfmtrc.json"),
+    `${JSON.stringify(
+      {
+        semi: false,
+        jsdoc: true,
+        overrides: [{ files: ["legacy/**"], options: { jsdoc: false } }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(documented, authored);
+  await writeFile(legacy, authored);
+
+  // Before this option was implemented the same config exited 2 without writing anything.
+  const result = await runFormat(cwd, ["--write", documented, legacy]);
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(result.stderr, /not available for TSRX/i);
+
+  const formatted = await readFile(documented, "utf8");
+  assert.match(formatted, /^\/\*\* Counts things \*\//);
+  assert.match(formatted, /const value = "hello"\n/);
+
+  // The override matched, so this file was formatted with JSDoc formatting off.
+  const overridden = await readFile(legacy, "utf8");
+  assert.match(overridden, /^\/\*\*    counts   things   \*\//);
+  assert.match(overridden, /const value = "hello"\n/);
+
+  const check = await runFormat(cwd, ["--check", documented, legacy]);
+  assert.equal(check.code, 0, check.stderr || check.stdout);
+});
+
 test("unsupported callback-backed options, editorconfig, and JS config modules fail before output or writes", async () => {
   const cases = [
     {

--- a/tests/config/native-format-config.test.mjs
+++ b/tests/config/native-format-config.test.mjs
@@ -551,6 +551,57 @@ test("a discovered jsdoc config formats .tsrx files, and one override turns it b
   assert.equal(check.code, 0, check.stderr || check.stdout);
 });
 
+test("one discovered sortImports policy covers a mixed .ts and .tsrx batch, and an override lifts it", async () => {
+  // Overrides match the path an authored file has under the config root, so this directory is
+  // resolved through its real path the way every other override test here does.
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), "oxc-tsrx-format-sort-imports-")));
+  await mkdir(join(cwd, "legacy"), { recursive: true });
+  const imports = ['import {z} from "zebra";', 'import {a} from "apple";'].join("\n");
+  const authoredTsrx = `${imports}\nexport function View() @{<p>{a}{z}</p>}\n`;
+  const authoredTs = `${imports}\nexport function view(){return a+z}\n`;
+  const sorted = ['import { a } from "apple";', 'import { z } from "zebra";'].join("\n");
+  const component = join(cwd, "View.tsrx");
+  const ordinary = join(cwd, "view.ts");
+  const legacy = join(cwd, "legacy", "View.tsrx");
+  await writeFile(
+    join(cwd, ".oxfmtrc.json"),
+    `${JSON.stringify(
+      {
+        sortImports: true,
+        overrides: [{ files: ["legacy/**"], options: { sortImports: false } }],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(component, authoredTsrx);
+  await writeFile(ordinary, authoredTs);
+  await writeFile(legacy, authoredTsrx);
+
+  // Before this option was implemented the same config exited 2 without writing anything, so a
+  // project that sorted its imports could not have a single .tsrx file in it.
+  const result = await runFormat(cwd, ["--write", component, ordinary, legacy]);
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  assert.doesNotMatch(result.stderr, /not available for TSRX/i);
+
+  const formatted = await readFile(component, "utf8");
+  assert.ok(formatted.startsWith(`${sorted}\n`), formatted);
+  assert.match(formatted, /export function View\(\) @\{/);
+
+  // The ordinary TypeScript file in the same batch took the canonical lane, so stock Oxfmt run
+  // over the authored bytes with the same config is the oracle for what it now holds.
+  const stockOrdinary = await run(stock, cwd, ["--stdin-filepath=view.ts"], authoredTs);
+  assert.equal(stockOrdinary.code, 0, stockOrdinary.stderr || stockOrdinary.stdout);
+  assert.equal(await readFile(ordinary, "utf8"), stockOrdinary.stdout);
+
+  // The override matched, so this file was formatted with import sorting off.
+  const overridden = await readFile(legacy, "utf8");
+  assert.ok(overridden.startsWith('import { z } from "zebra";\n'), overridden);
+
+  const check = await runFormat(cwd, ["--check", component, ordinary, legacy]);
+  assert.equal(check.code, 0, check.stderr || check.stdout);
+});
+
 test("unsupported callback-backed options, editorconfig, and JS config modules fail before output or writes", async () => {
   const cases = [
     {

--- a/tests/native-format.test.mjs
+++ b/tests/native-format.test.mjs
@@ -132,6 +132,57 @@ test('invalid TSRX returns no formatted output', async () => {
   assert.match(result.stderr, /parse|expected|unexpected/i);
 });
 
+test('a jsdoc config reflows JSDoc in .tsrx and matches canonical Oxfmt on ordinary TS', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'oxc-tsrx-format-jsdoc-'));
+  const configPath = join(directory, '.oxfmtrc.json');
+  const doc = ['/**', '*   counts   things', '*  @param {number}   start   the first value', '*/'];
+  const tsrx = `${doc.join('\n')}\nexport function View({start}:{start:number}) @{<p>{start}</p>}\n`;
+  const ts = `${doc.join('\n')}\nexport function view(start:number){return start+1}\n`;
+  // The reflowed comment canonical Oxfmt produces for that source: the description is
+  // capitalized, the runs of spaces collapse, and a blank line opens the tag group.
+  const reflowed = [
+    '/**',
+    ' * Counts things',
+    ' *',
+    ' * @param {number} start The first value',
+    ' */',
+  ].join('\n');
+
+  await writeFile(configPath, '{ "semi": false, "jsdoc": true }\n');
+  const [component, control, stock] = await Promise.all([
+    runFormat([`--config=${configPath}`, '--stdin-filepath=View.tsrx'], tsrx),
+    runFormat([`--config=${configPath}`, '--stdin-filepath=view.ts'], ts),
+    run(stockBinary, [`--config=${configPath}`, '--stdin-filepath=view.ts'], ts),
+  ]);
+  assert.equal(component.code, 0, component.stderr || component.stdout);
+  assert.equal(component.stderr, '');
+  assert.ok(component.stdout.startsWith(`${reflowed}\n`), component.stdout);
+  assert.match(component.stdout, /@\{\n {2};<p>\{start\}<\/p>\n\}/);
+  assert.equal(stock.code, 0, stock.stderr || stock.stdout);
+  assert.equal(control.stdout, stock.stdout);
+
+  const again = await runFormat([`--config=${configPath}`, '--stdin-filepath=View.tsrx'], component.stdout);
+  assert.equal(again.code, 0, again.stderr || again.stdout);
+  assert.equal(again.stdout, component.stdout);
+
+  // The object form reaches the same engine, with the sub-options it names.
+  await writeFile(
+    configPath,
+    '{ "jsdoc": { "commentLineStrategy": "multiline", "descriptionWithDot": true } }\n',
+  );
+  const object = await runFormat([`--config=${configPath}`, '--stdin-filepath=View.tsrx'], tsrx);
+  assert.equal(object.code, 0, object.stderr || object.stdout);
+  assert.ok(object.stdout.startsWith('/**\n * Counts things.\n'), object.stdout);
+  assert.match(object.stdout, /@param \{number\} start The first value\./);
+
+  // A value the pinned formatter cannot use is still refused, in its own wording.
+  await writeFile(configPath, '{ "jsdoc": { "lineWrappingStyle": "wrap" } }\n');
+  const rejected = await runFormat([`--config=${configPath}`, '--stdin-filepath=View.tsrx'], tsrx);
+  assert.equal(rejected.code, 2, rejected.stderr || rejected.stdout);
+  assert.equal(rejected.stdout, '');
+  assert.match(rejected.stderr, /jsdoc lineWrappingStyle `wrap`/);
+});
+
 test('ordinary JS, JSX, TS, and TSX take the canonical format path byte-for-byte', async () => {
   const cases = {
     'ordinary.js': 'export function value( ){return {answer:1}}\n',

--- a/tests/native-format.test.mjs
+++ b/tests/native-format.test.mjs
@@ -183,6 +183,98 @@ test('a jsdoc config reflows JSDoc in .tsrx and matches canonical Oxfmt on ordin
   assert.match(rejected.stderr, /jsdoc lineWrappingStyle `wrap`/);
 });
 
+test('a sortImports config orders imports in .tsrx and matches canonical Oxfmt on ordinary TS', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'oxc-tsrx-format-sort-imports-'));
+  const configPath = join(directory, '.oxfmtrc.json');
+  const imports = [
+    'import {B} from "Beta";',
+    'import {a} from "alpha";',
+    'import {readFile} from "node:fs";',
+  ].join('\n');
+  const tsrx = `${imports}\nexport function Card() @{<p>{a}{B}{readFile}</p>}\n`;
+  const ts = `${imports}\nexport function view(){return a+B+readFile}\n`;
+  // The order canonical Oxfmt produces for that source with the default groups: the Node built-in
+  // leads its own group, then the two external packages sort together, case-insensitively.
+  const sorted = [
+    'import { readFile } from "node:fs";',
+    '',
+    'import { a } from "alpha";',
+    'import { B } from "Beta";',
+  ].join('\n');
+
+  await writeFile(configPath, '{ "sortImports": true }\n');
+  const [component, control, stock] = await Promise.all([
+    runFormat([`--config=${configPath}`, '--stdin-filepath=Card.tsrx'], tsrx),
+    runFormat([`--config=${configPath}`, '--stdin-filepath=view.ts'], ts),
+    run(stockBinary, [`--config=${configPath}`, '--stdin-filepath=view.ts'], ts),
+  ]);
+  assert.equal(component.code, 0, component.stderr || component.stdout);
+  assert.equal(component.stderr, '');
+  // The refusal this option used to get is gone.
+  assert.doesNotMatch(component.stderr, /not available for TSRX/i);
+  assert.ok(component.stdout.startsWith(`${sorted}\n`), component.stdout);
+  assert.match(component.stdout, /export function Card\(\) @\{\n {2}<p>/);
+  assert.equal(stock.code, 0, stock.stderr || stock.stdout);
+  assert.equal(control.stdout, stock.stdout);
+
+  const again = await runFormat(
+    [`--config=${configPath}`, '--stdin-filepath=Card.tsrx'],
+    component.stdout,
+  );
+  assert.equal(again.code, 0, again.stderr || again.stdout);
+  assert.equal(again.stdout, component.stdout);
+
+  // The object form reaches the same engine, with the sub-options it names: a case-sensitive
+  // order puts `Beta` above `alpha`, and `newlinesBetween: false` drops the blank line.
+  await writeFile(
+    configPath,
+    `${JSON.stringify({
+      sortImports: {
+        ignoreCase: false,
+        newlinesBetween: false,
+        groups: ['builtin', 'external', 'unknown'],
+      },
+    })}\n`,
+  );
+  const [object, objectControl, objectStock] = await Promise.all([
+    runFormat([`--config=${configPath}`, '--stdin-filepath=Card.tsrx'], tsrx),
+    runFormat([`--config=${configPath}`, '--stdin-filepath=view.ts'], ts),
+    run(stockBinary, [`--config=${configPath}`, '--stdin-filepath=view.ts'], ts),
+  ]);
+  assert.equal(object.code, 0, object.stderr || object.stdout);
+  assert.ok(
+    object.stdout.startsWith(
+      [
+        'import { readFile } from "node:fs";',
+        'import { B } from "Beta";',
+        'import { a } from "alpha";',
+        '',
+      ].join('\n'),
+    ),
+    object.stdout,
+  );
+  assert.equal(objectControl.stdout, objectStock.stdout);
+
+  // Canonical Oxfmt's original spelling of this option reaches the same engine.
+  await writeFile(configPath, '{ "experimentalSortImports": true }\n');
+  const aliased = await runFormat(
+    [`--config=${configPath}`, '--stdin-filepath=Card.tsrx'],
+    tsrx,
+  );
+  assert.equal(aliased.code, 0, aliased.stderr || aliased.stdout);
+  assert.ok(aliased.stdout.startsWith(`${sorted}\n`), aliased.stdout);
+
+  // A group name nothing defines is still refused, in canonical Oxfmt's own wording.
+  await writeFile(configPath, '{ "sortImports": { "groups": ["nope"] } }\n');
+  const rejectedGroup = await runFormat(
+    [`--config=${configPath}`, '--stdin-filepath=Card.tsrx'],
+    tsrx,
+  );
+  assert.equal(rejectedGroup.code, 2, rejectedGroup.stderr || rejectedGroup.stdout);
+  assert.equal(rejectedGroup.stdout, '');
+  assert.match(rejectedGroup.stderr, /unknown group name `nope` in `groups`/);
+});
+
 test('ordinary JS, JSX, TS, and TSX take the canonical format path byte-for-byte', async () => {
   const cases = {
     'ordinary.js': 'export function value( ){return {answer:1}}\n',


### PR DESCRIPTION
Implements Oxfmt `sortImports` (#25) and `jsdoc` (#26) for `.tsrx` files. Both options previously failed the whole `oxfmt` run with exit 2 (`Oxfmt \`<option>\` is not available for TSRX in root Oxfmt config`) and left every `.tsrx` file unformatted; in mixed projects the `.ts`/`.tsx` files had already been formatted with the option applied, so one config produced two policies and a failed command.

Closes #25
Closes #26

## Approach

Both options are pure pass-throughs to the pinned formatter (rev `8e0ed2eb`), which already exposes them as plain public `JsFormatOptions` fields. No callback surface is involved, no lift changes were needed, and the pin does not move.

- `crates/oxc_adapter/src/toolchain/format.rs` mirrors the canonical `true | false | object` config shapes into revision-independent project-owned types (`JsdocSetting`/`JsdocConfig`, `SortImportsSetting`/`SortImportsConfig` with `groups`, `newlinesBetween` markers, `customGroups`, `order`), with `deny_unknown_fields` so a misspelled sub-option is refused rather than silently ignored, and maps them onto the pinned engine via its public `GroupEntry::parse` / `ImportSelector::parse` / `ImportModifier::parse` / `SortImportsOptions::validate` APIs, reproducing canonical error wording.
- `crates/tsrx_format/src/lib.rs` drops the two `reject_enabled_value` calls and threads both fields through `resolve()` and the `merge!` list so `overrides` compose. The `experimentalSortImports` alias is accepted, matching canonical Oxfmt. `sortTailwindcss` and `embeddedLanguageFormatting` still refuse (those genuinely need `ExternalCallbacks`).
- Docs: both options removed from the refusal lists in `docs/guide/formatting.md` and `docs/integrations/configuration.md` and documented, including the one caveat: a dynamic tag's region is restored from authored bytes, so JSDoc written inside one is preserved verbatim rather than reflowed.

## Safety

`crates/tsrx_syntax/` is untouched and its full suite passes unchanged. Import sorting permutes only runs of consecutive import declarations, so projection markers never cross, and the `MarkerResidual` / `StructuralMismatch` lift invariants stay armed as a fail-closed net (a violation refuses and leaves the file byte-identical rather than corrupting it).

## Evidence

- Ordinary `.ts`/`.tsx` output is asserted byte-identical to the stock `oxfmt` 0.59.0 binary under both options (bool, object, and alias forms).
- The exact reporter config `{"semi": false, "sortImports": true, "jsdoc": true}` formats a `.tsrx` component end-to-end, converges on a second pass, and leaves no marker residue.
- New tests: 8 Rust (chunk-local sorting between components, comments attached to imports, side-effect/type imports, marker and dynamic-region safety, idempotence) and 4 JS integration tests including `overrides` switching each option back off.
- Live before/after: the released 0.5.0 binary exits 2 on the scaffold from the issue reports; this branch's build formats it (sorted grouped imports, reflowed JSDoc) and `--check` then exits 0.

## Out of scope

A pre-existing `tsrx_syntax` quirk (reproducible with both options off): a comment authored inside a dynamic tag's braces can be duplicated/re-emitted as JSX text on a later pass. Will be filed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `jsdoc` formatting configuration support.
  * Added `sortImports` with custom groups, ordering, newline controls, and the `experimentalSortImports` alias.
  * Supports simple boolean and detailed configuration forms, including per-directory overrides.
  * Added validation with clear errors for invalid or unsupported settings.

* **Documentation**
  * Updated formatting and integration guides with supported options, examples, aliases, and validation details.

* **Bug Fixes**
  * Improved formatting compatibility and parity with standard Oxfmt for TypeScript and TSRX files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->