### PR TITLE
feat(parser): support standalone lazy assignments

### DIFF
--- a/crates/tsrx_parser_engine/src/pipeline.rs
+++ b/crates/tsrx_parser_engine/src/pipeline.rs
@@ -49,6 +49,7 @@ pub(super) fn parse_tsrx_utf8_source<W: Utf16WorkObserver>(
     if overlay_view.tokens.is_empty()
         && overlay_view.dynamic_tags.is_empty()
         && overlay_view.style_blocks.is_empty()
+        && overlay_view.parser_lazy_patterns.is_empty()
     {
         return parse_direct(
             source,

--- a/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
@@ -1,7 +1,7 @@
 //! Lazy destructuring patterns, projected without `&` and restored with `lazy: true`.
 
 use tsrx_syntax::{OverlayView, ProjectionSegment};
-use tsrx_tape_schema::{FlatTape, RecordIndex};
+use tsrx_tape_schema::{FlatTape, RecordIndex, ValueRef};
 
 use crate::{
     TsrxParseError,
@@ -10,7 +10,8 @@ use crate::{
 };
 
 use super::{
-    access::{has_type, object_field, scalar_u32},
+    access::{field_value, has_type, list_field, object_field, scalar_u32},
+    edits::append_node_head,
     objects::find_unique_start,
     spans::{AuthoredStart, record_authored_span},
 };
@@ -41,16 +42,88 @@ pub(super) fn reconstruct_lazy_patterns(
             tsrx_syntax::ByteSpan::new(lazy.pattern_start, authored_end),
         );
         if let Some(declarator) = declarator {
-            let declarator_end = scalar_u32(tape, declarator, "end")?;
-            let declarator_end = map_endpoint(segments, declarator_end, false)
-                .ok_or(TsrxParseError::Unsupported("lazy declarator end is unmapped"))?;
-            record_authored_span(
-                starts,
-                declarator,
-                tsrx_syntax::ByteSpan::new(lazy.ampersand, declarator_end),
-            );
+            if lazy.standalone {
+                reconstruct_standalone_assignment(
+                    tape,
+                    pattern,
+                    declarator,
+                    lazy.ampersand,
+                    segments,
+                    parents,
+                    starts,
+                )?;
+            } else {
+                let declarator_end = scalar_u32(tape, declarator, "end")?;
+                let declarator_end = map_endpoint(segments, declarator_end, false)
+                    .ok_or(TsrxParseError::Unsupported("lazy declarator end is unmapped"))?;
+                record_authored_span(
+                    starts,
+                    declarator,
+                    tsrx_syntax::ByteSpan::new(lazy.ampersand, declarator_end),
+                );
+            }
+        } else if lazy.standalone {
+            return Err(TsrxParseError::Unsupported(
+                "standalone lazy pattern is not a variable-shaped projection",
+            ));
         }
     }
+    Ok(())
+}
+
+fn reconstruct_standalone_assignment(
+    tape: &mut FlatTape,
+    pattern: RecordIndex,
+    declarator: RecordIndex,
+    authored_start: u32,
+    segments: &[ProjectionSegment],
+    parents: &ParentIndex,
+    starts: &mut Vec<AuthoredStart>,
+) -> Result<(), TsrxParseError> {
+    let declarations =
+        parents.parent_container(ValueRef::object(declarator)).and_then(ValueRef::as_list).ok_or(
+            TsrxParseError::Unsupported("standalone lazy declarator has no declarations list"),
+        )?;
+    let declaration = parents
+        .parent_container(ValueRef::list(declarations))
+        .and_then(ValueRef::as_object)
+        .ok_or(TsrxParseError::Unsupported(
+            "standalone lazy declarator has no declaration parent",
+        ))?;
+    if !has_type(tape, declaration, r#""VariableDeclaration""#)
+        || list_field(tape, declaration, "declarations")? != declarations
+    {
+        return Err(TsrxParseError::Unsupported(
+            "standalone lazy pattern projection is not a variable declaration",
+        ));
+    }
+    let mut values = tape.values(declarations);
+    if values.next().and_then(ValueRef::as_object) != Some(declarator) || values.next().is_some() {
+        return Err(TsrxParseError::Unsupported(
+            "standalone lazy assignment projection has multiple declarators",
+        ));
+    }
+
+    let right = field_value(tape, declarator, "init")?;
+    let expression_end = map_endpoint(segments, scalar_u32(tape, declarator, "end")?, false)
+        .ok_or(TsrxParseError::Unsupported("standalone lazy assignment end is unmapped"))?;
+    let statement_end = map_endpoint(segments, scalar_u32(tape, declaration, "end")?, false)
+        .ok_or(TsrxParseError::Unsupported("standalone lazy statement end is unmapped"))?;
+    let expression_span = tsrx_syntax::ByteSpan::new(authored_start, expression_end);
+    let statement_span = tsrx_syntax::ByteSpan::new(authored_start, statement_end);
+
+    tape.clear_fields(declarator)?;
+    append_node_head(tape, declarator, r#""AssignmentExpression""#, expression_span)?;
+    let operator = tape.push_scalar(r#""=""#)?;
+    tape.append_field(declarator, "operator", operator)?;
+    tape.append_field(declarator, "left", ValueRef::object(pattern))?;
+    tape.append_field(declarator, "right", right)?;
+    record_authored_span(starts, declarator, expression_span);
+
+    tape.clear_fields(declaration)?;
+    append_node_head(tape, declaration, r#""ExpressionStatement""#, statement_span)?;
+    tape.append_field(declaration, "expression", ValueRef::object(declarator))?;
+    record_authored_span(starts, declaration, statement_span);
     Ok(())
 }
 

--- a/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
@@ -27,6 +27,12 @@ pub(super) fn reconstruct_lazy_patterns(
     for lazy in overlay.parser_lazy_patterns {
         let pattern = find_pattern(tape, lazy.pattern_start, segments, patterns)?;
         let declarator = declarator_for_pattern(tape, pattern, parents)?;
+        if lazy.standalone && pattern_contains_assignment_default(tape, pattern, parents)? {
+            return Err(TsrxParseError::AuthoredGrammar(
+                "standalone lazy assignment defaults are not supported by the JavaScript TSRX parser"
+                    .into(),
+            ));
+        }
 
         if tape.field_index(pattern, "lazy").is_some() {
             return Err(TsrxParseError::Unsupported("projected lazy pattern already has metadata"));
@@ -69,6 +75,30 @@ pub(super) fn reconstruct_lazy_patterns(
         }
     }
     Ok(())
+}
+
+fn pattern_contains_assignment_default(
+    tape: &FlatTape,
+    pattern: RecordIndex,
+    parents: &ParentIndex,
+) -> Result<bool, TsrxParseError> {
+    for raw in 0..tape.object_count() {
+        let object = RecordIndex::new(
+            u32::try_from(raw)
+                .map_err(|_| TsrxParseError::Unsupported("object index exceeds 4 GiB"))?,
+        );
+        if !has_type(tape, object, r#""AssignmentPattern""#) {
+            continue;
+        }
+        let mut child = ValueRef::object(object);
+        while let Some(parent) = parents.parent_container(child) {
+            if parent.as_object() == Some(pattern) {
+                return Ok(true);
+            }
+            child = parent;
+        }
+    }
+    Ok(false)
 }
 
 fn reconstruct_standalone_assignment(

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -278,12 +278,12 @@ fn lazy_destructuring_patterns_preserve_markers_in_declarations_and_for_headers(
 
 #[test]
 fn standalone_lazy_assignment_statements_match_the_estree_shape_and_authored_spans() {
-    let source = "&{ value = 1, ...rest } = object;\n&[first, ...tail] = items;";
+    let source = "&{ value, ...rest } = object;\n&[first, ...tail] = items;";
     let overlay = scan_for_parser(source).expect("standalone lazy assignment overlay");
     let projection = project_for_parser(source, &overlay).expect("standalone lazy projection");
     assert_eq!(
         projection.source(),
-        "var { value = 1, ...rest } = object;\nvar [first, ...tail] = items;"
+        "var { value, ...rest } = object;\nvar [first, ...tail] = items;"
     );
     let ordinary = parse_ordinary(OrdinaryParseRequest {
         filename: "standalone.tsx",

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -12,6 +12,7 @@ use support::{
     scalar_field, span,
 };
 use tsrx_parser_engine::{TsrxParseOptions, TsrxParseRequest, parse_tsrx, parse_tsrx_with_options};
+use tsrx_syntax::{project_for_parser, scan_for_parser};
 use tsrx_tape_schema::{FlatTape, RecordIndex, ValueKind, ValueRef};
 
 fn offset(value: usize) -> u32 {
@@ -272,6 +273,89 @@ fn lazy_destructuring_patterns_preserve_markers_in_declarations_and_for_headers(
         }
         assert_eq!(source.as_bytes()[usize::try_from(pattern_start - 1).expect("offset")], b'&');
     }
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn standalone_lazy_assignment_statements_match_the_estree_shape_and_authored_spans() {
+    let source = "&{ value = 1, ...rest } = object;\n&[first, ...tail] = items;";
+    let overlay = scan_for_parser(source).expect("standalone lazy assignment overlay");
+    let projection = project_for_parser(source, &overlay).expect("standalone lazy projection");
+    assert_eq!(
+        projection.source(),
+        "var { value = 1, ...rest } = object;\nvar [first, ...tail] = items;"
+    );
+    let ordinary = parse_ordinary(OrdinaryParseRequest {
+        filename: "standalone.tsx",
+        source: projection.source(),
+        lang: None,
+        source_type: None,
+        ast_type: Some("js"),
+        ranges: false,
+        preserve_parens: None,
+        show_semantic_errors: false,
+    });
+    assert!(ordinary.errors.is_empty(), "{:?}", ordinary.errors);
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("standalone lazy assignments");
+    assert_eq!(result.status, tsrx_tape_schema::ParseCompleteness::Complete, "{:?}", result.errors);
+    let tape = result.program();
+    let body = program_body(tape);
+    assert_eq!(body.len(), 2);
+
+    for (statement, sigil) in body.into_iter().zip(["&{", "&["]) {
+        let statement = statement.as_object().expect("expression statement");
+        require_type(tape, statement, "ExpressionStatement");
+        let expression = object_field(tape, statement, "expression");
+        require_type(tape, expression, "AssignmentExpression");
+        assert_eq!(scalar_field(tape, expression, "operator"), r#""=""#);
+        let pattern = object_field(tape, expression, "left");
+        assert_eq!(scalar_field(tape, pattern, "lazy"), "true");
+
+        let statement_start = source.find(sigil).expect("assignment sigil");
+        let statement_end = source[statement_start..]
+            .find(';')
+            .map(|end| statement_start + end + 1)
+            .expect("assignment terminator");
+        assert_eq!(span(tape, statement), (offset(statement_start), offset(statement_end)));
+        assert_eq!(span(tape, expression), (offset(statement_start), offset(statement_end - 1)));
+        assert_eq!(
+            span(tape, pattern).0,
+            offset(statement_start + 1),
+            "the pattern starts at the authored bracket"
+        );
+    }
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn standalone_lazy_assignments_work_in_every_statement_context_without_matching_expressions() {
+    let source = "function View(source: any) @{\n\
+        if (source) /* consequent */ &{ first } = source;\n\
+        else /* alternate */ &[second] = source;\n\
+        do /* body */ &{ third } = source; while (false);\n\
+        switch (source.kind) { case 'ready': &{ fourth } = source; break; }\n\
+        <p>{first}{second}{third}{fourth}</p>\n\
+    }\n\
+    const text = '&{ ignored } = source';\n\
+    const bitwise = source &{ value: 1 };";
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("statement-context assignments");
+    assert_eq!(result.status, tsrx_tape_schema::ParseCompleteness::Complete);
+    let tape = result.program();
+    let assignments = (0..tape.object_count())
+        .map(|raw| RecordIndex::new(u32::try_from(raw).expect("object index")))
+        .filter(|object| {
+            tape.field_index(*object, "type")
+                .and_then(|field| tape.field_value(field))
+                .and_then(|value| tape.scalar(value))
+                == Some(r#""AssignmentExpression""#)
+                && tape
+                    .field_index(*object, "left")
+                    .and_then(|field| tape.field_value(field))
+                    .and_then(ValueRef::as_object)
+                    .is_some_and(|left| tape.field_index(left, "lazy").is_some())
+        })
+        .count();
+    assert_eq!(assignments, 4);
     assert_no_scaffold(tape);
 }
 

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -360,6 +360,11 @@ fn standalone_lazy_assignments_work_in_every_statement_context_without_matching_
 }
 
 #[test]
+fn standalone_lazy_assignment_defaults_match_the_javascript_parser_rejection() {
+    assert_failed("&{ value = 1 } = source;");
+}
+
+#[test]
 fn parenthesized_sequence_expressions_survive_jsx_validation_without_parent_nodes() {
     let source = "function Leaf(theme: () => string) @{ \
         <span>{((window as any).__renders.leaf++, theme())}</span> \

--- a/crates/tsrx_syntax/src/model.rs
+++ b/crates/tsrx_syntax/src/model.rs
@@ -159,12 +159,14 @@ pub struct ParserShorthandAttribute {
     pub identifier: ByteSpan,
 }
 
-/// One lazy destructuring marker between a declaration keyword and an array/object pattern.
+/// One lazy destructuring marker before an array/object pattern.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ParserLazyPattern {
     pub ampersand: u32,
     pub pattern_start: u32,
+    /// `true` for a standalone `&{...} = value;` / `&[...] = value;` statement.
+    pub standalone: bool,
 }
 
 #[repr(C)]

--- a/crates/tsrx_syntax/src/parser_projection/builder.rs
+++ b/crates/tsrx_syntax/src/parser_projection/builder.rs
@@ -536,6 +536,9 @@ impl<'a> Builder<'a> {
             return Err(ProjectionError::StructuralMismatch);
         }
         self.copy_to(pattern.ampersand as usize)?;
+        if pattern.standalone {
+            self.output.push_str("var ");
+        }
         self.cursor = pattern.ampersand.saturating_add(1) as usize;
         Ok(())
     }

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -319,6 +319,26 @@ impl Scanner<'_> {
             .map(|_| pattern_start)
     }
 
+    pub(super) fn standalone_lazy_pattern_start(
+        &self,
+        ampersand: usize,
+        statement_context: bool,
+    ) -> Option<usize> {
+        let pattern_start = ampersand.checked_add(1)?;
+        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{')) {
+            return None;
+        }
+        let previous = previous_significant_byte(self.bytes, ampersand);
+        if previous.is_none()
+            || matches!(previous, Some(b';' | b'{' | b'}' | b':'))
+            || statement_context
+        {
+            Some(pattern_start)
+        } else {
+            None
+        }
+    }
+
     pub(super) fn keyword_at(&self, index: usize, keyword: &[u8]) -> bool {
         let end = index + 1 + keyword.len();
         self.bytes.get(index) == Some(&b'@')

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -47,6 +47,7 @@ impl Scanner<'_> {
         let mut can_start_jsx = true;
         let mut pending_control_paren = false;
         let mut closed_control_paren = false;
+        let mut pending_statement_body = false;
         let mut parens = TinyStack::<bool, 16>::new();
 
         while index < self.bytes.len() {
@@ -63,6 +64,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'`' => {
                     index = self.scan_template(index)?;
@@ -70,6 +72,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'/' if self.bytes.get(index + 1) == Some(&b'/') => {
                     index = self.skip_line_comment(index + 2);
@@ -83,6 +86,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'/' => {
                     index += usize::from(self.bytes.get(index + 1) == Some(&b'=')) + 1;
@@ -90,6 +94,7 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'<' if (can_start_jsx || self.line_leading_markup_starts_a_statement(index))
                     && self.looks_like_jsx_start(index)
@@ -109,6 +114,7 @@ impl Scanner<'_> {
                             can_start_jsx = true;
                             pending_control_paren = false;
                             closed_control_paren = false;
+                            pending_statement_body = false;
                         }
                         Err(ProjectionError::UnsupportedSyntax { offset, construct }) => {
                             return Err(ProjectionError::UnsupportedSyntax { offset, construct });
@@ -121,6 +127,7 @@ impl Scanner<'_> {
                             can_start_jsx = false;
                             pending_control_paren = false;
                             closed_control_paren = false;
+                            pending_statement_body = false;
                         }
                     }
                 }
@@ -130,6 +137,7 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'@' if self.keyword_at(index, b"for") => {
                     index = self.parse_for(index, self.code_context(index, root_control_start))?;
@@ -137,6 +145,7 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'@' if self.keyword_at(index, b"switch") => {
                     index =
@@ -145,6 +154,7 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'@' if self.keyword_at(index, b"try") => {
                     index = self.parse_try(index, self.code_context(index, root_control_start))?;
@@ -152,6 +162,7 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'@' if self.bytes.get(index + 1) == Some(&b'{') => {
                     self.push_token(StructuralKind::FunctionBody, index)?;
@@ -160,6 +171,7 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'@' => {
                     if self.keyword_at(index, b"else")
@@ -185,20 +197,40 @@ impl Scanner<'_> {
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
-                b'&' if self.lazy_pattern_start(index).is_some() => {
-                    let pattern_start = self
-                        .lazy_pattern_start(index)
-                        .ok_or(ProjectionError::StructuralMismatch)?;
+                b'&' if self.lazy_pattern_start(index).is_some()
+                    || self
+                        .standalone_lazy_pattern_start(
+                            index,
+                            closed_control_paren || pending_statement_body,
+                        )
+                        .is_some() =>
+                {
+                    let (pattern_start, standalone) =
+                        if let Some(pattern_start) = self.lazy_pattern_start(index) {
+                            (pattern_start, false)
+                        } else {
+                            (
+                                self.standalone_lazy_pattern_start(
+                                    index,
+                                    closed_control_paren || pending_statement_body,
+                                )
+                                .ok_or(ProjectionError::StructuralMismatch)?,
+                                true,
+                            )
+                        };
                     self.parser_lazy_patterns.push(ParserLazyPattern {
                         ampersand: to_u32(index)?,
                         pattern_start: to_u32(pattern_start)?,
+                        standalone,
                     });
                     index += 1;
                     can_start_expression = true;
                     can_start_jsx = true;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'(' | b'[' | b'{' => {
                     let close = match byte {
@@ -223,6 +255,7 @@ impl Scanner<'_> {
                     }
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                     index += 1;
                     can_start_expression = true;
                     can_start_jsx = true;
@@ -256,6 +289,7 @@ impl Scanner<'_> {
                     };
                     can_start_jsx = (byte == b'}' && closed_block) || can_start_expression;
                     pending_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'0'..=b'9' => {
                     index = self.skip_number(index);
@@ -263,6 +297,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 _ if self.identifier_start_width(index).is_some() => {
                     let end = self.skip_identifier(index);
@@ -292,6 +327,7 @@ impl Scanner<'_> {
                             ));
                     can_start_jsx = can_start_expression;
                     closed_control_paren = false;
+                    pending_statement_body = matches!(identifier, b"else" | b"do");
                     index = end;
                 }
                 b'+' | b'-'
@@ -302,6 +338,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'!' if !can_start_expression => {
                     // In TypeScript expression position this is a postfix non-null assertion,
@@ -311,6 +348,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 b'.' => {
                     index += if self.bytes.get(index..index + 3) == Some(b"...") { 3 } else { 1 };
@@ -318,6 +356,7 @@ impl Scanner<'_> {
                     can_start_jsx = false;
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
                 _ => {
                     index += 1;
@@ -325,6 +364,7 @@ impl Scanner<'_> {
                     can_start_jsx = can_start_expression || matches!(byte, b';');
                     pending_control_paren = false;
                     closed_control_paren = false;
+                    pending_statement_body = false;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- recognize statement-position `&{...} = value;` and `&[...] = value;` lazy assignments without confusing ordinary bitwise expressions
- project standalone assignments through valid `var` scaffolding, then reconstruct the canonical ESTree `ExpressionStatement` / `AssignmentExpression` shape and authored spans
- cover top-level, control-flow, commented, array/object, rest, non-match, and default-rejection cases already defined by the JavaScript TSRX parser

## Test plan
- [x] `cargo test -p tsrx_syntax -p tsrx_parser_engine`
- [x] `cargo clippy -p tsrx_syntax -p tsrx_parser_engine --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes parser scanning disambiguation and AST reconstruction in the projection path; behavior is bounded by tests and fail-closed errors, but mistakes could mis-classify `&` or reshape statements.
> 
> **Overview**
> Adds **statement-position** lazy destructuring assignments (`&{...} = rhs;` / `&[...] = rhs;`) end-to-end: scan, project through legal TSX, parse, and reconstruct canonical ESTree.
> 
> The scanner now tags lazy `&` patterns with **`standalone`** when they are not tied to `let`/`const`/`var` or parameter lists, using stricter context (statement boundaries, control-flow bodies after `if`/`else`/`do`, etc.) so expression forms like `source &{ value: 1 }` stay ordinary bitwise/object syntax. Projection strips the `&` and inserts **`var`** scaffolding; reconstruction turns the projected single-declarator `VariableDeclaration` into an **`ExpressionStatement`** wrapping an **`AssignmentExpression`** with **`lazy: true`** on the left pattern and authored spans from the `&`. Standalone patterns with **assignment defaults** fail with the same authored-grammar rejection as the JS parser.
> 
> The UTF-8 pipeline only skips projection when **`parser_lazy_patterns`** is empty alongside other overlay features. Integration tests cover ESTree shape, spans, control-flow contexts, non-matches in strings/bitwise code, and default rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb531ed3ba1333363b003b6ee21c1367234cd49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->