### PR TITLE
chore: allow stage publishes in trusted publisher binding

### DIFF
--- a/scripts/trust-publishers.sh
+++ b/scripts/trust-publishers.sh
@@ -88,6 +88,7 @@ for name in $NAMES; do
     --repo "$REPO" \
     --file "$WORKFLOW" \
     --allow-publish \
+    --allow-stage-publish \
     --yes
   then
     echo "  trusted   $name"


### PR DESCRIPTION
Adds `--allow-stage-publish` to the `npm trust github` call in `scripts/trust-publishers.sh`, matching the TSRX org's standard trusted-publishing setup (per Leonidaz). One line.