### PR TITLE
fix: rename fallout — lane host paths, owner identities, discovery order

### DIFF
--- a/crates/oxc_tsrx_cli/src/lsp.rs
+++ b/crates/oxc_tsrx_cli/src/lsp.rs
@@ -494,7 +494,9 @@ const LANE_HOST_FLAG: &str = "--oxc-tsrx-js-plugin-lane-host";
 /// compiled while the package briefly shipped authored `src/` JavaScript would
 /// otherwise fail to find a current package's lane host, and a current binary would
 /// otherwise fail to find that older package's. Both directions resolve here instead.
-const LANE_HOST_PATHS: [&str; 4] = [
+const LANE_HOST_PATHS: [&str; 6] = [
+    "node_modules/@tsrx/oxc/dist/lint-js-plugins.js",
+    "node_modules/@tsrx/oxc/src/lint-js-plugins.js",
     "node_modules/oxc-tsrx/dist/lint-js-plugins.js",
     "node_modules/oxc-tsrx/src/lint-js-plugins.js",
     "packages/toolchain/dist/lint-js-plugins.js",
@@ -565,7 +567,7 @@ impl JsPluginLane {
     fn locate(root: &Path) -> Result<Self, String> {
         let script = locate_lane_host_script(root).ok_or_else(|| {
             format!(
-                "unable to find {}. Install `oxc-tsrx` in this project, or set OXC_TSRX_JS_PLUGIN_LANE to the file",
+                "unable to find {}. Install `@tsrx/oxc` in this project, or set OXC_TSRX_JS_PLUGIN_LANE to the file",
                 LANE_HOST_PATHS[0]
             )
         })?;

--- a/packages/toolchain/dist/canonical-command.d.ts
+++ b/packages/toolchain/dist/canonical-command.d.ts
@@ -2,7 +2,7 @@ export type OxcTsrxCanonicalCommand = "oxlint" | "oxfmt";
 
 export interface OxcTsrxCanonicalDecisionKept {
   readonly command: OxcTsrxCanonicalCommand;
-  readonly owner: "oxc-tsrx";
+  readonly owner: "@tsrx/oxc";
   readonly reason: "no-project-manifest" | "not-directly-declared" | "compatibility-facade";
   readonly projectRoot: string | null;
   readonly officialRoot?: string;

--- a/packages/toolchain/dist/canonical-command.js
+++ b/packages/toolchain/dist/canonical-command.js
@@ -78,7 +78,7 @@ async function decideCanonicalCommand(command, options = {}) {
 	} catch {
 		return {
 			command,
-			owner: "oxc-tsrx",
+			owner: "@tsrx/oxc",
 			reason: "no-project-manifest",
 			projectRoot: null
 		};
@@ -86,7 +86,7 @@ async function decideCanonicalCommand(command, options = {}) {
 	const field = declaresDirectly(manifest, command);
 	if (field === null) return {
 		command,
-		owner: "oxc-tsrx",
+		owner: "@tsrx/oxc",
 		reason: "not-directly-declared",
 		projectRoot
 	};
@@ -99,7 +99,7 @@ async function decideCanonicalCommand(command, options = {}) {
 	const officialManifest = JSON.parse(await readFile(manifestPath, "utf8"));
 	if (isCompatibilityFacade(officialManifest)) return {
 		command,
-		owner: "oxc-tsrx",
+		owner: "@tsrx/oxc",
 		reason: "compatibility-facade",
 		projectRoot,
 		officialRoot: dirname(manifestPath)

--- a/packages/toolchain/dist/compat.js
+++ b/packages/toolchain/dist/compat.js
@@ -731,13 +731,13 @@ async function inspectLinterShim(modules, providerRoot) {
 		if (target && within(providerReal, target)) return {
 			path: shim,
 			target,
-			owner: PROVIDER,
+			owner: PACKAGE_NAME,
 			resolvedBy: "symlink"
 		};
 		if (target && facadeIsOurs && facadeReal && within(facadeReal, target)) return {
 			path: shim,
 			target,
-			owner: PROVIDER,
+			owner: PACKAGE_NAME,
 			resolvedBy: "compatibility-facade"
 		};
 		if (info.isFile() && !info.isSymbolicLink()) {
@@ -745,7 +745,7 @@ async function inspectLinterShim(modules, providerRoot) {
 			if (PROVIDER_LAUNCHER_TEXT.test(source)) return {
 				path: shim,
 				target: target ?? null,
-				owner: PROVIDER,
+				owner: PACKAGE_NAME,
 				resolvedBy: "shim-text"
 			};
 			return {
@@ -1070,7 +1070,7 @@ async function inspectEditorSlot(projectRoot, providerRoot, modules, options = {
 		};
 	};
 	const unwritten = async () => {
-		if (shim.owner !== PROVIDER) return reported("missing", null);
+		if (shim.owner !== PACKAGE_NAME) return reported("missing", null);
 		const reach = await judgeAutoDetection({
 			settingsRoot,
 			projectRoot,

--- a/packages/toolchain/dist/index.d.ts
+++ b/packages/toolchain/dist/index.d.ts
@@ -1,5 +1,5 @@
 export interface OxcTsrxToolchain {
-  readonly name: "oxc-tsrx";
+  readonly name: "@tsrx/oxc";
   readonly language: "tsrx";
   readonly extensions: readonly [".tsrx"];
   readonly capabilities: readonly ["parser", "lint", "format", "languageServer"];

--- a/packages/toolchain/dist/index.js
+++ b/packages/toolchain/dist/index.js
@@ -7,7 +7,7 @@ const capabilities = Object.freeze([
 	"languageServer"
 ]);
 const toolchain = Object.freeze({
-	name: "oxc-tsrx",
+	name: "@tsrx/oxc",
 	language: "tsrx",
 	extensions,
 	capabilities

--- a/packages/toolchain/src/canonical-command.d.ts
+++ b/packages/toolchain/src/canonical-command.d.ts
@@ -2,7 +2,7 @@ export type OxcTsrxCanonicalCommand = "oxlint" | "oxfmt";
 
 export interface OxcTsrxCanonicalDecisionKept {
   readonly command: OxcTsrxCanonicalCommand;
-  readonly owner: "oxc-tsrx";
+  readonly owner: "@tsrx/oxc";
   readonly reason: "no-project-manifest" | "not-directly-declared" | "compatibility-facade";
   readonly projectRoot: string | null;
   readonly officialRoot?: string;

--- a/packages/toolchain/src/canonical-command.ts
+++ b/packages/toolchain/src/canonical-command.ts
@@ -87,12 +87,12 @@ export async function decideCanonicalCommand(command, options: any = {}) {
     projectRoot = await findProjectRoot(cwd);
     manifest = JSON.parse(await readFile(join(projectRoot, "package.json"), "utf8"));
   } catch {
-    return { command, owner: "oxc-tsrx", reason: "no-project-manifest", projectRoot: null };
+    return { command, owner: "@tsrx/oxc", reason: "no-project-manifest", projectRoot: null };
   }
 
   const field = declaresDirectly(manifest, command);
   if (field === null) {
-    return { command, owner: "oxc-tsrx", reason: "not-directly-declared", projectRoot };
+    return { command, owner: "@tsrx/oxc", reason: "not-directly-declared", projectRoot };
   }
 
   let manifestPath;
@@ -114,7 +114,7 @@ export async function decideCanonicalCommand(command, options: any = {}) {
     // Delegating would re-enter this launcher without bound.
     return {
       command,
-      owner: "oxc-tsrx",
+      owner: "@tsrx/oxc",
       reason: "compatibility-facade",
       projectRoot,
       officialRoot: dirname(manifestPath),

--- a/packages/toolchain/src/compat.ts
+++ b/packages/toolchain/src/compat.ts
@@ -856,15 +856,15 @@ async function inspectLinterShim(modules, providerRoot) {
     if (!info) continue;
     const target = await realPathOrNull(shim);
     if (target && within(providerReal, target)) {
-      return { path: shim, target, owner: PROVIDER, resolvedBy: "symlink" };
+      return { path: shim, target, owner: PACKAGE_NAME, resolvedBy: "symlink" };
     }
     if (target && facadeIsOurs && facadeReal && within(facadeReal, target)) {
-      return { path: shim, target, owner: PROVIDER, resolvedBy: "compatibility-facade" };
+      return { path: shim, target, owner: PACKAGE_NAME, resolvedBy: "compatibility-facade" };
     }
     if (info.isFile() && !info.isSymbolicLink()) {
       const source = await readFile(shim, "utf8").catch(() => "");
       if (PROVIDER_LAUNCHER_TEXT.test(source)) {
-        return { path: shim, target: target ?? null, owner: PROVIDER, resolvedBy: "shim-text" };
+        return { path: shim, target: target ?? null, owner: PACKAGE_NAME, resolvedBy: "shim-text" };
       }
       return { path: shim, target: target ?? null, owner: "other", resolvedBy: "shim-text" };
     }
@@ -1330,7 +1330,7 @@ async function inspectEditorSlot(projectRoot, providerRoot, modules, options: an
   // whole answer, and `unnecessary` has to be earned by asking rather than
   // assumed from `.bin/oxlint` being ours in this one folder.
   const unwritten = async () => {
-    if (shim.owner !== PROVIDER) return reported("missing", null);
+    if (shim.owner !== PACKAGE_NAME) return reported("missing", null);
     const reach = await judgeAutoDetection({
       settingsRoot,
       projectRoot,

--- a/packages/toolchain/src/index.d.ts
+++ b/packages/toolchain/src/index.d.ts
@@ -1,5 +1,5 @@
 export interface OxcTsrxToolchain {
-  readonly name: "oxc-tsrx";
+  readonly name: "@tsrx/oxc";
   readonly language: "tsrx";
   readonly extensions: readonly [".tsrx"];
   readonly capabilities: readonly ["parser", "lint", "format", "languageServer"];

--- a/packages/toolchain/src/index.ts
+++ b/packages/toolchain/src/index.ts
@@ -2,7 +2,7 @@ const extensions = Object.freeze([".tsrx"]);
 const capabilities = Object.freeze(["parser", "lint", "format", "languageServer"]);
 
 export const toolchain = Object.freeze({
-  name: "oxc-tsrx",
+  name: "@tsrx/oxc",
   language: "tsrx",
   extensions,
   capabilities,

--- a/tests/packaging/provider-discovery.test.mjs
+++ b/tests/packaging/provider-discovery.test.mjs
@@ -536,7 +536,7 @@ test(
         assert.deepEqual(Object.keys(index.extensions).sort(), [".demo", ".tsrx"]);
         assert.deepEqual(
           index.providers.map(({ name }) => name).sort(),
-          ["demo-language-provider", "@tsrx/oxc"],
+          ["@tsrx/oxc", "demo-language-provider"],
         );
         assert.equal(index.extensions[".demo"].package, "demo-language-provider");
         assert.deepEqual(
@@ -607,7 +607,7 @@ test("the providers report is a read-only audit that fails loudly", async (conte
   const fixture = async (name, dependencies, packages) => {
     const directory = join(temporary, name);
     await writePackage(directory, { name, private: true, type: "module", dependencies });
-    await mkdir(join(directory, "node_modules"), { recursive: true });
+    await mkdir(join(directory, "node_modules/@tsrx"), { recursive: true });
     // A junction is the Windows form that needs no elevated privilege; a plain
     // directory symlink there requires Developer Mode or an admin token, which
     // would make this fixture fail for a reason that is not about discovery.

--- a/tests/packaging/provider-discovery.test.mjs
+++ b/tests/packaging/provider-discovery.test.mjs
@@ -642,7 +642,7 @@ test("the providers report is a read-only audit that fails loudly", async (conte
     assert.equal(text.status, 0, text.stderr);
     assert.match(text.stdout, /@tsrx\/oxc@0\.6\.0 \(provider tsrx, protocol 1\)/u);
     assert.match(text.stdout, /language tsrx: \.tsrx/u);
-    assert.match(text.stdout, /routed extensions: \.tsrx -> oxc-tsrx/u);
+    assert.match(text.stdout, /routed extensions: \.tsrx -> @tsrx\/oxc/u);
   });
 
   await context.test("two providers claiming one extension fail loudly", async () => {


### PR DESCRIPTION
Fixes the CI failures on main after the @tsrx migration (all one class: rename fallout that static greps couldn't catch):

- `lsp.rs`: `LANE_HOST_PATHS` now resolves `node_modules/@tsrx/oxc/...` first, keeping the old paths as version-skew fallback per the table's own doc; diagnostic message says `@tsrx/oxc`
- `canonical-command` / `compat`: `owner` values are the npm package name (`@tsrx/oxc`); provider id `"oxc-tsrx"` untouched
- `toolchain.name` export → `@tsrx/oxc` (matches discovery and the export-map test)
- provider-discovery test fixture: create the `@tsrx` scope dir before symlinking; sorted-order and routing expectations re-sorted for the scoped name

Verified locally: full JS suite and full `test:packaging:unit` both green (0 failures), targeted provider-discovery / toolchain-package / js-plugins suites green, native rebuilt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-alignment only: path fallbacks preserve old layouts, and behavior is covered by packaging/provider-discovery tests.
> 
> **Overview**
> Follow-up to the **`oxc-tsrx` → `@tsrx/oxc`** npm rename: strings and resolution order that greps missed, so CI and discovery match the scoped package.
> 
> **LSP JS plugin lane** (`lsp.rs`): **`LANE_HOST_PATHS`** now tries **`node_modules/@tsrx/oxc/...`** (`dist` then `src`) before the legacy **`oxc-tsrx`** and monorepo paths. The “install …” diagnostic points at **`@tsrx/oxc`**.
> 
> **Toolchain identity**: **`toolchain.name`** and canonical-command **`owner`** literals are **`@tsrx/oxc`** (types + built JS). **Compat** reports `.bin/oxlint` shim ownership with **`PACKAGE_NAME`** (`@tsrx/oxc`); the internal provider id **`oxc-tsrx`** for facades/metadata is unchanged.
> 
> **Tests**: Provider-discovery fixture creates **`node_modules/@tsrx`** before linking **`oxc`**; expectations use sorted scoped names and **`providers` CLI** output **`routed extensions: .tsrx -> @tsrx/oxc`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0afdc4d1606fe27cd3bf54c14d548612c0f35c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->