### PR TITLE
fix: release consistency gate — manifest url form and frozen launch record

### DIFF
--- a/docs/releasing/v0.1.0-launch.json
+++ b/docs/releasing/v0.1.0-launch.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "version": "0.1.0",
-  "repository": "https://github.com/tsrx-org/oxc",
+  "repository": "https://github.com/markless-dev/oxc-tsrx",
   "site": {
     "url": "https://oxc-tsrx.dev/",
     "artifact": "docs/dist",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tsrx-org/oxc.git",
+    "url": "https://github.com/tsrx-org/oxc.git",
     "directory": "packages/vscode"
   },
   "bugs": {


### PR DESCRIPTION
Two coordination mismatches the release gate (test:release) caught:

- `packages/vscode/package.json` `repository.url` back to the bare `https://github.com/tsrx-org/oxc.git` form the launch-identity test intentionally preserves per-manifest
- `docs/releasing/v0.1.0-launch.json` `repository` restored to the markless-dev URL — the file is a frozen record of the launch as it ran; only operative fields (publishOrder, installPreview) carry the new names

`pnpm run test:release` green locally (0 failures).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only URL corrections in a launch record and VS Code manifest; no runtime, auth, or publish logic changes.
> 
> **Overview**
> Fixes two **release consistency** mismatches so `pnpm run test:release` passes.
> 
> The frozen **`docs/releasing/v0.1.0-launch.json`** `repository` field is set back to `https://github.com/markless-dev/oxc-tsrx`, matching the launch-as-shipped record the contract test asserts (distinct from current `tsrx-org/oxc` identity elsewhere).
> 
> In **`packages/vscode/package.json`**, `repository.url` is changed to the bare `https://github.com/tsrx-org/oxc.git` form—without the `git+` prefix used by other manifests—per the launch-identity test’s VS Code-specific expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e157a9441bd82104f949363c04473e5a515d21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->