### PR TITLE
Support lazy catch bindings

### DIFF
--- a/crates/tsrx_parser_engine/src/projection/marker_validation.rs
+++ b/crates/tsrx_parser_engine/src/projection/marker_validation.rs
@@ -338,11 +338,33 @@ fn try_marker_positioned(
             } else {
                 tail
             };
-            synthetic_comma_precedes(projected, comment.span.start)? && tail == Some(authored_tail)
+            let authored_tail =
+                catch_tail_without_lazy_sigils(authored, trivia_start, clause.body.start, overlay)?;
+            synthetic_comma_precedes(projected, comment.span.start)?
+                && tail == Some(authored_tail.as_str())
         }
         _ => false,
     };
     Ok(scaffold_matches)
+}
+
+fn catch_tail_without_lazy_sigils(
+    authored: &str,
+    start: u32,
+    end: u32,
+    overlay: OverlayView<'_>,
+) -> Result<String, TsrxParseError> {
+    let mut output = String::new();
+    let mut cursor = start;
+    for pattern in overlay.parser_lazy_patterns {
+        if pattern.ampersand < start || pattern.ampersand >= end {
+            continue;
+        }
+        output.push_str(slice(authored, cursor, pattern.ampersand)?);
+        cursor = pattern.ampersand.saturating_add(1);
+    }
+    output.push_str(slice(authored, cursor, end)?);
+    Ok(output)
 }
 
 fn strip_scaffold_name<'a>(

--- a/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
@@ -187,6 +187,11 @@ fn declarator_for_pattern(
         {
             return Ok(Some(declarator));
         }
+        if has_type(tape, declarator, r#""CatchClause""#)
+            && object_field(tape, declarator, "param")? == pattern
+        {
+            return Ok(None);
+        }
         return Err(TsrxParseError::Unsupported("lazy pattern has an unsupported object parent"));
     }
     let list =
@@ -198,11 +203,14 @@ fn declarator_for_pattern(
     if !matches!(
         super::access::object_type(tape, function),
         Some(
-            r#""FunctionDeclaration""# | r#""FunctionExpression""# | r#""ArrowFunctionExpression""#
+            r#""FunctionDeclaration""#
+                | r#""FunctionExpression""#
+                | r#""ArrowFunctionExpression""#
+                | r#""CatchClause""#
         )
     ) {
         return Err(TsrxParseError::Unsupported(
-            "lazy pattern list is not a function parameter list",
+            "lazy pattern list is not a supported parameter list",
         ));
     }
     Ok(None)

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -235,7 +235,9 @@ fn lazy_destructuring_patterns_preserve_markers_in_declarations_and_for_headers(
             <li>{label}</li>\n\
         }</ul>\n\
     }\n\
-    function Param(&{ greeting, name }: any) @{ <p>{greeting + name}</p> }";
+    function Param(&{ greeting, name }: any) @{ <p>{greeting + name}</p> }\n\
+    function Catch() @{ @try { <A/> } @catch /* gap */ (&{ message }, reset) { <p>{message}</p> } }\n\
+    function Ordinary() { try {} catch /* gap */ (&{ cause }) { console.log(cause); } }";
     let result = parse_tsrx(&TsrxParseRequest { source }).expect("lazy destructuring patterns");
     let tape = result.program();
     let mut patterns = Vec::new();
@@ -260,7 +262,7 @@ fn lazy_destructuring_patterns_preserve_markers_in_declarations_and_for_headers(
             declarators.push(object);
         }
     }
-    assert_eq!(patterns.len(), 4);
+    assert_eq!(patterns.len(), 6);
     for pattern in patterns {
         assert_eq!(scalar_field(tape, pattern, "lazy"), "true");
         let (pattern_start, _) = span(tape, pattern);

--- a/crates/tsrx_syntax/src/parser_scanner/control.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/control.rs
@@ -276,6 +276,7 @@ impl Scanner<'_> {
             let after_keyword = self.skip_trivia(Self::after_keyword(catch_start, b"catch"))?;
             let (header, bindings, catch_body_start) =
                 if self.bytes.get(after_keyword) == Some(&b'(') {
+                    self.register_lazy_catch_parameter(after_keyword)?;
                     let (header, after_header) = self.parse_parenthesized(after_keyword)?;
                     let bindings = self.catch_binding_count(header)?;
                     (header, bindings, self.skip_trivia(after_header)?)

--- a/crates/tsrx_syntax/src/parser_scanner/header.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/header.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     diagnostics::{ProjectionError, to_u32},
-    model::{ByteSpan, ClauseRole, ForHeader},
+    model::{ByteSpan, ClauseRole, ForHeader, ParserLazyPattern},
 };
 
 use super::Scanner;
@@ -11,6 +11,33 @@ use super::lexical::trim_ascii_end;
 use super::stack::TinyStack;
 
 impl Scanner<'_> {
+    pub(super) fn register_lazy_catch_parameter(
+        &mut self,
+        open: usize,
+    ) -> Result<(), ProjectionError> {
+        if self.bytes.get(open) != Some(&b'(') {
+            return Ok(());
+        }
+        let ampersand = self.skip_trivia(open + 1)?;
+        let pattern_start =
+            self.skip_ascii_whitespace(ampersand.saturating_add(1), self.bytes.len());
+        if self.bytes.get(ampersand) != Some(&b'&')
+            || !matches!(self.bytes.get(pattern_start), Some(b'{' | b'['))
+            || self
+                .parser_lazy_patterns
+                .iter()
+                .any(|pattern| pattern.ampersand as usize == ampersand)
+        {
+            return Ok(());
+        }
+        self.parser_lazy_patterns.push(ParserLazyPattern {
+            ampersand: to_u32(ampersand)?,
+            pattern_start: to_u32(pattern_start)?,
+            standalone: false,
+        });
+        Ok(())
+    }
+
     pub(super) fn parse_parenthesized(
         &mut self,
         start: usize,

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -304,6 +304,12 @@ impl Scanner<'_> {
                     let identifier = &self.bytes[index..end];
                     let type_position = identifier == b"void"
                         && previous_significant_byte(self.bytes, index) == Some(b':');
+                    if identifier == b"catch"
+                        && previous_significant_byte(self.bytes, index) != Some(b'.')
+                    {
+                        let open = self.skip_trivia(end)?;
+                        self.register_lazy_catch_parameter(open)?;
+                    }
                     pending_control_paren = matches!(
                         identifier,
                         b"if" | b"for" | b"while" | b"with" | b"switch" | b"catch"


### PR DESCRIPTION
## Summary
- recognize lazy object and array patterns in ordinary and TSRX catch parameters
- preserve catch-marker validation while removing projected lazy sigils
- reconstruct the canonical lazy catch binding shape, including trivia between `catch` and its parameter

## Test plan
- [x] `cargo test -p tsrx_syntax -p tsrx_parser_engine`
- [x] `cargo clippy -p tsrx_syntax -p tsrx_parser_engine --all-targets -- -D warnings`

Made with [Cursor](https://cursor.com)