### PR TITLE
Support lazy arrow parameters

### DIFF
--- a/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use super::{
-    access::{field_value, has_type, list_field, object_field, scalar_u32},
+    access::{field_value, has_type, list_field, scalar_u32},
     edits::append_node_head,
     objects::find_unique_start,
     spans::{AuthoredStart, record_authored_span},
@@ -178,32 +178,61 @@ fn declarator_for_pattern(
     pattern: RecordIndex,
     parents: &ParentIndex,
 ) -> Result<Option<RecordIndex>, TsrxParseError> {
-    let parent = parents
-        .parent_container(tsrx_tape_schema::ValueRef::object(pattern))
-        .ok_or(TsrxParseError::Unsupported("lazy pattern has no parent"))?;
-    if let Some(declarator) = parent.as_object() {
-        if has_type(tape, declarator, r#""VariableDeclarator""#)
-            && object_field(tape, declarator, "id")? == pattern
-        {
-            return Ok(Some(declarator));
+    let mut child = ValueRef::object(pattern);
+    loop {
+        let parent = parents
+            .parent_container(child)
+            .ok_or(TsrxParseError::Unsupported("lazy pattern has no binding owner"))?;
+        if let Some(owner) = parent.as_object() {
+            let owner_type = super::access::object_type(tape, owner);
+            if owner_type == Some(r#""VariableDeclarator""#)
+                && field_value(tape, owner, "id")? == child
+            {
+                return Ok(Some(owner));
+            }
+            let binding_child = match owner_type {
+                Some(r#""AssignmentPattern""#) => field_value(tape, owner, "left")?,
+                Some(r#""RestElement""#) => field_value(tape, owner, "argument")?,
+                Some(r#""Property""#) => field_value(tape, owner, "value")?,
+                _ => {
+                    return Err(TsrxParseError::Unsupported(
+                        "lazy pattern has an unsupported binding parent",
+                    ));
+                }
+            };
+            if binding_child != child {
+                return Err(TsrxParseError::Unsupported(
+                    "lazy pattern is outside the binding side of its parent",
+                ));
+            }
+            child = parent;
+            continue;
         }
-        return Err(TsrxParseError::Unsupported("lazy pattern has an unsupported object parent"));
+
+        let list = parent
+            .as_list()
+            .ok_or(TsrxParseError::Unsupported("lazy pattern parent is not a binding list"))?;
+        let owner = parents
+            .parent_container(ValueRef::list(list))
+            .and_then(ValueRef::as_object)
+            .ok_or(TsrxParseError::Unsupported("lazy pattern list has no owner"))?;
+        match super::access::object_type(tape, owner) {
+            Some(
+                r#""FunctionDeclaration""#
+                | r#""FunctionExpression""#
+                | r#""ArrowFunctionExpression""#,
+            ) if list_field(tape, owner, "params")? == list => return Ok(None),
+            Some(r#""ObjectPattern""#) if list_field(tape, owner, "properties")? == list => {
+                child = ValueRef::object(owner);
+            }
+            Some(r#""ArrayPattern""#) if list_field(tape, owner, "elements")? == list => {
+                child = ValueRef::object(owner);
+            }
+            _ => {
+                return Err(TsrxParseError::Unsupported(
+                    "lazy pattern list is not part of a binding pattern",
+                ));
+            }
+        }
     }
-    let list =
-        parent.as_list().ok_or(TsrxParseError::Unsupported("lazy pattern parent is not a list"))?;
-    let function = parents
-        .parent_container(tsrx_tape_schema::ValueRef::list(list))
-        .and_then(tsrx_tape_schema::ValueRef::as_object)
-        .ok_or(TsrxParseError::Unsupported("lazy parameter has no function parent"))?;
-    if !matches!(
-        super::access::object_type(tape, function),
-        Some(
-            r#""FunctionDeclaration""# | r#""FunctionExpression""# | r#""ArrowFunctionExpression""#
-        )
-    ) {
-        return Err(TsrxParseError::Unsupported(
-            "lazy pattern list is not a function parameter list",
-        ));
-    }
-    Ok(None)
 }

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -277,6 +277,41 @@ fn lazy_destructuring_patterns_preserve_markers_in_declarations_and_for_headers(
 }
 
 #[test]
+fn lazy_arrow_parameters_preserve_patterns_types_defaults_and_async_arrows() {
+    let source = "const View = (&{ name, title = name }: Props): string => title;\n\
+        const select = async (prefix: string, /* gap */ &[first, ...rest]: Items = items) => [prefix, first, rest];\n\
+        const nested = (&{ user: &{ id } }: Props) => id;\n\
+        const bitwise = (value = source&{ value: 1 }) => value;";
+    let overlay = scan_for_parser(source).expect("lazy arrow overlay");
+    let projection = project_for_parser(source, &overlay).expect("lazy arrow projection");
+    assert!(!projection.source().contains("(&{ name"));
+    assert!(!projection.source().contains("/* gap */ &[first"));
+    assert!(!projection.source().contains("&{ user:"));
+    assert!(!projection.source().contains("user: &{ id"));
+    assert!(projection.source().contains("source&{ value: 1 }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("lazy arrow parameters");
+    let tape = result.program();
+    let patterns = (0..tape.object_count())
+        .map(|raw| RecordIndex::new(u32::try_from(raw).expect("object index")))
+        .filter(|object| {
+            tape.field_index(*object, "type")
+                .and_then(|field| tape.field_value(field))
+                .and_then(|value| tape.scalar(value))
+                .is_some_and(|kind| matches!(kind, r#""ArrayPattern""# | r#""ObjectPattern""#))
+                && tape.field_index(*object, "lazy").is_some()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(patterns.len(), 4);
+    for pattern in patterns {
+        assert_eq!(scalar_field(tape, pattern, "lazy"), "true");
+        let (pattern_start, _) = span(tape, pattern);
+        assert_eq!(source.as_bytes()[usize::try_from(pattern_start - 1).expect("offset")], b'&');
+    }
+    assert_no_scaffold(tape);
+}
+
+#[test]
 fn standalone_lazy_assignment_statements_match_the_estree_shape_and_authored_spans() {
     let source = "&{ value, ...rest } = object;\n&[first, ...tail] = items;";
     let overlay = scan_for_parser(source).expect("standalone lazy assignment overlay");

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -339,6 +339,77 @@ impl Scanner<'_> {
         }
     }
 
+    pub(super) fn lazy_arrow_pattern_start(
+        &self,
+        ampersand: usize,
+        parameter_open: Option<usize>,
+        previous_token: Option<u8>,
+    ) -> Option<usize> {
+        parameter_open?;
+        let pattern_start = ampersand.checked_add(1)?;
+        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{'))
+            || !matches!(previous_token, Some(b'(' | b'[' | b'{' | b',' | b':'))
+        {
+            return None;
+        }
+        Some(pattern_start)
+    }
+
+    pub(super) fn arrow_follows_parameter_list(&self, mut index: usize) -> bool {
+        let Ok(next) = self.skip_trivia(index) else {
+            return false;
+        };
+        index = next;
+        if self.bytes.get(index..index + 2) == Some(b"=>") {
+            return true;
+        }
+        if self.bytes.get(index) != Some(&b':') {
+            return false;
+        }
+        index += 1;
+
+        let mut delimiters = Vec::new();
+        while index < self.bytes.len() {
+            match self.bytes[index] {
+                b'\'' | b'"' => {
+                    let Ok(end) = self.skip_quote(index, self.bytes[index]) else {
+                        return false;
+                    };
+                    index = end;
+                }
+                b'/' if self.bytes.get(index + 1) == Some(&b'/') => {
+                    index = self.skip_line_comment(index + 2);
+                }
+                b'/' if self.bytes.get(index + 1) == Some(&b'*') => {
+                    let Ok(end) = self.skip_block_comment(index) else {
+                        return false;
+                    };
+                    index = end;
+                }
+                b'(' | b'[' | b'{' | b'<' => {
+                    delimiters.push(match self.bytes[index] {
+                        b'(' => b')',
+                        b'[' => b']',
+                        b'{' => b'}',
+                        b'<' => b'>',
+                        _ => unreachable!(),
+                    });
+                    index += 1;
+                }
+                byte @ (b')' | b']' | b'}' | b'>') if delimiters.last().copied() == Some(byte) => {
+                    delimiters.pop();
+                    index += 1;
+                }
+                b'=' if delimiters.is_empty() && self.bytes.get(index + 1) == Some(&b'>') => {
+                    return true;
+                }
+                b';' if delimiters.is_empty() => return false,
+                _ => index += 1,
+            }
+        }
+        false
+    }
+
     pub(super) fn keyword_at(&self, index: usize, keyword: &[u8]) -> bool {
         let end = index + 1 + keyword.len();
         self.bytes.get(index) == Some(&b'@')

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -49,6 +49,9 @@ impl Scanner<'_> {
         let mut closed_control_paren = false;
         let mut pending_statement_body = false;
         let mut parens = TinyStack::<bool, 16>::new();
+        let mut paren_starts = TinyStack::<usize, 16>::new();
+        let mut pending_lazy_arrow_patterns = Vec::<(usize, usize, usize)>::new();
+        let mut previous_token = None;
 
         while index < self.bytes.len() {
             let byte = self.bytes[index];
@@ -57,6 +60,8 @@ impl Scanner<'_> {
                 continue;
             }
 
+            let records_previous_token =
+                !matches!(self.bytes.get(index..index + 2), Some(b"//" | b"/*"));
             match byte {
                 b'\'' | b'"' => {
                     index = self.skip_quote(index, byte)?;
@@ -199,31 +204,58 @@ impl Scanner<'_> {
                     closed_control_paren = false;
                     pending_statement_body = false;
                 }
-                b'&' if self.lazy_pattern_start(index).is_some()
-                    || self
+                b'&' if self.lazy_pattern_start(index).is_some() => {
+                    let pattern_start = self
+                        .lazy_pattern_start(index)
+                        .ok_or(ProjectionError::StructuralMismatch)?;
+                    self.parser_lazy_patterns.push(ParserLazyPattern {
+                        ampersand: to_u32(index)?,
+                        pattern_start: to_u32(pattern_start)?,
+                        standalone: false,
+                    });
+                    index += 1;
+                    can_start_expression = true;
+                    can_start_jsx = true;
+                    pending_control_paren = false;
+                    closed_control_paren = false;
+                    pending_statement_body = false;
+                }
+                b'&' if self
+                    .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                    .is_some() =>
+                {
+                    let pattern_start = self
+                        .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                        .ok_or(ProjectionError::StructuralMismatch)?;
+                    pending_lazy_arrow_patterns.push((
+                        paren_starts.last().ok_or(ProjectionError::StructuralMismatch)?,
+                        index,
+                        pattern_start,
+                    ));
+                    index += 1;
+                    can_start_expression = true;
+                    can_start_jsx = true;
+                    pending_control_paren = false;
+                    closed_control_paren = false;
+                    pending_statement_body = false;
+                }
+                b'&' if self
+                    .standalone_lazy_pattern_start(
+                        index,
+                        closed_control_paren || pending_statement_body,
+                    )
+                    .is_some() =>
+                {
+                    let pattern_start = self
                         .standalone_lazy_pattern_start(
                             index,
                             closed_control_paren || pending_statement_body,
                         )
-                        .is_some() =>
-                {
-                    let (pattern_start, standalone) =
-                        if let Some(pattern_start) = self.lazy_pattern_start(index) {
-                            (pattern_start, false)
-                        } else {
-                            (
-                                self.standalone_lazy_pattern_start(
-                                    index,
-                                    closed_control_paren || pending_statement_body,
-                                )
-                                .ok_or(ProjectionError::StructuralMismatch)?,
-                                true,
-                            )
-                        };
+                        .ok_or(ProjectionError::StructuralMismatch)?;
                     self.parser_lazy_patterns.push(ParserLazyPattern {
                         ampersand: to_u32(index)?,
                         pattern_start: to_u32(pattern_start)?,
-                        standalone,
+                        standalone: true,
                     });
                     index += 1;
                     can_start_expression = true;
@@ -252,6 +284,7 @@ impl Scanner<'_> {
                     delimiters.push((close, block));
                     if byte == b'(' {
                         parens.push(pending_control_paren);
+                        paren_starts.push(index);
                     }
                     pending_control_paren = false;
                     closed_control_paren = false;
@@ -262,6 +295,7 @@ impl Scanner<'_> {
                 }
                 b')' | b']' | b'}' => {
                     let mut closed_block = false;
+                    let parameter_open = (byte == b')').then(|| paren_starts.pop()).flatten();
                     if delimiters.last().is_some_and(|delimiter| delimiter.0 == byte) {
                         closed_block = delimiters.pop().is_some_and(|delimiter| delimiter.1);
                         index += 1;
@@ -275,6 +309,31 @@ impl Scanner<'_> {
                         });
                     } else {
                         index += 1;
+                    }
+                    if let Some(parameter_open) = parameter_open {
+                        let is_arrow = self.arrow_follows_parameter_list(index);
+                        let mut pending = 0;
+                        while pending < pending_lazy_arrow_patterns.len() {
+                            let (open, ampersand, pattern_start) =
+                                pending_lazy_arrow_patterns[pending];
+                            if open != parameter_open {
+                                pending += 1;
+                                continue;
+                            }
+                            pending_lazy_arrow_patterns.remove(pending);
+                            if is_arrow {
+                                let pattern = ParserLazyPattern {
+                                    ampersand: to_u32(ampersand)?,
+                                    pattern_start: to_u32(pattern_start)?,
+                                    standalone: false,
+                                };
+                                let insert =
+                                    self.parser_lazy_patterns.partition_point(|existing| {
+                                        existing.ampersand < pattern.ampersand
+                                    });
+                                self.parser_lazy_patterns.insert(insert, pattern);
+                            }
+                        }
                     }
                     can_start_expression = if byte == b')' {
                         let control = parens.pop().unwrap_or(false);
@@ -366,6 +425,9 @@ impl Scanner<'_> {
                     closed_control_paren = false;
                     pending_statement_body = false;
                 }
+            }
+            if records_previous_token {
+                previous_token = Some(byte);
             }
         }
 


### PR DESCRIPTION
## Summary
- recognize `&{}` and `&[]` only inside confirmed arrow parameter lists, including async and TypeScript return-annotated arrows
- preserve exact bitwise-AND behavior by deferring lazy registration until the matching parameter list closes before `=>`
- reconstruct typed, defaulted, rest, and nested lazy patterns through their binding wrappers

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p tsrx_syntax -p tsrx_parser_engine`
- [x] `cargo clippy -p tsrx_syntax -p tsrx_parser_engine --all-targets -- -D warnings`

Full-workspace Clippy additionally requires CMake for the optional N-API mimalloc build; the two changed crates pass with warnings denied.

Made with [Cursor](https://cursor.com)