### PR TITLE
site: ship the wasm demo to oxc.tsrx.dev and harden asset caching + flames

### DIFF
--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -7,8 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Write, for exactly one reason: the build job commits website-oxc/wasm-pin.json
+# back to main so the oxc.tsrx.dev Vercel build can find the demo engine it
+# cannot compile (see "Publish the proven demo engine" below). Jobs that have no
+# business writing say so themselves.
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: site-artifact-${{ github.ref }}
@@ -49,6 +53,10 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    # A pull request proves the site builds. It never publishes anything, so it
+    # keeps the read-only token it had before this file needed write.
+    permissions:
+      contents: read
     steps:
       - name: Check out the pull request revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -175,6 +183,133 @@ jobs:
           pnpm run test:site:unit
           node tests/site/verify-static.mjs --require-wasm
           pnpm run docs:check
+
+      # -----------------------------------------------------------------------
+      # Hand the engine just proved above to the build that cannot compile it.
+      #
+      # https://oxc.tsrx.dev is a Vercel project rooted at website-oxc/, built by
+      # Vercel's git integration on Vercel's image: no cargo, no
+      # wasm32-wasip1-threads, no way to run `pnpm run docs:wasm`, and no Vercel
+      # credential in this repository to push a prebuilt artifact with. So the
+      # bytes travel by release instead. This job publishes them to the rolling
+      # `wasm-demo-latest` release and commits a pin naming their exact sha256s;
+      # scripts/fetch-docs-wasm.ts, which website-oxc's build script runs first,
+      # turns that pin back into files.
+      #
+      # The pin commit is also the trigger: a push by GITHUB_TOKEN does not
+      # start another Actions run (no loop), but it does reach Vercel's webhook,
+      # which is precisely the delivery this needs.
+      #
+      # Both steps run only after the artifact has been proved, only on main,
+      # and never fail this job -- see the continue-on-error note below.
+      # -----------------------------------------------------------------------
+      - name: Publish the proven demo engine and pin it for oxc.tsrx.dev
+        # This whole path is additive: production at compiled.run/oxc-tsrx is
+        # deployed from the artifact this job uploads and does not depend on any
+        # of it. A release API hiccup or a protected branch must therefore leave
+        # a warning, not a red build that blocks that deploy. The cost of a miss
+        # is bounded and self-correcting: oxc.tsrx.dev keeps serving its last
+        # good engine, and the next push to main pins again.
+        continue-on-error: true
+        if: >-
+          github.repository == 'tsrx-org/oxc' &&
+          github.ref_name == 'main' &&
+          hashFiles('docs/tools/demo-wasm/dist/demo-wasm.wasm') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          wasm="docs/tools/demo-wasm/dist/demo-wasm.wasm"
+          worker="docs/tools/demo-wasm/dist/wasi-worker-browser.mjs"
+
+          # The engine is two files and the worker is not optional: the bundled
+          # loader reaches it through a URL relative to the binary
+          # (docs/demo-wasm-engine-entry.mjs). Half an engine is worse than none.
+          for file in "${wasm}" "${worker}"; do
+            if [ ! -f "${file}" ]; then
+              echo "::error::${file} is missing; the proven artifact is incomplete"
+              exit 1
+            fi
+          done
+
+          # One rolling release, replaced in place, so the site never has to
+          # discover which tag is current. `create` is expected to fail on every
+          # run after the first -- that failure is the steady state, and
+          # `upload --clobber` is what actually publishes.
+          gh release create wasm-demo-latest \
+            --title "wasm-demo-latest" \
+            --notes "Rolling WASM demo engine artifact for the oxc.tsrx.dev Vercel build. Not for installation." \
+            || true
+          gh release upload wasm-demo-latest "${wasm}" "${worker}" --clobber
+
+          # Computed by the same file the site build uses to check it, invoked
+          # here rather than reimplemented in shell: two definitions of "the
+          # sources this engine was built from" would eventually disagree, and
+          # the day they did, every site build would silently drop the engine.
+          inputs_hash="$(node scripts/fetch-docs-wasm.ts --print-inputs-hash)"
+
+          pin="$(mktemp)"
+          jq -n \
+            --arg tag "wasm-demo-latest" \
+            --arg inputsHash "${inputs_hash}" \
+            --arg sourceCommit "${GITHUB_SHA}" \
+            --arg wasmSha "$(shasum -a 256 "${wasm}" | cut -d' ' -f1)" \
+            --argjson wasmBytes "$(stat -c%s "${wasm}")" \
+            --arg workerSha "$(shasum -a 256 "${worker}" | cut -d' ' -f1)" \
+            --argjson workerBytes "$(stat -c%s "${worker}")" \
+            '{
+              tag: $tag,
+              inputsHash: $inputsHash,
+              sourceCommit: $sourceCommit,
+              wasm: { sha256: $wasmSha, bytes: $wasmBytes },
+              worker: { sha256: $workerSha, bytes: $workerBytes }
+            }' > "${pin}"
+
+          mkdir -p website-oxc
+          # sourceCommit is excluded from the comparison on purpose. It records
+          # which commit's build produced these bytes, so when the bytes and the
+          # inputs hash are unchanged the existing value is still the true
+          # answer and rewriting it would churn a commit -- and a Vercel rebuild
+          # -- on every push to main that cannot possibly change the engine.
+          if [ -f website-oxc/wasm-pin.json ] &&
+            [ "$(jq -S 'del(.sourceCommit)' website-oxc/wasm-pin.json 2>/dev/null)" = "$(jq -S 'del(.sourceCommit)' "${pin}")" ]; then
+            echo "The published engine is unchanged; the existing pin still describes it."
+          else
+            cp "${pin}" website-oxc/wasm-pin.json
+            echo "Pinned wasm-demo-latest at inputs hash ${inputs_hash}"
+          fi
+
+      - name: Commit the pin when it changed
+        # Same reasoning as above, and one more: main can be protected or can
+        # have moved on. Neither is this job's business to turn red.
+        continue-on-error: true
+        if: >-
+          github.repository == 'tsrx-org/oxc' &&
+          github.ref_name == 'main' &&
+          hashFiles('docs/tools/demo-wasm/dist/demo-wasm.wasm') != ''
+        run: |
+          set -euo pipefail
+          git add website-oxc/wasm-pin.json
+          # Staged first so this is one question, not two: an unchanged pin and
+          # a pin that does not exist in the tree yet both answer it correctly.
+          if git diff --cached --quiet -- website-oxc/wasm-pin.json; then
+            echo "The pin is unchanged; nothing to commit, and nothing to rebuild."
+            exit 0
+          fi
+
+          # Substituted before the commit exists, so this names the source
+          # commit whose build produced the engine, not the pin commit itself.
+          short="$(git rev-parse --short HEAD)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "site: pin wasm demo engine ${short}"
+
+          # Losing a race with another push to main is ordinary, not
+          # exceptional. This commit touches one file that nothing else writes,
+          # so replaying it on top of whatever landed is always safe.
+          git fetch origin main
+          git rebase FETCH_HEAD
+          git push origin HEAD:main
 
       - name: Fetch and embed Guessless docs
         run: |

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,6 +1,13 @@
 // OXC for TSRX docs client — vanilla JS: theme, nav drawer, copy, outline,
 // search, and Navigation-API SPA routing (progressive enhancement).
 
+// This module is served as app.js?v=<hash> so a deploy never pairs fresh HTML
+// with a stale cached script. `new URL('./x.js', import.meta.url)` drops that
+// query, so every lazily imported sibling would be fetched unversioned and
+// could be served from cache forever. Re-append the search we were loaded with
+// (empty in a dev server that serves us unversioned) to every lazy import.
+const ASSET_VERSION = new URL(import.meta.url).search
+
 // ---------- theme toggle (persistent chrome) ----------
 const themeToggle = document.getElementById('theme-toggle')
 const root = document.documentElement
@@ -690,7 +697,7 @@ function initPage() {
       '[data-matrix-filter], [data-review-route], [data-editor-replay], [data-chooser]',
     )
   ) {
-    import(new URL('./interactive.js', import.meta.url))
+    import(new URL(`./interactive.js${ASSET_VERSION}`, import.meta.url))
       .then((module) => module.init(pageCleanupCallbacks))
       .catch(() => {})
   }
@@ -698,7 +705,7 @@ function initPage() {
   const demo = document.getElementById('hero-demo')
   if (demo && !demo.dataset.ready) {
     demo.dataset.ready = '1'
-    import(new URL('./playground.js', import.meta.url))
+    import(new URL(`./playground.js${ASSET_VERSION}`, import.meta.url))
       .then((module) => module.initDemo(demo))
       .catch(() => {})
   }
@@ -706,16 +713,17 @@ function initPage() {
     '.comp-row[data-key="oxlint"], .comp-row[data-key="oxcTsrx"], .comp-row[data-key="oxcTsrxMixed"]',
   )
   const chart = document.querySelector('.comp-chart')
-  if (
-    fuelRows.length &&
-    chart &&
-    !window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  ) {
+  // Reduced motion no longer skips the plume. Skipping it left those readers on
+  // the CSS fallback gradient — a visibly different chart, not a calmer one.
+  // fuel.js reads the preference itself and paints a single still frame, so the
+  // picture matches and nothing moves. WebGL being unavailable still falls all
+  // the way back to the CSS fill.
+  if (fuelRows.length && chart) {
     const io = new IntersectionObserver(
       (entries) => {
         if (!entries.some((entry) => entry.isIntersecting)) return
         io.disconnect()
-        import(new URL('./fuel.js', import.meta.url))
+        import(new URL(`./fuel.js${ASSET_VERSION}`, import.meta.url))
           .then((module) => module.init(fuelRows, pageCleanupCallbacks))
           .catch(() => {})
       },
@@ -1112,7 +1120,7 @@ let selectedIndex = -1
 function loadSearch() {
   searchReady ??= (async () => {
     const [{ default: MiniSearch }, response] = await Promise.all([
-      import(new URL('./minisearch/index.js', import.meta.url)),
+      import(new URL(`./minisearch/index.js${ASSET_VERSION}`, import.meta.url)),
       fetch(new URL('../search-index.json', import.meta.url)),
     ])
     const documents = await response.json()

--- a/docs/assets/demo-wasm-backend.js
+++ b/docs/assets/demo-wasm-backend.js
@@ -5,7 +5,9 @@
 
 let enginePromise = null
 const loadEngine = () =>
-  (enginePromise ??= import(new URL('./demo-wasm/engine.js', import.meta.url)))
+  (enginePromise ??= import(
+    new URL(`./demo-wasm/engine.js${new URL(import.meta.url).search}`, import.meta.url),
+  ))
 
 const parseJsonRequest = (body) => {
   if (typeof body === 'string' && body.trimStart().startsWith('{')) {

--- a/docs/assets/fuel.js
+++ b/docs/assets/fuel.js
@@ -83,6 +83,17 @@ gl_FragColor=vec4(ramp(clamp(heat,0.,1.))*a*d,a*mix(1.,d,uL));}`
 // and the cool lane keep the stops they had.
 const lit = () => (document.documentElement.classList.contains('dark') ? 0 : 1)
 
+// Reduced motion used to skip this module entirely, which left the CSS
+// fallback gradient showing: a different, flatter picture than everyone else
+// sees. The preference is about MOTION, not about the fire, so the shader
+// still runs — it just paints exactly one frame per bar and never starts the
+// rAF loop. Repaints on resize and on a theme swap keep that same frame.
+const still = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches
+// An arbitrary but non-zero clock: at t=0 the fbm domain sits on its lattice
+// and the plume reads unnaturally smooth, so the frozen frame is sampled from
+// mid-burn instead.
+const STILL_SECONDS = 6.5
+
 // The dark field dissolves into the track, so the canvas is transparent and the
 // shader writes premultiplied colour to match premultipliedAlpha.
 // prettier-ignore
@@ -172,13 +183,14 @@ function paint(item, seconds) {
 }
 
 export function init(rows, cleanups) {
+  const frozen = still()
   const dpr = Math.min(window.devicePixelRatio || 1, 2)
   const items = []
   for (const row of rows) {
     const item = build(row, dpr)
     if (!item) continue
     resize(item)
-    paint(item, 0)
+    paint(item, frozen ? STILL_SECONDS : 0)
     if (item.dead) continue
     item.track.append(item.canvas)
     // The CSS fill is the no-JS fallback only. Left visible it sits opaque
@@ -191,8 +203,10 @@ export function init(rows, cleanups) {
 
   const start = performance.now()
   // Wrapped: an unbounded clock eventually costs the hash its precision.
-  const clock = () => ((performance.now() - start) / 1000) % 300
-  const awake = () => items.some((it) => it.seen)
+  // Under reduced motion the clock never advances, so every repaint below
+  // reproduces the one frame already on screen.
+  const clock = () => (frozen ? STILL_SECONDS : ((performance.now() - start) / 1000) % 300)
+  const awake = () => !frozen && items.some((it) => it.seen)
   let raf = 0
 
   const frame = () => {
@@ -204,13 +218,17 @@ export function init(rows, cleanups) {
   const wake = () => {
     if (!raf && awake()) raf = requestAnimationFrame(frame)
   }
-  const io = new IntersectionObserver((entries) => {
-    for (const entry of entries) {
-      const item = items.find((it) => it.track === entry.target)
-      if (item) item.seen = entry.isIntersecting
-    }
-    wake()
-  })
+  // Visibility only matters as an animation gate, so reduced motion skips it:
+  // the single frame is already painted and nothing needs waking.
+  const io = frozen
+    ? null
+    : new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          const item = items.find((it) => it.track === entry.target)
+          if (item) item.seen = entry.isIntersecting
+        }
+        wake()
+      })
   const ro = new ResizeObserver(() => {
     for (const item of items) if (resize(item) && !raf) paint(item, clock())
   })
@@ -226,14 +244,14 @@ export function init(rows, cleanups) {
   })
   mo.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
   for (const item of items) {
-    io.observe(item.track)
+    io?.observe(item.track)
     ro.observe(item.track)
   }
 
   cleanups.push(() => {
     if (raf) cancelAnimationFrame(raf)
     raf = 0
-    io.disconnect()
+    io?.disconnect()
     ro.disconnect()
     mo.disconnect()
     for (const item of items) {

--- a/docs/assets/playground.js
+++ b/docs/assets/playground.js
@@ -3,6 +3,12 @@
 // oxfmt formatting shown as a reviewable diff, opt-in type-aware runs, rule
 // severity filters, Oxlint config, and shareable URL snippets.
 
+// app.js imports this module with the ?v=<hash> stamp it was itself loaded
+// with, but `new URL('./x.js', import.meta.url)` drops the query, so a lazy
+// sibling would be fetched unversioned and could be served stale forever.
+// Re-append our own search to every lazy import (empty when served unversioned).
+const ASSET_VERSION = new URL(import.meta.url).search
+
 const escapeHtml = (text) =>
   String(text)
     .replaceAll('&', '&amp;')
@@ -136,7 +142,9 @@ export async function initDemo(panel) {
   // (see armClientHighlighter below).
   let clientHighlighterPromise = null
   const startClientHighlighter = () =>
-    (clientHighlighterPromise ??= import(new URL('./demo-highlighter.js', import.meta.url))
+    (clientHighlighterPromise ??= import(
+      new URL(`./demo-highlighter.js${ASSET_VERSION}`, import.meta.url)
+    )
       .then((module) => module.createDemoHighlighter())
       .catch(() => null))
 
@@ -161,12 +169,12 @@ export async function initDemo(panel) {
     let realBackend = null
     let backendPromise = null
     const loadBackend = () =>
-      (backendPromise ??= import(new URL('./demo-wasm-backend.js', import.meta.url)).then(
-        (module) => {
-          realBackend = module.createWasmBackend(() => startClientHighlighter())
-          return realBackend
-        },
-      ))
+      (backendPromise ??= import(
+        new URL(`./demo-wasm-backend.js${ASSET_VERSION}`, import.meta.url)
+      ).then((module) => {
+        realBackend = module.createWasmBackend(() => startClientHighlighter())
+        return realBackend
+      }))
     backend = (endpoint, body) =>
       realBackend
         ? realBackend(endpoint, body)

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -2970,7 +2970,11 @@ html:not(.dark) .comp-track::after {
 }
 /* Static fallback plume for the treated lanes: what ships before, and instead
    of, the shader. The dark pill lives on the canvas that fuel.js sizes, never
-   on the track, so the track keeps encoding time as length in every state. */
+   on the track, so the track keeps encoding time as length in every state.
+   The stops are the shader's own ramp read core-to-tail, so the fallback is the
+   same fire flattened rather than a second palette. It used to end pink then
+   magenta, which fuel.js explicitly rules out ("orange, red and yellowish with
+   no magenta"): the two pictures disagreed wherever the fallback showed. */
 .comp-chart .comp-row[data-key='oxlint'] .comp-fill,
 .comp-chart .comp-row[data-key='oxcTsrx'] .comp-fill {
   background: linear-gradient(
@@ -2979,8 +2983,8 @@ html:not(.dark) .comp-track::after {
     #ffe066 12%,
     #ffa726 32%,
     #ff7a1a 55%,
-    #ff3a5e 78%,
-    #e912a8 100%
+    #ff3d14 78%,
+    #9c1f08 100%
   );
   mask-image: linear-gradient(90deg, #000 0%, #000 48%, transparent 100%);
 }
@@ -3212,6 +3216,11 @@ html.dark .gate-meter::after {
     #f2400f 100%
   );
 }
+/* Same ramp as light, minus the darkened core: on a dark card the near-white
+   core reads, so only the first stop differs. The tail used to run pink into
+   magenta while light's ran red into red-orange, which made one theme's meter a
+   different object from the other's — and put magenta next to a flame chart
+   that has none. */
 html.dark .gate-meter-fill {
   background-image: linear-gradient(
     90deg,
@@ -3219,8 +3228,8 @@ html.dark .gate-meter-fill {
     #ffe066 12%,
     #ffa726 32%,
     #ff7a1a 55%,
-    #ff3a5e 78%,
-    #e912a8 100%
+    #ff3d14 78%,
+    #f2400f 100%
   );
 }
 /* A failing gate is signalled by flatness plus the glyph plus the FAILING aria

--- a/docs/build.mjs
+++ b/docs/build.mjs
@@ -306,6 +306,20 @@ const assetVersionHash = createHash('sha256').update(styleSource)
 for (const entry of scriptAssets) {
   assetVersionHash.update(entry).update(await readFile(path.join(assetsDir, entry)))
 }
+// The rolldown bundles (demo-highlighter.js, demo-wasm/engine.js, the wasi
+// worker) are written straight into the site output, so their bytes cannot be
+// hashed here — hash their entry modules instead, so editing one still
+// rotates the stamp.
+for (const entry of [
+  'demo-highlighter-entry.mjs',
+  'demo-wasm-engine-entry.mjs',
+  'demo-wasm-worker-entry.mjs',
+]) {
+  const entryPath = path.join(docsDir, entry)
+  if (existsSync(entryPath)) {
+    assetVersionHash.update(entry).update(await readFile(entryPath))
+  }
+}
 const assetVersion = assetVersionHash.digest('hex').slice(0, 10)
 
 // The three page shells this site renders. Each one gets its own stylesheet.

--- a/docs/build.mjs
+++ b/docs/build.mjs
@@ -290,12 +290,23 @@ const highlightHtml = (code, lang) => highlightWith(highlighter, code, lang)
 
 // Content hash of the shared chrome assets, appended as ?v= to their URLs so
 // deployed pages never pair fresh HTML with a stale cached stylesheet.
-const styleSource = await readFile(path.join(docsDir, 'assets', 'style.css'), 'utf8')
-const assetVersion = createHash('sha256')
-  .update(styleSource)
-  .update(await readFile(path.join(docsDir, 'assets', 'app.js')))
-  .digest('hex')
-  .slice(0, 10)
+// Every shipped script is folded in, not just app.js: the modules app.js and
+// playground.js pull in lazily (interactive.js, fuel.js, demo-wasm-backend.js,
+// the minisearch bundle) inherit this same stamp through import.meta.url, so a
+// hash over app.js alone left an edit to any of them serving from cache
+// forever. Paths are sorted and hashed alongside their contents, so a rename
+// rotates the stamp too.
+const assetsDir = path.join(docsDir, 'assets')
+const styleSource = await readFile(path.join(assetsDir, 'style.css'), 'utf8')
+const scriptAssets = (await readdir(assetsDir, { recursive: true }))
+  .filter((entry) => entry.endsWith('.js') || entry.endsWith('.mjs'))
+  .map((entry) => entry.split(path.sep).join('/'))
+  .sort()
+const assetVersionHash = createHash('sha256').update(styleSource)
+for (const entry of scriptAssets) {
+  assetVersionHash.update(entry).update(await readFile(path.join(assetsDir, entry)))
+}
+const assetVersion = assetVersionHash.digest('hex').slice(0, 10)
 
 // The three page shells this site renders. Each one gets its own stylesheet.
 const CSS_SHELLS = ['doc', 'home', 'playground']

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "build:editor:check": "pnpm --filter oxc-tsrx-vscode run build --check",
     "docs:build": "node docs/build.mjs",
     "docs:wasm": "node scripts/build-docs-wasm.ts",
+    "docs:wasm:fetch": "node scripts/fetch-docs-wasm.ts",
     "docs:transcripts": "node docs/generate-transcripts.mjs",
     "docs:serve": "node docs/serve.mjs",
     "docs:verify": "node docs/verify.mjs",

--- a/scripts/fetch-docs-wasm.ts
+++ b/scripts/fetch-docs-wasm.ts
@@ -1,0 +1,221 @@
+// Put the playground's WebAssembly demo engine in place for a build that cannot
+// compile it.
+//
+// https://oxc.tsrx.dev is a Vercel project rooted at website-oxc/, built by
+// Vercel's own git integration on Vercel's image. That image has no cargo and no
+// wasm32-wasip1-threads target, so `pnpm run docs:wasm` can never run there. The
+// engine is instead built and *proved* once, on GitHub Actions, and published to
+// the rolling `wasm-demo-latest` release; the same workflow commits a pin
+// (website-oxc/wasm-pin.json) naming the exact bytes it published. That commit
+// is what tells Vercel to rebuild, and this script is what turns the pin back
+// into files:
+//
+//   .github/workflows/site-artifact.yml   builds, proves, uploads, pins
+//   website-oxc/wasm-pin.json             tag + inputs hash + sha256 of each byte
+//   this script                           downloads and verifies against the pin
+//
+// Two rules shape everything below.
+//
+// It never fails the site build. A missing pin, a pin describing a different
+// source tree, a download that will not come, bytes that do not match their
+// hash: each one prints one line and exits 0. docs/build.mjs detects the engine
+// by the presence of docs/tools/demo-wasm/dist/demo-wasm.wasm and renders the
+// static preview contract without it (docs/build.mjs, `wasmDemo`), so the
+// correct degradation is a site that builds and says the demo is unavailable --
+// never a red deploy.
+//
+// It refuses bytes that do not belong to this source tree. The pin carries a
+// hash of the sources the engine is compiled from; if this checkout hashes
+// differently, the released engine is from other source and is not downloaded.
+// That check is why the hash lives here rather than in the workflow: the
+// workflow authors the pin by calling this same file with --print-inputs-hash,
+// so the two definitions cannot drift.
+//
+// Deliberately repo-only: the hash covers tracked source, not the rustc that
+// compiled it. Vercel's builder cannot know which compiler CI used, and it does
+// not need to -- the pin's sha256s are the byte-level truth, and the hash only
+// answers the coarser question of whether these bytes were built from this tree.
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const pinPath = "website-oxc/wasm-pin.json";
+const outputDir = "docs/tools/demo-wasm/dist";
+const releaseBase = "https://github.com/tsrx-org/oxc/releases/download";
+
+// Both files land in docs/tools/demo-wasm/dist/ and neither is optional: the
+// engine bundle reaches the worker through a relative URL that the worker entry
+// hard-codes as a sibling of the binary (docs/demo-wasm-worker-entry.mjs).
+const assets = [
+  { field: "wasm", name: "demo-wasm.wasm" },
+  { field: "worker", name: "wasi-worker-browser.mjs" },
+];
+
+// Every input the compiled engine is a function of, as tracked source. The
+// demo-wasm crate itself, the three tsrx_* crates it links, and the toolchain
+// file that picks the compiler.
+const hashPatterns = [
+  "docs/tools/demo-wasm/**",
+  "crates/tsrx_format/**",
+  "crates/tsrx_lint/**",
+  "crates/tsrx_syntax/**",
+  "rust-toolchain.toml",
+];
+
+// Build output, never source. docs/tools/demo-wasm/.gitignore ignores exactly
+// these three names, so skipping them here is the same set of files `git
+// ls-files` would report -- computed without needing a .git directory, which a
+// Vercel build does not have.
+const hashIgnore = ["**/dist/**", "**/node_modules/**", "**/target/**", "**/.DS_Store"];
+
+// A reason to leave the playground on its static preview, as opposed to a fault.
+class Skip extends Error {}
+
+function describe(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function computeInputsHash() {
+  // Imported here rather than at module scope so that a checkout whose
+  // dependencies are missing degrades into a skip instead of a crash.
+  const { glob } = await import("tinyglobby");
+  const files = await glob(hashPatterns, {
+    cwd: root,
+    dot: true,
+    absolute: false,
+    onlyFiles: true,
+    followSymbolicLinks: false,
+    ignore: hashIgnore,
+  });
+  if (files.length === 0) {
+    throw new Error(`no engine sources found under ${root}`);
+  }
+  // Path and content both, so that a rename is a different hash. Sorted by code
+  // unit, which is stable across platforms and locales, unlike readdir order.
+  files.sort();
+  const digest = createHash("sha256");
+  for (const file of files) {
+    const contents = await readFile(join(root, file));
+    digest.update(file);
+    digest.update("\0");
+    digest.update(createHash("sha256").update(contents).digest("hex"));
+    digest.update("\n");
+  }
+  return digest.digest("hex");
+}
+
+async function readPin() {
+  let source;
+  try {
+    source = await readFile(join(root, pinPath), "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Skip(
+        `no ${pinPath} yet -- no run of site-artifact.yml has published an engine for this site`,
+      );
+    }
+    throw error;
+  }
+  let pin;
+  try {
+    pin = JSON.parse(source);
+  } catch (error) {
+    throw new Skip(`${pinPath} is not valid JSON: ${describe(error)}`);
+  }
+  if (typeof pin?.tag !== "string" || pin.tag === "") {
+    throw new Skip(`${pinPath} names no release tag`);
+  }
+  if (typeof pin.inputsHash !== "string" || pin.inputsHash === "") {
+    throw new Skip(`${pinPath} carries no inputs hash`);
+  }
+  for (const asset of assets) {
+    const entry = pin[asset.field];
+    if (typeof entry?.sha256 !== "string" || entry.sha256 === "" || !Number.isInteger(entry.bytes)) {
+      throw new Skip(`${pinPath} does not describe ${asset.name}`);
+    }
+  }
+  return pin;
+}
+
+async function download(url, expected, name) {
+  let response;
+  try {
+    // A build must not hang on a download it can do without.
+    response = await fetch(url, { redirect: "follow", signal: AbortSignal.timeout(120_000) });
+  } catch (error) {
+    throw new Skip(`${name} could not be downloaded: ${describe(error)}`);
+  }
+  if (!response.ok) {
+    throw new Skip(`${url} responded ${response.status} ${response.statusText}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length !== expected.bytes) {
+    throw new Skip(`${name} is ${bytes.length} bytes, the pin says ${expected.bytes}`);
+  }
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  if (sha256 !== expected.sha256) {
+    throw new Skip(`${name} hashes to ${sha256}, the pin says ${expected.sha256}`);
+  }
+  return bytes;
+}
+
+async function fetchPinnedEngine() {
+  const pin = await readPin();
+
+  let inputsHash;
+  try {
+    inputsHash = await computeInputsHash();
+  } catch (error) {
+    throw new Skip(`the engine sources could not be hashed: ${describe(error)}`);
+  }
+  if (inputsHash !== pin.inputsHash) {
+    throw new Skip(
+      `${pinPath} pins an engine built from other source ` +
+        `(pinned ${pin.inputsHash.slice(0, 12)}, this checkout ${inputsHash.slice(0, 12)})`,
+    );
+  }
+
+  // Downloaded and verified in full before anything is written, so that a
+  // failure half way through cannot leave a partial engine on disk for
+  // docs/build.mjs to find and believe.
+  const downloaded = [];
+  for (const asset of assets) {
+    downloaded.push({
+      ...asset,
+      bytes: await download(`${releaseBase}/${pin.tag}/${asset.name}`, pin[asset.field], asset.name),
+    });
+  }
+
+  await mkdir(join(root, outputDir), { recursive: true });
+  for (const asset of downloaded) {
+    await writeFile(join(root, outputDir, asset.name), asset.bytes);
+  }
+
+  const sizes = downloaded.map((asset) => `${asset.name} ${asset.bytes.length} bytes`).join(", ");
+  const commit = typeof pin.sourceCommit === "string" ? pin.sourceCommit.slice(0, 7) : "unknown";
+  console.log(
+    `fetch-docs-wasm: demo engine in place from ${pin.tag} (${sizes}), built from ${commit}`,
+  );
+}
+
+const options = process.argv.slice(2);
+const printInputsHash = options.length === 1 && options[0] === "--print-inputs-hash";
+if (options.length > 0 && !printInputsHash) {
+  throw new Error(`unsupported option(s): ${options.join(", ")}`);
+}
+
+if (printInputsHash) {
+  // The workflow's half of the contract. Failure here must be loud: a pin
+  // written with a wrong hash is a pin no site build will ever accept.
+  process.stdout.write(`${await computeInputsHash()}\n`);
+} else {
+  try {
+    await fetchPinnedEngine();
+  } catch (error) {
+    const reason = error instanceof Skip ? error.message : `unexpected failure: ${describe(error)}`;
+    console.log(`fetch-docs-wasm: no demo engine, ${reason}`);
+    console.log("fetch-docs-wasm: the playground will render its static preview instead.");
+  }
+}

--- a/tests/release/launch-contract.test.mjs
+++ b/tests/release/launch-contract.test.mjs
@@ -153,7 +153,17 @@ test("launch manifest names every byte set and keeps external actions approval-g
     workflow,
     /configure-pages|upload-pages-artifact|deploy-pages|github-pages/iu,
   );
-  assert.doesNotMatch(workflow, /npm publish|vsce publish|git push|curl .*social/iu);
+  assert.doesNotMatch(workflow, /npm publish|vsce publish|curl .*social/iu);
+  // The one git push this workflow is allowed is the wasm-pin commit that
+  // retriggers the oxc.tsrx.dev Vercel build; anything else pushing from the
+  // site workflow is still a contract violation.
+  const sitePushes = workflow.match(/git push/gu) ?? [];
+  assert.equal(sitePushes.length, 1, "site-artifact.yml may push only the wasm pin");
+  assert.match(
+    workflow,
+    /wasm-pin\.json[\s\S]{0,3000}git push|git push[\s\S]{0,3000}wasm-pin\.json/u,
+    "the sole git push must belong to the wasm-pin step",
+  );
 });
 
 test("all platform-independent npm payloads pass pack dry-run", async () => {

--- a/website-oxc/README.md
+++ b/website-oxc/README.md
@@ -1,0 +1,70 @@
+# website-oxc
+
+Vercel project root for the docs site at **https://oxc.tsrx.dev**, following the
+`website-tsrx` convention in [tsrx-org/tsrx](https://github.com/tsrx-org/tsrx/tree/main/website-tsrx).
+
+The site itself is generated from `../docs` by `docs/build.mjs`. This folder holds
+no content — `vercel.json` drives the build: install the workspace at the repo
+root, run the docs generator with `SITE_ORIGIN=https://oxc.tsrx.dev SITE_BASE=/`
+(the same generator that publishes https://compiled.run/oxc-tsrx, just rooted at
+`/`), and serve the output from `dist/`.
+
+## One-time Vercel setup
+
+1. Create a Vercel project from this repository with **Root Directory: `website-oxc`**
+   and Framework Preset **Other**. `vercel.json` supplies the install/build/output
+   settings.
+2. Add the domain **oxc.tsrx.dev** to the project (DNS per Vercel's instructions).
+3. Deploy. No repository secrets or variables are required for this path.
+
+## The playground's WASM demo engine
+
+The playground can run the real lint, format, and projection engines in the
+browser, compiled to WebAssembly. Vercel's builder cannot produce that artifact:
+it has no cargo and no `wasm32-wasip1-threads` target, so `pnpm run docs:wasm`
+is not an option here. The engine reaches this build as prebuilt bytes instead.
+
+1. `.github/workflows/site-artifact.yml` builds the engine on GitHub Actions and
+   proves it — the site build runs with `OXC_TSRX_REQUIRE_WASM=1` and the static
+   verifier runs with `--require-wasm`, so nothing unproven is ever published.
+2. On `main`, that workflow uploads the two files the engine needs
+   (`demo-wasm.wasm` and `wasi-worker-browser.mjs`) to the rolling
+   [`wasm-demo-latest`](https://github.com/tsrx-org/oxc/releases/tag/wasm-demo-latest)
+   release, which is a delivery channel and not something to install.
+3. It then writes `wasm-pin.json` here — the release tag, a hash of the sources
+   the engine was compiled from, and the sha256 and byte count of each file —
+   and commits it only when that content changed. That commit is also the
+   trigger: a push by `GITHUB_TOKEN` starts no further Actions run, but it does
+   reach Vercel's webhook, so the pin and the deploy that consumes it arrive
+   together.
+4. `pnpm run build` here runs `../scripts/fetch-docs-wasm.ts` first, which reads
+   the pin, recomputes the source hash against this checkout, downloads both
+   files into `docs/tools/demo-wasm/dist/`, and verifies them byte for byte.
+
+The pin is what keeps this honest. The hash covers `docs/tools/demo-wasm`, the
+`tsrx_format`, `tsrx_lint`, and `tsrx_syntax` crates, and `rust-toolchain.toml`,
+computed by the same code in `scripts/fetch-docs-wasm.ts` that the workflow calls
+to author the pin — one definition, so the two cannot drift. A released engine
+built from different source than the commit being deployed therefore fails the
+check rather than shipping.
+
+**None of this can fail the build.** A missing pin, a pin describing other
+source, a download that does not arrive, or bytes that do not match their
+sha256: each prints one line explaining itself and exits 0. `docs/build.mjs`
+detects the engine by whether the artifact is on disk, so without it the
+playground page renders and reports that the demo engine is unavailable, exactly
+as it did before this mechanism existed. Everything else on the site is
+identical. Getting a stale engine, or a wrong one, would be worse than getting
+none — so the degradation is deliberate, and the failure mode is a site that
+builds.
+
+You can exercise the fetch by hand from the repo root with
+`pnpm run docs:wasm:fetch`; contributors with a Rust toolchain can keep building
+the engine locally with `pnpm run docs:wasm` instead.
+
+## Notes
+
+- The GitHub-Actions deploy path in `.github/workflows/site-artifact.yml`
+  (`deploy-tsrx-dev` job, see `docs/releasing/site-oxc-tsrx-dev.md`) is an
+  alternative that ships the WASM artifact too; either can own the domain —
+  pick one to avoid competing deploys.

--- a/website-oxc/package.json
+++ b/website-oxc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "website-oxc",
+  "private": true,
+  "description": "Vercel project root for https://oxc.tsrx.dev — builds the docs site from ../docs with a root base path",
+  "scripts": {
+    "build": "node ../scripts/fetch-docs-wasm.ts && cd .. && SITE_ORIGIN=https://oxc.tsrx.dev SITE_BASE=/ node docs/build.mjs && rm -rf website-oxc/dist && cp -R docs/dist website-oxc/dist"
+  },
+  "engines": {
+    "node": "24.x"
+  }
+}


### PR DESCRIPTION
Two things, both aimed at the oxc.tsrx.dev deploy:

## WASM demo engine on the Vercel build
The folder-based Vercel build can't compile the engine (no cargo). Now: CI's site workflow, after proving the artifact it already builds, uploads `demo-wasm.wasm` + `wasi-worker-browser.mjs` to the rolling `wasm-demo-latest` release and commits a ~200-byte `website-oxc/wasm-pin.json` (repo-only inputs hash + sha256s). That pin commit is also the Vercel trigger. `scripts/fetch-docs-wasm.ts` runs first in the `website-oxc` build: verifies the pin against the sources it sits next to and the downloaded bytes, and on ANY mismatch or network failure skips cleanly to today's static preview — it can never redden a build or ship a stale engine. All skip paths and the success path exercised offline; the pin-authoring logic dry-run four ways (new/unchanged/changed/corrupt).

`launch-contract.test.mjs` now permits exactly one `git push` in the site workflow and requires it to be the wasm-pin step (publishes and social calls stay banned).

## Asset caching + flames
- `assetVersion` hashed only `style.css`+`app.js`, and `new URL()` drops `?v=` on dynamic imports — so `fuel.js`, `playground.js`, `interactive.js`, `demo-wasm-backend.js` shipped unversioned under `max-age=3600, immutable`: a returning visitor could run hour-stale JS against fresh HTML and see the silent fallback chips. Now every asset script (plus the rolldown entry modules) rotates the stamp, and the version is threaded through all lazy imports including the engine import.
- Reduced-motion users used to get the gradient chips (this is what the "broken flames" screenshot was — the WebGL is fine on both deploys, verified in headless Chrome). Now `fuel.js` paints one static flame frame and skips the animation loop instead.
- The CSS fallback gradient (and the dark gate meter) dropped their magenta stop for the shader's own warm ramp.

Verified: `test:release` green, `website-oxc` build green end-to-end (fetch skip path → docs build → dist), default compiled.run build unchanged.

Bootstrap after merge: one `workflow_dispatch` of `site-artifact.yml` on main publishes the first engine + pin; the pin commit triggers the Vercel rebuild.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now pushes pins to `main` and grants workflow `contents: write`, but publish/commit steps are gated, non-blocking, and isolated from the primary compiled.run deploy; fetch failures degrade safely to static preview.
> 
> **Overview**
> **WASM on Vercel (oxc.tsrx.dev)** — After CI proves the demo engine, `site-artifact.yml` uploads `demo-wasm.wasm` and `wasi-worker-browser.mjs` to the rolling `wasm-demo-latest` release, writes `website-oxc/wasm-pin.json` (inputs hash + sha256s), and commits it on `main` when the pin changes (`continue-on-error`, scoped `contents: write`; PR `site-tests` stays read-only). New `scripts/fetch-docs-wasm.ts` runs first in the `website-oxc` build: verifies the pin against this tree and downloaded bytes, or exits 0 and leaves the static playground preview. `docs:wasm:fetch` and release-contract tests allow exactly one workflow `git push` for the pin step.
> 
> **Cache busting** — `assetVersion` in `docs/build.mjs` now covers every shipped `.js`/`.mjs` under `docs/assets` plus rolldown entry modules, and lazy imports in `app.js`, `playground.js`, and `demo-wasm-backend.js` re-append the parent script’s `?v=` query so siblings cannot load stale from cache.
> 
> **Benchmark flames** — `fuel.js` still runs under `prefers-reduced-motion` but freezes at one sampled frame and skips the animation loop; `app.js` always loads it. CSS fallback plumes and dark gate-meter gradients drop magenta tails to match the shader ramp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8a28a6a76a9e4e2f461202acf411f64e5e7b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->