### PR TITLE
Lazy arrow parameters: merge main and fix lookahead defects (#36 fix-up)

### DIFF
--- a/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use super::{
-    access::{field_value, has_type, list_field, object_field, scalar_u32},
+    access::{field_value, has_type, list_field, scalar_u32},
     edits::append_node_head,
     objects::find_unique_start,
     spans::{AuthoredStart, record_authored_span},
@@ -178,32 +178,61 @@ fn declarator_for_pattern(
     pattern: RecordIndex,
     parents: &ParentIndex,
 ) -> Result<Option<RecordIndex>, TsrxParseError> {
-    let parent = parents
-        .parent_container(tsrx_tape_schema::ValueRef::object(pattern))
-        .ok_or(TsrxParseError::Unsupported("lazy pattern has no parent"))?;
-    if let Some(declarator) = parent.as_object() {
-        if has_type(tape, declarator, r#""VariableDeclarator""#)
-            && object_field(tape, declarator, "id")? == pattern
-        {
-            return Ok(Some(declarator));
+    let mut child = ValueRef::object(pattern);
+    loop {
+        let parent = parents
+            .parent_container(child)
+            .ok_or(TsrxParseError::Unsupported("lazy pattern has no binding owner"))?;
+        if let Some(owner) = parent.as_object() {
+            let owner_type = super::access::object_type(tape, owner);
+            if owner_type == Some(r#""VariableDeclarator""#)
+                && field_value(tape, owner, "id")? == child
+            {
+                return Ok(Some(owner));
+            }
+            let binding_child = match owner_type {
+                Some(r#""AssignmentPattern""#) => field_value(tape, owner, "left")?,
+                Some(r#""RestElement""#) => field_value(tape, owner, "argument")?,
+                Some(r#""Property""#) => field_value(tape, owner, "value")?,
+                _ => {
+                    return Err(TsrxParseError::Unsupported(
+                        "lazy pattern has an unsupported binding parent",
+                    ));
+                }
+            };
+            if binding_child != child {
+                return Err(TsrxParseError::Unsupported(
+                    "lazy pattern is outside the binding side of its parent",
+                ));
+            }
+            child = parent;
+            continue;
         }
-        return Err(TsrxParseError::Unsupported("lazy pattern has an unsupported object parent"));
+
+        let list = parent
+            .as_list()
+            .ok_or(TsrxParseError::Unsupported("lazy pattern parent is not a binding list"))?;
+        let owner = parents
+            .parent_container(ValueRef::list(list))
+            .and_then(ValueRef::as_object)
+            .ok_or(TsrxParseError::Unsupported("lazy pattern list has no owner"))?;
+        match super::access::object_type(tape, owner) {
+            Some(
+                r#""FunctionDeclaration""#
+                | r#""FunctionExpression""#
+                | r#""ArrowFunctionExpression""#,
+            ) if list_field(tape, owner, "params")? == list => return Ok(None),
+            Some(r#""ObjectPattern""#) if list_field(tape, owner, "properties")? == list => {
+                child = ValueRef::object(owner);
+            }
+            Some(r#""ArrayPattern""#) if list_field(tape, owner, "elements")? == list => {
+                child = ValueRef::object(owner);
+            }
+            _ => {
+                return Err(TsrxParseError::Unsupported(
+                    "lazy pattern list is not part of a binding pattern",
+                ));
+            }
+        }
     }
-    let list =
-        parent.as_list().ok_or(TsrxParseError::Unsupported("lazy pattern parent is not a list"))?;
-    let function = parents
-        .parent_container(tsrx_tape_schema::ValueRef::list(list))
-        .and_then(tsrx_tape_schema::ValueRef::as_object)
-        .ok_or(TsrxParseError::Unsupported("lazy parameter has no function parent"))?;
-    if !matches!(
-        super::access::object_type(tape, function),
-        Some(
-            r#""FunctionDeclaration""# | r#""FunctionExpression""# | r#""ArrowFunctionExpression""#
-        )
-    ) {
-        return Err(TsrxParseError::Unsupported(
-            "lazy pattern list is not a function parameter list",
-        ));
-    }
-    Ok(None)
 }

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -422,6 +422,125 @@ fn lazy_arrow_lookahead_reads_a_function_return_type_as_part_of_the_annotation()
 }
 
 #[test]
+fn lazy_arrow_lookahead_stops_at_a_parenthesised_function_type() {
+    // `((x: number) => number)` carries its own arrow inside the parentheses, so the `=>` that
+    // follows the annotation is the lazy arrow's and the parameter has to commit.
+    let source = "const wrap = (&{ a }): ((x: number) => number) => (x) => x + a;\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("parenthesised function type overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("parenthesised function type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("parenthesised function type");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+
+    // The same annotation over a method keeps its `{ … }` body, so nothing may commit.
+    let source = "const helpers = {\n\
+        build(&{ a }): ((x: number) => number) { return (x) => x + a }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("parenthesised method type overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("parenthesised method type projection");
+    assert!(projection.source().contains("build(&{ a })"));
+
+    // A parameter list whose own parameter is annotated with a function type is still a function
+    // head, so its trailing `=>` belongs to the annotation rather than to the arrow.
+    let source = "const helpers = {\n\
+        chain(&{ a }): (step: (x: number) => number) => number { return (step) => step(a) }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("nested function type overlay");
+    let projection = project_for_parser(source, &overlay).expect("nested function type projection");
+    assert!(projection.source().contains("chain(&{ a })"));
+
+    // The completed function type still takes the postfix and union continuations that follow any
+    // other type, and a constructor type's parameter list remains a function head.
+    let source = "const union = (&{ a }): ((x: number) => number) | null => null;\n\
+        const array = (&{ b }): ((x: number) => number)[] => [];\n\
+        const made = (&{ c }): new (x: number) => number => c;";
+    let overlay = scan_for_parser(source).expect("completed function type overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("completed function type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+    assert!(!projection.source().contains("(&{ b }"));
+    assert!(!projection.source().contains("(&{ c }"));
+}
+
+#[test]
+fn parameter_type_intersections_are_not_queued_as_lazy_patterns() {
+    let source = "const pick = (x: &{ a: number }) => x;\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("intersection annotation overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("intersection annotation projection");
+    assert!(projection.source().contains("(x: &{ a: number })"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("intersection annotation");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 0);
+    assert_no_scaffold(tape);
+
+    // The same holds for an intersection whose left member closed with `}`, and beside a
+    // parameter that really does carry a lazy pattern.
+    let source = "const mix = (&{ a }, x: { b: number }&{ c: string }) => [a, x];";
+    let overlay = scan_for_parser(source).expect("mixed intersection overlay");
+    let projection = project_for_parser(source, &overlay).expect("mixed intersection projection");
+    assert!(!projection.source().contains("(&{ a }"));
+    assert!(projection.source().contains("{ b: number }&{ c: string }"));
+
+    // The rename form that made `:` an admitting predecessor still queues its pattern.
+    let source = "const rename = ({ a: &{ b } }) => b;";
+    let overlay = scan_for_parser(source).expect("rename overlay");
+    let projection = project_for_parser(source, &overlay).expect("rename projection");
+    assert!(!projection.source().contains("a: &{ b }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("destructuring rename");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn lazy_arrow_lookahead_reads_an_import_type_return_annotation() {
+    let source = "const load = (&{ a }): import(\"mod\").Shape => a;\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("import type overlay");
+    let projection = project_for_parser(source, &overlay).expect("import type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("import type return annotation");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+
+    // An import type over a method still leaves the `{ … }` body outside the annotation.
+    let source = "const helpers = {\n\
+        load(&{ a }): import(\"mod\").Shape { return a }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("import type method overlay");
+    let projection = project_for_parser(source, &overlay).expect("import type method projection");
+    assert!(projection.source().contains("load(&{ a })"));
+}
+
+fn lazy_pattern_count(tape: &FlatTape) -> usize {
+    (0..tape.object_count())
+        .map(|raw| RecordIndex::new(u32::try_from(raw).expect("object index")))
+        .filter(|object| {
+            tape.field_index(*object, "type")
+                .and_then(|field| tape.field_value(field))
+                .and_then(|value| tape.scalar(value))
+                .is_some_and(|kind| matches!(kind, r#""ArrayPattern""# | r#""ObjectPattern""#))
+                && tape.field_index(*object, "lazy").is_some()
+        })
+        .count()
+}
+
+#[test]
 fn rest_lazy_parameters_admit_trivia_between_the_spread_and_the_pattern() {
     let source = "const gather = (head: string, ... /* gap */ &{ a, b }) => [head, a, b];\n\
         const spread = (lead: string, ... // gap\n\

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -277,6 +277,41 @@ fn lazy_destructuring_patterns_preserve_markers_in_declarations_and_for_headers(
 }
 
 #[test]
+fn lazy_arrow_parameters_preserve_patterns_types_defaults_and_async_arrows() {
+    let source = "const View = (&{ name, title = name }: Props): string => title;\n\
+        const select = async (prefix: string, /* gap */ &[first, ...rest]: Items = items) => [prefix, first, rest];\n\
+        const nested = (&{ user: &{ id } }: Props) => id;\n\
+        const bitwise = (value = source&{ value: 1 }) => value;";
+    let overlay = scan_for_parser(source).expect("lazy arrow overlay");
+    let projection = project_for_parser(source, &overlay).expect("lazy arrow projection");
+    assert!(!projection.source().contains("(&{ name"));
+    assert!(!projection.source().contains("/* gap */ &[first"));
+    assert!(!projection.source().contains("&{ user:"));
+    assert!(!projection.source().contains("user: &{ id"));
+    assert!(projection.source().contains("source&{ value: 1 }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("lazy arrow parameters");
+    let tape = result.program();
+    let patterns = (0..tape.object_count())
+        .map(|raw| RecordIndex::new(u32::try_from(raw).expect("object index")))
+        .filter(|object| {
+            tape.field_index(*object, "type")
+                .and_then(|field| tape.field_value(field))
+                .and_then(|value| tape.scalar(value))
+                .is_some_and(|kind| matches!(kind, r#""ArrayPattern""# | r#""ObjectPattern""#))
+                && tape.field_index(*object, "lazy").is_some()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(patterns.len(), 4);
+    for pattern in patterns {
+        assert_eq!(scalar_field(tape, pattern, "lazy"), "true");
+        let (pattern_start, _) = span(tape, pattern);
+        assert_eq!(source.as_bytes()[usize::try_from(pattern_start - 1).expect("offset")], b'&');
+    }
+    assert_no_scaffold(tape);
+}
+
+#[test]
 fn standalone_lazy_assignment_statements_match_the_estree_shape_and_authored_spans() {
     let source = "&{ value, ...rest } = object;\n&[first, ...tail] = items;";
     let overlay = scan_for_parser(source).expect("standalone lazy assignment overlay");

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -471,6 +471,61 @@ fn lazy_arrow_lookahead_stops_at_a_parenthesised_function_type() {
 }
 
 #[test]
+fn optional_parameter_markers_in_a_function_type_do_not_open_a_conditional_type() {
+    // `step?` is an untyped optional parameter, so the `:` that follows belongs to `next`'s
+    // annotation. Reading the `?` as a conditional type would spend that `:` on a branch and let
+    // the inner `=>` complete the type, which would misread the method's annotation as an arrow
+    // and commit a marker that has no arrow to commit to.
+    let source = "const helpers = {\n\
+        chain(&{ a }): (step?, next: (x: number) => number) => number { return (s, n) => n(a) }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("optional parameter method overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("optional parameter method projection");
+    assert!(projection.source().contains("chain(&{ a })"));
+
+    // The arrow counterpart ends the same annotation at the `=>` that really is the lazy arrow's,
+    // so its marker still has to commit.
+    let source = "const build = (&{ a }): (step?, next: (x: number) => number) => number =>\n\
+        (s, n) => n(a);\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("optional parameter arrow overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("optional parameter arrow projection");
+    assert!(!projection.source().contains("(&{ a }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("optional parameter arrow");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+
+    // An optional parameter closing the list directly reads the same way on both sides.
+    let source = "const helpers = {\n\
+        last(&{ a }): (step?) => number { return (s) => a }\n\
+        }\n\
+        const only = (&{ b }): (step?) => number => (s) => b;";
+    let overlay = scan_for_parser(source).expect("trailing optional parameter overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("trailing optional parameter projection");
+    assert!(projection.source().contains("last(&{ a })"));
+    assert!(!projection.source().contains("(&{ b }"));
+
+    // A `?` with a type after it still opens a conditional type, whose `:` spends the branch
+    // rather than opening an annotation, so the `=>` inside completes the type and the `=>` that
+    // follows the whole annotation is the arrow's.
+    let source = "const pick = (&{ a }): (A extends B ? C : (x: T) => U) => a;\n\
+        const helpers = {\n\
+        pick(&{ b }): (A extends B ? C : (x: T) => U) { return b }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("conditional type overlay");
+    let projection = project_for_parser(source, &overlay).expect("conditional type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+    assert!(projection.source().contains("pick(&{ b })"));
+}
+
+#[test]
 fn parameter_type_intersections_are_not_queued_as_lazy_patterns() {
     let source = "const pick = (x: &{ a: number }) => x;\n\
         const run = (value) => value";

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -319,41 +319,50 @@ impl Scanner<'_> {
             .map(|_| pattern_start)
     }
 
+    /// `inside_parentheses` says the innermost group still open is a `(` one. A statement cannot
+    /// start there — only a `for` header's `;` reaches statement position inside parentheses — so
+    /// the predecessors that are ambiguous between a statement boundary and a type do not admit
+    /// the sigil: `:` opens a parameter's annotation and `}` closes an object type in one.
     pub(super) fn standalone_lazy_pattern_start(
         &self,
         ampersand: usize,
         statement_context: bool,
+        inside_parentheses: bool,
     ) -> Option<usize> {
         let pattern_start = ampersand.checked_add(1)?;
         if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{')) {
             return None;
         }
         let previous = previous_significant_byte(self.bytes, ampersand);
-        if previous.is_none()
-            || matches!(previous, Some(b';' | b'{' | b'}' | b':'))
-            || statement_context
-        {
-            Some(pattern_start)
-        } else {
-            None
-        }
+        let admitted = previous.is_none()
+            || previous == Some(b';')
+            || matches!(previous, Some(b'{' | b'}' | b':')) && !inside_parentheses
+            || statement_context;
+        admitted.then_some(pattern_start)
     }
 
+    /// `pattern_interior` says the innermost group still open at the ampersand is an object or
+    /// array one, so the position is inside a binding pattern rather than directly in the
+    /// parameter list. It is what separates the two meanings of a preceding `:`.
     pub(super) fn lazy_arrow_pattern_start(
         &self,
         ampersand: usize,
         parameter_open: Option<usize>,
         previous_token: Option<u8>,
+        pattern_interior: bool,
     ) -> Option<usize> {
         parameter_open?;
         let pattern_start = ampersand.checked_add(1)?;
-        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{'))
-            || !(matches!(previous_token, Some(b'(' | b'[' | b'{' | b',' | b':'))
-                || self.follows_rest_spread(ampersand))
-        {
+        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{')) {
             return None;
         }
-        Some(pattern_start)
+        // A `:` inside a pattern renames into a nested lazy pattern (`{ a: &{ b } }`). The same
+        // `:` written directly in the parameter list opens a type annotation instead, and a type
+        // may perfectly well lead with the intersection `&` of an object type.
+        let admitted = matches!(previous_token, Some(b'(' | b'[' | b'{' | b','))
+            || (previous_token == Some(b':') && pattern_interior)
+            || self.follows_rest_spread(ampersand);
+        admitted.then_some(pattern_start)
     }
 
     /// `...&{ … }` is a rest lazy parameter, so the spread's own `.` has to admit the pattern the
@@ -462,12 +471,21 @@ impl Scanner<'_> {
             let byte = *self.bytes.get(index)?;
             // Only a parenthesised parameter list can carry a function type's `=>`; every other
             // way of reaching a `=>` means the type already ended.
-            let mut function_head = byte == b'(';
+            let mut function_head = false;
+            // `import("mod")` is the one type form whose name takes a call-like group.
+            let mut import_head = false;
             match byte {
-                b'(' | b'[' | b'{' => index = self.skip_type_group(index)?,
+                b'(' | b'[' | b'{' => {
+                    let group = self.skip_type_group(index)?;
+                    index = group.end;
+                    // A parenthesised group holding its own top-level `=>` is already a complete
+                    // function type — `((x: T) => U)` — rather than the parameter list opening
+                    // one, so the `=>` after it belongs to whatever follows the annotation.
+                    function_head = byte == b'(' && !group.complete_function_type;
+                }
                 // Type parameters lead a generic function type, whose parameter list is the type.
                 b'<' => {
-                    index = self.skip_type_group(index)?;
+                    index = self.skip_type_group(index)?.end;
                     continue;
                 }
                 // A leading `|` or `&`, and a numeric literal's sign, carry no type of their own.
@@ -480,7 +498,9 @@ impl Scanner<'_> {
                 b'0'..=b'9' => index = self.skip_number(index),
                 _ if self.identifier_start_width(index).is_some() => {
                     let end = self.skip_identifier(index);
-                    let leads_a_type = TYPE_PREFIX_KEYWORDS.contains(&&self.bytes[index..end]);
+                    let name = &self.bytes[index..end];
+                    let leads_a_type = TYPE_PREFIX_KEYWORDS.contains(&name);
+                    import_head = matches!(name, b"import");
                     index = end;
                     if leads_a_type {
                         continue;
@@ -492,8 +512,11 @@ impl Scanner<'_> {
             loop {
                 let next = self.skip_trivia(index).ok()?;
                 match self.bytes.get(next) {
+                    // The module specifier of `import("mod").T`, the only call-like group a type
+                    // may take. Its qualified name and type arguments continue below as usual.
+                    Some(b'(') if import_head => index = self.skip_type_group(next)?.end,
                     // `T[]`, `T[K]`, and `T<Args>` all extend the type they follow.
-                    Some(b'[' | b'<') => index = self.skip_type_group(next)?,
+                    Some(b'[' | b'<') => index = self.skip_type_group(next)?.end,
                     // A qualified name: `A.B.C`.
                     Some(b'.') => {
                         let name = self.skip_trivia(next + 1).ok()?;
@@ -505,6 +528,7 @@ impl Scanner<'_> {
                     _ => break,
                 }
                 function_head = false;
+                import_head = false;
             }
 
             let next = self.skip_trivia(index).ok()?;
@@ -544,10 +568,18 @@ impl Scanner<'_> {
     /// opaque. A closer that does not match, and a `;` inside an angle group, both mean the group
     /// was never a group — most often a `<` that was really a comparison — and end the scan rather
     /// than let it run away through the rest of the file.
-    fn skip_type_group(&self, open: usize) -> Option<usize> {
-        let mut closers = vec![group_close(*self.bytes.get(open)?)?];
+    fn skip_type_group(&self, open: usize) -> Option<TypeGroup> {
+        let open_byte = *self.bytes.get(open)?;
+        let parenthesised = open_byte == b'(';
+        let mut closers = vec![group_close(open_byte)?];
+        // A `=>` written directly in a parenthesised group belongs to a parameter's annotation
+        // when a `:` has already opened one, and to the group's own function type otherwise.
+        let mut annotated = false;
+        let mut conditionals = 0_u32;
+        let mut complete_function_type = false;
         let mut index = open + 1;
         while let Some(&byte) = self.bytes.get(index) {
+            let outermost = parenthesised && closers.len() == 1;
             match byte {
                 b'\'' | b'"' => index = self.skip_quote(index, byte).ok()?,
                 b'`' => index = self.skip_template_raw(index, self.bytes.len()).ok()?,
@@ -558,7 +590,27 @@ impl Scanner<'_> {
                     index = self.skip_block_comment(index).ok()?;
                 }
                 // A nested function type's `=>` ends in a `>` that closes no angle group.
-                b'=' if self.bytes.get(index + 1) == Some(&b'>') => index += 2,
+                b'=' if self.bytes.get(index + 1) == Some(&b'>') => {
+                    complete_function_type |= outermost && !annotated;
+                    index += 2;
+                }
+                // `a?: T` marks an optional parameter, so its `:` still opens an annotation. Any
+                // other `?` opens a conditional type, whose `:` only separates the branches.
+                b'?' if outermost => {
+                    let next = self.skip_trivia(index + 1).ok()?;
+                    if self.bytes.get(next) != Some(&b':') {
+                        conditionals += 1;
+                    }
+                    index += 1;
+                }
+                b':' if outermost => {
+                    if conditionals > 0 {
+                        conditionals -= 1;
+                    } else {
+                        annotated = true;
+                    }
+                    index += 1;
+                }
                 b'(' | b'[' | b'{' | b'<' => {
                     closers.push(group_close(byte)?);
                     index += 1;
@@ -570,7 +622,7 @@ impl Scanner<'_> {
                     closers.pop();
                     index += 1;
                     if closers.is_empty() {
-                        return Some(index);
+                        return Some(TypeGroup { end: index, complete_function_type });
                     }
                 }
                 b';' if closers.last() == Some(&b'>') => return None,
@@ -622,6 +674,15 @@ impl Scanner<'_> {
         }
         index
     }
+}
+
+/// One balanced group consumed in type position.
+struct TypeGroup {
+    /// The index just past the group's closing delimiter.
+    end: usize,
+    /// The group is a function type in its own right rather than the parameter list opening one,
+    /// so a following `=>` continues something else.
+    complete_function_type: bool,
 }
 
 /// Type operators that lead the type they apply to, so consumption continues past them into it.

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -339,6 +339,77 @@ impl Scanner<'_> {
         }
     }
 
+    pub(super) fn lazy_arrow_pattern_start(
+        &self,
+        ampersand: usize,
+        parameter_open: Option<usize>,
+        previous_token: Option<u8>,
+    ) -> Option<usize> {
+        parameter_open?;
+        let pattern_start = ampersand.checked_add(1)?;
+        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{'))
+            || !matches!(previous_token, Some(b'(' | b'[' | b'{' | b',' | b':'))
+        {
+            return None;
+        }
+        Some(pattern_start)
+    }
+
+    pub(super) fn arrow_follows_parameter_list(&self, mut index: usize) -> bool {
+        let Ok(next) = self.skip_trivia(index) else {
+            return false;
+        };
+        index = next;
+        if self.bytes.get(index..index + 2) == Some(b"=>") {
+            return true;
+        }
+        if self.bytes.get(index) != Some(&b':') {
+            return false;
+        }
+        index += 1;
+
+        let mut delimiters = Vec::new();
+        while index < self.bytes.len() {
+            match self.bytes[index] {
+                b'\'' | b'"' => {
+                    let Ok(end) = self.skip_quote(index, self.bytes[index]) else {
+                        return false;
+                    };
+                    index = end;
+                }
+                b'/' if self.bytes.get(index + 1) == Some(&b'/') => {
+                    index = self.skip_line_comment(index + 2);
+                }
+                b'/' if self.bytes.get(index + 1) == Some(&b'*') => {
+                    let Ok(end) = self.skip_block_comment(index) else {
+                        return false;
+                    };
+                    index = end;
+                }
+                b'(' | b'[' | b'{' | b'<' => {
+                    delimiters.push(match self.bytes[index] {
+                        b'(' => b')',
+                        b'[' => b']',
+                        b'{' => b'}',
+                        b'<' => b'>',
+                        _ => unreachable!(),
+                    });
+                    index += 1;
+                }
+                byte @ (b')' | b']' | b'}' | b'>') if delimiters.last().copied() == Some(byte) => {
+                    delimiters.pop();
+                    index += 1;
+                }
+                b'=' if delimiters.is_empty() && self.bytes.get(index + 1) == Some(&b'>') => {
+                    return true;
+                }
+                b';' if delimiters.is_empty() => return false,
+                _ => index += 1,
+            }
+        }
+        false
+    }
+
     pub(super) fn keyword_at(&self, index: usize, keyword: &[u8]) -> bool {
         let end = index + 1 + keyword.len();
         self.bytes.get(index) == Some(&b'@')

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -594,11 +594,13 @@ impl Scanner<'_> {
                     complete_function_type |= outermost && !annotated;
                     index += 2;
                 }
-                // `a?: T` marks an optional parameter, so its `:` still opens an annotation. Any
-                // other `?` opens a conditional type, whose `:` only separates the branches.
+                // A `?` that ends its parameter marks that parameter optional: `a?: T` goes on to
+                // an annotation whose `:` opens one here, and the untyped `a?,` and `a?)` end the
+                // parameter outright. Only a `?` with a type after it opens a conditional type,
+                // whose `:` separates the branches instead of opening an annotation.
                 b'?' if outermost => {
                     let next = self.skip_trivia(index + 1).ok()?;
-                    if self.bytes.get(next) != Some(&b':') {
+                    if !matches!(self.bytes.get(next), Some(b':' | b',' | b')')) {
                         conditionals += 1;
                     }
                     index += 1;

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -359,7 +359,8 @@ impl Scanner<'_> {
     /// `...&{ … }` is a rest lazy parameter, so the spread's own `.` has to admit the pattern the
     /// way an opening delimiter or a comma does.
     fn follows_rest_spread(&self, ampersand: usize) -> bool {
-        let Some(dot) = (0..ampersand).rev().find(|index| !self.bytes[*index].is_ascii_whitespace())
+        let Some(dot) =
+            (0..ampersand).rev().find(|index| !self.bytes[*index].is_ascii_whitespace())
         else {
             return false;
         };
@@ -431,7 +432,9 @@ impl Scanner<'_> {
                 }
                 // An outstanding `>` means a `<` was read as type arguments it never opened, so
                 // stop here instead of trusting the rest of the scan.
-                b';' if delimiters.last().is_none_or(|delimiter| *delimiter == b'>') => return false,
+                b';' if delimiters.last().is_none_or(|delimiter| *delimiter == b'>') => {
+                    return false;
+                }
                 _ => index += 1,
             }
         }

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -232,11 +232,21 @@ impl Scanner<'_> {
                     pending_statement_body = false;
                 }
                 b'&' if self
-                    .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                    .lazy_arrow_pattern_start(
+                        index,
+                        paren_starts.last(),
+                        previous_token,
+                        pattern_interior(&delimiters),
+                    )
                     .is_some() =>
                 {
                     let pattern_start = self
-                        .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                        .lazy_arrow_pattern_start(
+                            index,
+                            paren_starts.last(),
+                            previous_token,
+                            pattern_interior(&delimiters),
+                        )
                         .ok_or(ProjectionError::StructuralMismatch)?;
                     pending_lazy_arrow_patterns.push((
                         paren_starts.last().ok_or(ProjectionError::StructuralMismatch)?,
@@ -254,6 +264,7 @@ impl Scanner<'_> {
                     .standalone_lazy_pattern_start(
                         index,
                         closed_control_paren || pending_statement_body,
+                        inside_parentheses(&delimiters),
                     )
                     .is_some() =>
                 {
@@ -261,6 +272,7 @@ impl Scanner<'_> {
                         .standalone_lazy_pattern_start(
                             index,
                             closed_control_paren || pending_statement_body,
+                            inside_parentheses(&delimiters),
                         )
                         .ok_or(ProjectionError::StructuralMismatch)?;
                     self.parser_lazy_patterns.push(ParserLazyPattern {
@@ -458,4 +470,17 @@ impl Scanner<'_> {
         }
         Ok(index)
     }
+}
+
+/// Whether the innermost group still open is an object or array one — the interior of a
+/// destructuring pattern rather than the parameter list that encloses it. A `(` here means the
+/// cursor sits directly among the parameters, where a `:` is a type annotation.
+fn pattern_interior(delimiters: &TinyStack<(u8, bool), 16>) -> bool {
+    matches!(delimiters.last(), Some((b'}' | b']', _)))
+}
+
+/// Whether the innermost group still open is a `(` one, where a parameter list or an ordinary
+/// parenthesised expression lives and a statement cannot begin.
+fn inside_parentheses(delimiters: &TinyStack<(u8, bool), 16>) -> bool {
+    matches!(delimiters.last(), Some((b')', _)))
 }

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -49,6 +49,9 @@ impl Scanner<'_> {
         let mut closed_control_paren = false;
         let mut pending_statement_body = false;
         let mut parens = TinyStack::<bool, 16>::new();
+        let mut paren_starts = TinyStack::<usize, 16>::new();
+        let mut pending_lazy_arrow_patterns = Vec::<(usize, usize, usize)>::new();
+        let mut previous_token = None;
 
         while index < self.bytes.len() {
             let byte = self.bytes[index];
@@ -57,6 +60,8 @@ impl Scanner<'_> {
                 continue;
             }
 
+            let records_previous_token =
+                !matches!(self.bytes.get(index..index + 2), Some(b"//" | b"/*"));
             match byte {
                 b'\'' | b'"' => {
                     index = self.skip_quote(index, byte)?;
@@ -199,31 +204,58 @@ impl Scanner<'_> {
                     closed_control_paren = false;
                     pending_statement_body = false;
                 }
-                b'&' if self.lazy_pattern_start(index).is_some()
-                    || self
+                b'&' if self.lazy_pattern_start(index).is_some() => {
+                    let pattern_start = self
+                        .lazy_pattern_start(index)
+                        .ok_or(ProjectionError::StructuralMismatch)?;
+                    self.parser_lazy_patterns.push(ParserLazyPattern {
+                        ampersand: to_u32(index)?,
+                        pattern_start: to_u32(pattern_start)?,
+                        standalone: false,
+                    });
+                    index += 1;
+                    can_start_expression = true;
+                    can_start_jsx = true;
+                    pending_control_paren = false;
+                    closed_control_paren = false;
+                    pending_statement_body = false;
+                }
+                b'&' if self
+                    .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                    .is_some() =>
+                {
+                    let pattern_start = self
+                        .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                        .ok_or(ProjectionError::StructuralMismatch)?;
+                    pending_lazy_arrow_patterns.push((
+                        paren_starts.last().ok_or(ProjectionError::StructuralMismatch)?,
+                        index,
+                        pattern_start,
+                    ));
+                    index += 1;
+                    can_start_expression = true;
+                    can_start_jsx = true;
+                    pending_control_paren = false;
+                    closed_control_paren = false;
+                    pending_statement_body = false;
+                }
+                b'&' if self
+                    .standalone_lazy_pattern_start(
+                        index,
+                        closed_control_paren || pending_statement_body,
+                    )
+                    .is_some() =>
+                {
+                    let pattern_start = self
                         .standalone_lazy_pattern_start(
                             index,
                             closed_control_paren || pending_statement_body,
                         )
-                        .is_some() =>
-                {
-                    let (pattern_start, standalone) =
-                        if let Some(pattern_start) = self.lazy_pattern_start(index) {
-                            (pattern_start, false)
-                        } else {
-                            (
-                                self.standalone_lazy_pattern_start(
-                                    index,
-                                    closed_control_paren || pending_statement_body,
-                                )
-                                .ok_or(ProjectionError::StructuralMismatch)?,
-                                true,
-                            )
-                        };
+                        .ok_or(ProjectionError::StructuralMismatch)?;
                     self.parser_lazy_patterns.push(ParserLazyPattern {
                         ampersand: to_u32(index)?,
                         pattern_start: to_u32(pattern_start)?,
-                        standalone,
+                        standalone: true,
                     });
                     index += 1;
                     can_start_expression = true;
@@ -252,6 +284,7 @@ impl Scanner<'_> {
                     delimiters.push((close, block));
                     if byte == b'(' {
                         parens.push(pending_control_paren);
+                        paren_starts.push(index);
                     }
                     pending_control_paren = false;
                     closed_control_paren = false;
@@ -262,6 +295,7 @@ impl Scanner<'_> {
                 }
                 b')' | b']' | b'}' => {
                     let mut closed_block = false;
+                    let parameter_open = (byte == b')').then(|| paren_starts.pop()).flatten();
                     if delimiters.last().is_some_and(|delimiter| delimiter.0 == byte) {
                         closed_block = delimiters.pop().is_some_and(|delimiter| delimiter.1);
                         index += 1;
@@ -275,6 +309,31 @@ impl Scanner<'_> {
                         });
                     } else {
                         index += 1;
+                    }
+                    if let Some(parameter_open) = parameter_open {
+                        let is_arrow = self.arrow_follows_parameter_list(index);
+                        let mut pending = 0;
+                        while pending < pending_lazy_arrow_patterns.len() {
+                            let (open, ampersand, pattern_start) =
+                                pending_lazy_arrow_patterns[pending];
+                            if open != parameter_open {
+                                pending += 1;
+                                continue;
+                            }
+                            pending_lazy_arrow_patterns.remove(pending);
+                            if is_arrow {
+                                let pattern = ParserLazyPattern {
+                                    ampersand: to_u32(ampersand)?,
+                                    pattern_start: to_u32(pattern_start)?,
+                                    standalone: false,
+                                };
+                                let insert =
+                                    self.parser_lazy_patterns.partition_point(|existing| {
+                                        existing.ampersand < pattern.ampersand
+                                    });
+                                self.parser_lazy_patterns.insert(insert, pattern);
+                            }
+                        }
                     }
                     can_start_expression = if byte == b')' {
                         let control = parens.pop().unwrap_or(false);
@@ -366,6 +425,9 @@ impl Scanner<'_> {
                     closed_control_paren = false;
                     pending_statement_body = false;
                 }
+            }
+            if records_previous_token {
+                previous_token = Some(byte);
             }
         }
 


### PR DESCRIPTION
Carries ryansolid's #36 (lazy arrow parameters, head 90ebc0f as a merge parent, so #36 is marked merged when this lands) merged onto current main, plus fixes for the outstanding review findings:

- rest lazy parameters (`...&{}` / `...&[]`) are now queued — the rest spread's `.` is admitted as a predecessor only when the significant bytes really are `...`
- `arrow_follows_parameter_list` only runs for a closing paren that actually queued a lazy marker, removing the quadratic rescan after typed signatures
- the lookahead stops when a balanced top-level `{...}` closes (only an immediate `=>` still reads as an arrow), so a later unrelated arrow can no longer misclassify a non-arrow paren list
- `<` is pushed as a type-argument delimiter only where a type can begin, and the `;` bail fires when a `>` is outstanding

The one `region.rs` conflict with #34 (expression code blocks) is resolved keeping both scanners' state machines intact, with a regression test covering the #34/#36 interaction. Four new tests in `program_composition.rs`, each verified non-vacuous against its fix.

Known residual (out of scope, needs real parsing): a ternary whose `:` is read as a return-type annotation can still reach a later top-level `=>`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lexical/region scanning and lazy-pattern reconstruction; mistakes could mis-project source or drop/duplicate `&` markers, though coverage is broad.
> 
> **Overview**
> Extends **lazy `&{` / `&[` pattern** handling to **arrow function parameter lists**, with deferred commit until the closing `)` is followed by an arrow (or a return type whose end is followed by `=>`).
> 
> The parser scanner now **queues** candidate markers in parameter lists separately from immediate standalone/`function` patterns, tracks **paren opens** and **previous token** context, and uses **`lazy_arrow_pattern_start`** so `&` in type intersections (e.g. `x: &{ a: number }`) is not treated as a lazy pattern while rename/nested patterns inside destructuring still are. **Rest** lazy params (`...&{ }`) admit trivia between spread and pattern via a trivia-aware backward walk.
> 
> **Return-type lookahead** adds a lightweight type-expression skipper (`skip_type_expression` / `skip_type_group`) so method signatures, function types inside annotations, generics, conditionals, optional params, and `import()` types do not steal a later unrelated `=>` or mis-commit markers on non-arrow lists.
> 
> **Reconstruction** updates `declarator_for_pattern` to climb binding owners (`AssignmentPattern`, `RestElement`, `Property`, nested object/array patterns) instead of assuming a direct `VariableDeclarator` parent.
> 
> Large integration tests cover projection, parse tape shape, and interaction with expression code blocks (`@{`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1c6653766cac8d4884a2b97926ad6807ef5e78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->