### PR TITLE
Lazy destructuring patterns as bare loop targets

### DIFF
--- a/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/lazy_patterns.rs
@@ -194,6 +194,18 @@ fn declarator_for_pattern(
             {
                 return Ok(None);
             }
+            // A bare loop target owns no declarator: the pattern is the loop's `left` outright, so
+            // the sigil belongs to no node's span and only the `lazy` field has to be restored.
+            // A TSRX `@for` has already been rewritten to `JSXForExpression` by the time this runs,
+            // and it keeps the same `left`; the classic three-clause form has no `left` at all.
+            if matches!(
+                owner_type,
+                Some(r#""ForOfStatement""# | r#""ForInStatement""# | r#""JSXForExpression""#)
+            ) && tape.field_index(owner, "left").is_some()
+                && field_value(tape, owner, "left")? == child
+            {
+                return Ok(None);
+            }
             let binding_child = match owner_type {
                 Some(r#""AssignmentPattern""#) => field_value(tape, owner, "left")?,
                 Some(r#""RestElement""#) => field_value(tape, owner, "argument")?,

--- a/crates/tsrx_parser_engine/tests/program_composition.rs
+++ b/crates/tsrx_parser_engine/tests/program_composition.rs
@@ -329,6 +329,133 @@ fn lazy_catch_bindings_reject_defaults_and_later_binding_slots() {
 }
 
 #[test]
+fn bare_lazy_loop_targets_bind_for_of_and_for_in_patterns() {
+    let source = "async function Ordinary(props: any) {\n\
+        for (&{ first, last } of props.pairs) { record(first, last); }\n\
+        for (&[key] in props.table) { record(key); }\n\
+        for await (& /* gap */ { chunk } of props.stream) { record(chunk); }\n\
+        for (const &{ id } of props.items) { record(id); }\n\
+    }\n\
+    function View(props: any) @{\n\
+        <ul>@for (&{ id, label } of props.items) {\n\
+            <li>{label}</li>\n\
+        }</ul>\n\
+    }";
+    let overlay = scan_for_parser(source).expect("bare loop target overlay");
+    let projection = project_for_parser(source, &overlay).expect("bare loop target projection");
+    assert!(!projection.source().contains('&'));
+    assert!(projection.source().contains("for ({ first, last } of props.pairs)"));
+    assert!(projection.source().contains("for ([key] in props.table)"));
+    assert!(projection.source().contains("for await ( /* gap */ { chunk } of props.stream)"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("bare lazy loop targets");
+    let tape = result.program();
+    // Four bare targets and the declared counterpart, which still reaches the declaration lane.
+    assert_eq!(lazy_pattern_count(tape), 5);
+
+    let mut bare_targets = 0;
+    for raw in 0..tape.object_count() {
+        let object = RecordIndex::new(u32::try_from(raw).expect("object index"));
+        let kind = tape
+            .field_index(object, "type")
+            .and_then(|field| tape.field_value(field))
+            .and_then(|value| tape.scalar(value));
+        // The TSRX `@for` keeps the same `left`; only its node type is rewritten.
+        if !matches!(
+            kind,
+            Some(r#""ForOfStatement""# | r#""ForInStatement""# | r#""JSXForExpression""#)
+        ) {
+            continue;
+        }
+        let left = object_field(tape, object, "left");
+        if tape.field_index(left, "lazy").is_none() {
+            continue;
+        }
+        bare_targets += 1;
+        assert_eq!(scalar_field(tape, left, "lazy"), "true");
+        // The sigil belongs to no node: the pattern's authored span still opens at its delimiter,
+        // with only trivia between the two.
+        let (pattern_start, _) = span(tape, left);
+        let pattern_start = usize::try_from(pattern_start).expect("offset");
+        assert!(matches!(source.as_bytes()[pattern_start], b'{' | b'['));
+        let sigil = source[..pattern_start].rfind('&').expect("authored sigil");
+        // Only trivia separates the sigil from the pattern it marks.
+        assert!(source[sigil + 1..pattern_start].replace("/* gap */", "").trim().is_empty());
+    }
+    assert_eq!(bare_targets, 4);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn loop_headers_without_an_of_or_in_target_keep_their_bitwise_ampersands() {
+    // The iterable is an ordinary expression, so `&` there stays a bitwise `and` however closely
+    // it is written to an object literal.
+    let source = "function Masks(props: any) @{\n\
+        for (const value of props.flags & props.mask) { record(value); }\n\
+        for (const bit of props.masks&{ length: 0 }) { record(bit); }\n\
+        <p>{props.name}</p>\n\
+    }";
+    let overlay = scan_for_parser(source).expect("bitwise loop overlay");
+    let projection = project_for_parser(source, &overlay).expect("bitwise loop projection");
+    assert!(projection.source().contains("props.flags & props.mask"));
+    assert!(projection.source().contains("props.masks&{ length: 0 }"));
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("bitwise loop headers");
+    assert_eq!(lazy_pattern_count(result.program()), 0);
+
+    // A C-style header has no assignment target at all, so the sigil is never admitted there and
+    // the `&{ … }` that survives into the projection is the syntax error it always was.
+    assert_failed("function A() { for (&{ bit }; index < 4; index += 1) { report(bit); } }");
+    assert_failed("function B() @{ @for (&{ bit }; index < 4; index += 1) { <p/> } }");
+}
+
+#[test]
+fn bare_lazy_loop_targets_bind_in_annotated_for_headers() {
+    // An annotated `@for` rewrites its header clause by clause instead of copying it, so the sigil
+    // is dropped out of the rewritten `left` even when it is the first byte of that clause.
+    let source = "function Object(props: any) @{\n\
+        <ol>@for (&{ id, label } of props.items; index i; key id) {\n\
+            <li>{i}{label}</li>\n\
+        }</ol>\n\
+    }\n\
+    function Array(props: any) @{\n\
+        <ul>@for (&[head] of props.pairs; index j) {\n\
+            <li>{j}{head}</li>\n\
+        }</ul>\n\
+    }";
+    let overlay = scan_for_parser(source).expect("annotated loop target overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("annotated loop target projection");
+    assert!(!projection.source().contains('&'));
+
+    let result =
+        parse_tsrx(&TsrxParseRequest { source }).expect("annotated bare lazy loop targets");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 2);
+
+    let mut bare_targets = 0;
+    for raw in 0..tape.object_count() {
+        let object = RecordIndex::new(u32::try_from(raw).expect("object index"));
+        let kind = tape
+            .field_index(object, "type")
+            .and_then(|field| tape.field_value(field))
+            .and_then(|value| tape.scalar(value));
+        if kind != Some(r#""JSXForExpression""#) {
+            continue;
+        }
+        let left = object_field(tape, object, "left");
+        assert_eq!(scalar_field(tape, left, "lazy"), "true");
+        bare_targets += 1;
+        // The sigil belongs to no node: the pattern's authored span opens at its own delimiter.
+        let (pattern_start, _) = span(tape, left);
+        let pattern_start = usize::try_from(pattern_start).expect("offset");
+        assert!(matches!(source.as_bytes()[pattern_start], b'{' | b'['));
+        assert_eq!(source.as_bytes()[pattern_start - 1], b'&');
+    }
+    assert_eq!(bare_targets, 2);
+    assert_no_scaffold(tape);
+}
+
+#[test]
 fn lazy_arrow_parameters_preserve_patterns_types_defaults_and_async_arrows() {
     let source = "const View = (&{ name, title = name }: Props): string => title;\n\
         const select = async (prefix: string, /* gap */ &[first, ...rest]: Items = items) => [prefix, first, rest];\n\
@@ -471,6 +598,180 @@ fn lazy_arrow_lookahead_reads_a_function_return_type_as_part_of_the_annotation()
     let overlay = scan_for_parser(source).expect("arrow function type overlay");
     let projection = project_for_parser(source, &overlay).expect("arrow function type projection");
     assert!(!projection.source().contains("(&{ a }"));
+}
+
+#[test]
+fn lazy_arrow_lookahead_stops_at_a_parenthesised_function_type() {
+    // `((x: number) => number)` carries its own arrow inside the parentheses, so the `=>` that
+    // follows the annotation is the lazy arrow's and the parameter has to commit.
+    let source = "const wrap = (&{ a }): ((x: number) => number) => (x) => x + a;\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("parenthesised function type overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("parenthesised function type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("parenthesised function type");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+
+    // The same annotation over a method keeps its `{ … }` body, so nothing may commit.
+    let source = "const helpers = {\n\
+        build(&{ a }): ((x: number) => number) { return (x) => x + a }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("parenthesised method type overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("parenthesised method type projection");
+    assert!(projection.source().contains("build(&{ a })"));
+
+    // A parameter list whose own parameter is annotated with a function type is still a function
+    // head, so its trailing `=>` belongs to the annotation rather than to the arrow.
+    let source = "const helpers = {\n\
+        chain(&{ a }): (step: (x: number) => number) => number { return (step) => step(a) }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("nested function type overlay");
+    let projection = project_for_parser(source, &overlay).expect("nested function type projection");
+    assert!(projection.source().contains("chain(&{ a })"));
+
+    // The completed function type still takes the postfix and union continuations that follow any
+    // other type, and a constructor type's parameter list remains a function head.
+    let source = "const union = (&{ a }): ((x: number) => number) | null => null;\n\
+        const array = (&{ b }): ((x: number) => number)[] => [];\n\
+        const made = (&{ c }): new (x: number) => number => c;";
+    let overlay = scan_for_parser(source).expect("completed function type overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("completed function type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+    assert!(!projection.source().contains("(&{ b }"));
+    assert!(!projection.source().contains("(&{ c }"));
+}
+
+#[test]
+fn optional_parameter_markers_in_a_function_type_do_not_open_a_conditional_type() {
+    // `step?` is an untyped optional parameter, so the `:` that follows belongs to `next`'s
+    // annotation. Reading the `?` as a conditional type would spend that `:` on a branch and let
+    // the inner `=>` complete the type, which would misread the method's annotation as an arrow
+    // and commit a marker that has no arrow to commit to.
+    let source = "const helpers = {\n\
+        chain(&{ a }): (step?, next: (x: number) => number) => number { return (s, n) => n(a) }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("optional parameter method overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("optional parameter method projection");
+    assert!(projection.source().contains("chain(&{ a })"));
+
+    // The arrow counterpart ends the same annotation at the `=>` that really is the lazy arrow's,
+    // so its marker still has to commit.
+    let source = "const build = (&{ a }): (step?, next: (x: number) => number) => number =>\n\
+        (s, n) => n(a);\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("optional parameter arrow overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("optional parameter arrow projection");
+    assert!(!projection.source().contains("(&{ a }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("optional parameter arrow");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+
+    // An optional parameter closing the list directly reads the same way on both sides.
+    let source = "const helpers = {\n\
+        last(&{ a }): (step?) => number { return (s) => a }\n\
+        }\n\
+        const only = (&{ b }): (step?) => number => (s) => b;";
+    let overlay = scan_for_parser(source).expect("trailing optional parameter overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("trailing optional parameter projection");
+    assert!(projection.source().contains("last(&{ a })"));
+    assert!(!projection.source().contains("(&{ b }"));
+
+    // A `?` with a type after it still opens a conditional type, whose `:` spends the branch
+    // rather than opening an annotation, so the `=>` inside completes the type and the `=>` that
+    // follows the whole annotation is the arrow's.
+    let source = "const pick = (&{ a }): (A extends B ? C : (x: T) => U) => a;\n\
+        const helpers = {\n\
+        pick(&{ b }): (A extends B ? C : (x: T) => U) { return b }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("conditional type overlay");
+    let projection = project_for_parser(source, &overlay).expect("conditional type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+    assert!(projection.source().contains("pick(&{ b })"));
+}
+
+#[test]
+fn parameter_type_intersections_are_not_queued_as_lazy_patterns() {
+    let source = "const pick = (x: &{ a: number }) => x;\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("intersection annotation overlay");
+    let projection =
+        project_for_parser(source, &overlay).expect("intersection annotation projection");
+    assert!(projection.source().contains("(x: &{ a: number })"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("intersection annotation");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 0);
+    assert_no_scaffold(tape);
+
+    // The same holds for an intersection whose left member closed with `}`, and beside a
+    // parameter that really does carry a lazy pattern.
+    let source = "const mix = (&{ a }, x: { b: number }&{ c: string }) => [a, x];";
+    let overlay = scan_for_parser(source).expect("mixed intersection overlay");
+    let projection = project_for_parser(source, &overlay).expect("mixed intersection projection");
+    assert!(!projection.source().contains("(&{ a }"));
+    assert!(projection.source().contains("{ b: number }&{ c: string }"));
+
+    // The rename form that made `:` an admitting predecessor still queues its pattern.
+    let source = "const rename = ({ a: &{ b } }) => b;";
+    let overlay = scan_for_parser(source).expect("rename overlay");
+    let projection = project_for_parser(source, &overlay).expect("rename projection");
+    assert!(!projection.source().contains("a: &{ b }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("destructuring rename");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn lazy_arrow_lookahead_reads_an_import_type_return_annotation() {
+    let source = "const load = (&{ a }): import(\"mod\").Shape => a;\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("import type overlay");
+    let projection = project_for_parser(source, &overlay).expect("import type projection");
+    assert!(!projection.source().contains("(&{ a }"));
+
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("import type return annotation");
+    let tape = result.program();
+    assert_eq!(lazy_pattern_count(tape), 1);
+    assert_no_scaffold(tape);
+
+    // An import type over a method still leaves the `{ … }` body outside the annotation.
+    let source = "const helpers = {\n\
+        load(&{ a }): import(\"mod\").Shape { return a }\n\
+        }\n\
+        const run = (value) => value";
+    let overlay = scan_for_parser(source).expect("import type method overlay");
+    let projection = project_for_parser(source, &overlay).expect("import type method projection");
+    assert!(projection.source().contains("load(&{ a })"));
+}
+
+fn lazy_pattern_count(tape: &FlatTape) -> usize {
+    (0..tape.object_count())
+        .map(|raw| RecordIndex::new(u32::try_from(raw).expect("object index")))
+        .filter(|object| {
+            tape.field_index(*object, "type")
+                .and_then(|field| tape.field_value(field))
+                .and_then(|value| tape.scalar(value))
+                .is_some_and(|kind| matches!(kind, r#""ArrayPattern""# | r#""ObjectPattern""#))
+                && tape.field_index(*object, "lazy").is_some()
+        })
+        .count()
 }
 
 #[test]

--- a/crates/tsrx_syntax/src/parser_projection/builder.rs
+++ b/crates/tsrx_syntax/src/parser_projection/builder.rs
@@ -123,7 +123,13 @@ impl<'a> Builder<'a> {
             if pattern.ampersand < span.start || pattern.ampersand >= span.end {
                 continue;
             }
-            self.copy_original(ByteSpan::new(cursor, pattern.ampersand))?;
+            // A bare loop target opens `left` with the sigil, so there is nothing authored to copy
+            // ahead of it. Copying the empty span anyway records a degenerate segment, which splits
+            // the one authored gap the caller left before the pattern into two consumptions and
+            // fails `consume_allowed_gap` as a non-canonical affine projection map.
+            if cursor < pattern.ampersand {
+                self.copy_original(ByteSpan::new(cursor, pattern.ampersand))?;
+            }
             cursor = pattern.ampersand.saturating_add(1);
         }
         self.copy_original(ByteSpan::new(cursor, span.end))

--- a/crates/tsrx_syntax/src/parser_scanner/control.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/control.rs
@@ -100,6 +100,7 @@ impl Scanner<'_> {
             is_await = true;
             index = self.skip_trivia(Self::after_bare_keyword(index, b"await"))?;
         }
+        self.register_lazy_loop_target(index)?;
         let (header, after_header) = self.parse_parenthesized(index)?;
         let mut for_header = self.analyze_for_header(header)?;
         for_header.r#await = is_await;

--- a/crates/tsrx_syntax/src/parser_scanner/header.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/header.rs
@@ -39,6 +39,50 @@ impl Scanner<'_> {
         Ok(())
     }
 
+    /// A bare loop target — `for (&{ name } of items)`, `@for (&[key] in table)` — carries no
+    /// declaration keyword to admit the sigil and never reaches an arrow, so neither the
+    /// declaration lane nor the pending-arrow queue can fire on it. `open` is the header's `(`.
+    ///
+    /// The `of` or `in` after the pattern is the whole of the evidence: without it the same bytes
+    /// open a C-style header, where `&{ … }` is a bitwise `and` against an object literal and the
+    /// position is an ordinary expression rather than an assignment target. A declared target
+    /// (`for (const &{ a } of pairs)`) does not reach here at all — its keyword is what the
+    /// declaration lane reads, and the sigil no longer sits directly after the `(`.
+    pub(super) fn register_lazy_loop_target(&mut self, open: usize) -> Result<(), ProjectionError> {
+        if self.bytes.get(open) != Some(&b'(') {
+            return Ok(());
+        }
+        let ampersand = self.skip_trivia(open + 1)?;
+        if self.bytes.get(ampersand) != Some(&b'&') {
+            return Ok(());
+        }
+        let pattern_start = self.skip_trivia(ampersand.saturating_add(1))?;
+        if !matches!(self.bytes.get(pattern_start), Some(b'{' | b'[')) {
+            return Ok(());
+        }
+        let Some(pattern_end) = self.skip_balanced_pattern(pattern_start) else {
+            return Ok(());
+        };
+        // The `of`/`in` requirement is what keeps a C-style `for (init; cond; step)` header out:
+        // such a header has no iteration target, so its `&` stays the bitwise operator it always
+        // was. Everything that gets here is a real loop target, annotated `@for` clauses included —
+        // the annotated lane drops the sigil out of its own `left` copy whether or not anything
+        // precedes it there.
+        let keyword = self.skip_trivia(pattern_end)?;
+        if !self.bare_keyword_at(keyword, b"of") && !self.bare_keyword_at(keyword, b"in") {
+            return Ok(());
+        }
+        if self.parser_lazy_patterns.iter().any(|pattern| pattern.ampersand as usize == ampersand) {
+            return Ok(());
+        }
+        self.parser_lazy_patterns.push(ParserLazyPattern {
+            ampersand: to_u32(ampersand)?,
+            pattern_start: to_u32(pattern_start)?,
+            standalone: false,
+        });
+        Ok(())
+    }
+
     pub(super) fn parse_parenthesized(
         &mut self,
         start: usize,

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -319,41 +319,117 @@ impl Scanner<'_> {
             .map(|_| pattern_start)
     }
 
+    /// Skips the balanced group opening at `open` — a destructuring pattern or the header that
+    /// encloses one — and returns the index just past its closing delimiter. String, template,
+    /// comment, and regex interiors stay opaque, because a destructuring default may hold any of
+    /// them. A mismatched closer or an unterminated group means the bytes were never the group they
+    /// looked like, and returning `None` there leaves the caller declining rather than guessing at
+    /// what follows.
+    pub(super) fn skip_balanced_pattern(&self, open: usize) -> Option<usize> {
+        let mut closers = vec![group_close(*self.bytes.get(open)?)?];
+        let mut index = open + 1;
+        let mut can_start_expression = true;
+        while let Some(&byte) = self.bytes.get(index) {
+            match byte {
+                b'\'' | b'"' => {
+                    index = self.skip_quote(index, byte).ok()?;
+                    can_start_expression = false;
+                }
+                b'`' => {
+                    index = self.skip_template_raw(index, self.bytes.len()).ok()?;
+                    can_start_expression = false;
+                }
+                b'/' if self.bytes.get(index + 1) == Some(&b'/') => {
+                    index = self.skip_line_comment(index + 2);
+                }
+                b'/' if self.bytes.get(index + 1) == Some(&b'*') => {
+                    index = self.skip_block_comment(index).ok()?;
+                }
+                b'/' if can_start_expression => {
+                    index = self.skip_regex(index).ok()?;
+                    can_start_expression = false;
+                }
+                b'(' | b'[' | b'{' => {
+                    closers.push(group_close(byte)?);
+                    index += 1;
+                    can_start_expression = true;
+                }
+                b')' | b']' | b'}' => {
+                    if closers.last() != Some(&byte) {
+                        return None;
+                    }
+                    closers.pop();
+                    index += 1;
+                    if closers.is_empty() {
+                        return Some(index);
+                    }
+                    can_start_expression = false;
+                }
+                b'0'..=b'9' => {
+                    index = self.skip_number(index);
+                    can_start_expression = false;
+                }
+                _ if self.identifier_start_width(index).is_some() => {
+                    index = self.skip_identifier(index);
+                    can_start_expression = false;
+                }
+                _ if byte.is_ascii_whitespace() => index += 1,
+                _ => {
+                    can_start_expression = matches!(
+                        byte,
+                        b'=' | b',' | b':' | b'?' | b'!' | b'+' | b'-' | b'*' | b'%' | b'&' | b'|'
+                    );
+                    index += 1;
+                }
+            }
+        }
+        None
+    }
+
+    /// `inside_parentheses` says the innermost group still open is a `(` one. A statement cannot
+    /// start there — only a `for` header's `;` reaches statement position inside parentheses — so
+    /// the predecessors that are ambiguous between a statement boundary and a type do not admit
+    /// the sigil: `:` opens a parameter's annotation and `}` closes an object type in one.
     pub(super) fn standalone_lazy_pattern_start(
         &self,
         ampersand: usize,
         statement_context: bool,
+        inside_parentheses: bool,
     ) -> Option<usize> {
         let pattern_start = ampersand.checked_add(1)?;
         if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{')) {
             return None;
         }
         let previous = previous_significant_byte(self.bytes, ampersand);
-        if previous.is_none()
-            || matches!(previous, Some(b';' | b'{' | b'}' | b':'))
-            || statement_context
-        {
-            Some(pattern_start)
-        } else {
-            None
-        }
+        let admitted = previous.is_none()
+            || previous == Some(b';')
+            || matches!(previous, Some(b'{' | b'}' | b':')) && !inside_parentheses
+            || statement_context;
+        admitted.then_some(pattern_start)
     }
 
+    /// `pattern_interior` says the innermost group still open at the ampersand is an object or
+    /// array one, so the position is inside a binding pattern rather than directly in the
+    /// parameter list. It is what separates the two meanings of a preceding `:`.
     pub(super) fn lazy_arrow_pattern_start(
         &self,
         ampersand: usize,
         parameter_open: Option<usize>,
         previous_token: Option<u8>,
+        pattern_interior: bool,
     ) -> Option<usize> {
         parameter_open?;
         let pattern_start = ampersand.checked_add(1)?;
-        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{'))
-            || !(matches!(previous_token, Some(b'(' | b'[' | b'{' | b',' | b':'))
-                || self.follows_rest_spread(ampersand))
-        {
+        if !matches!(self.bytes.get(pattern_start), Some(b'[' | b'{')) {
             return None;
         }
-        Some(pattern_start)
+        // A `:` inside a pattern renames into a nested lazy pattern (`{ a: &{ b } }`). The same
+        // `:` written directly in the parameter list opens a type annotation instead, and a type
+        // may perfectly well lead with the intersection `&` of an object type.
+        let admitted = matches!(previous_token, Some(b'(' | b'[' | b'{' | b','))
+            || (previous_token == Some(b':') && pattern_interior)
+            || self.follows_rest_spread(ampersand);
+        admitted.then_some(pattern_start)
     }
 
     /// `...&{ … }` is a rest lazy parameter, so the spread's own `.` has to admit the pattern the
@@ -462,12 +538,21 @@ impl Scanner<'_> {
             let byte = *self.bytes.get(index)?;
             // Only a parenthesised parameter list can carry a function type's `=>`; every other
             // way of reaching a `=>` means the type already ended.
-            let mut function_head = byte == b'(';
+            let mut function_head = false;
+            // `import("mod")` is the one type form whose name takes a call-like group.
+            let mut import_head = false;
             match byte {
-                b'(' | b'[' | b'{' => index = self.skip_type_group(index)?,
+                b'(' | b'[' | b'{' => {
+                    let group = self.skip_type_group(index)?;
+                    index = group.end;
+                    // A parenthesised group holding its own top-level `=>` is already a complete
+                    // function type — `((x: T) => U)` — rather than the parameter list opening
+                    // one, so the `=>` after it belongs to whatever follows the annotation.
+                    function_head = byte == b'(' && !group.complete_function_type;
+                }
                 // Type parameters lead a generic function type, whose parameter list is the type.
                 b'<' => {
-                    index = self.skip_type_group(index)?;
+                    index = self.skip_type_group(index)?.end;
                     continue;
                 }
                 // A leading `|` or `&`, and a numeric literal's sign, carry no type of their own.
@@ -480,7 +565,9 @@ impl Scanner<'_> {
                 b'0'..=b'9' => index = self.skip_number(index),
                 _ if self.identifier_start_width(index).is_some() => {
                     let end = self.skip_identifier(index);
-                    let leads_a_type = TYPE_PREFIX_KEYWORDS.contains(&&self.bytes[index..end]);
+                    let name = &self.bytes[index..end];
+                    let leads_a_type = TYPE_PREFIX_KEYWORDS.contains(&name);
+                    import_head = matches!(name, b"import");
                     index = end;
                     if leads_a_type {
                         continue;
@@ -492,8 +579,11 @@ impl Scanner<'_> {
             loop {
                 let next = self.skip_trivia(index).ok()?;
                 match self.bytes.get(next) {
+                    // The module specifier of `import("mod").T`, the only call-like group a type
+                    // may take. Its qualified name and type arguments continue below as usual.
+                    Some(b'(') if import_head => index = self.skip_type_group(next)?.end,
                     // `T[]`, `T[K]`, and `T<Args>` all extend the type they follow.
-                    Some(b'[' | b'<') => index = self.skip_type_group(next)?,
+                    Some(b'[' | b'<') => index = self.skip_type_group(next)?.end,
                     // A qualified name: `A.B.C`.
                     Some(b'.') => {
                         let name = self.skip_trivia(next + 1).ok()?;
@@ -505,6 +595,7 @@ impl Scanner<'_> {
                     _ => break,
                 }
                 function_head = false;
+                import_head = false;
             }
 
             let next = self.skip_trivia(index).ok()?;
@@ -544,10 +635,18 @@ impl Scanner<'_> {
     /// opaque. A closer that does not match, and a `;` inside an angle group, both mean the group
     /// was never a group — most often a `<` that was really a comparison — and end the scan rather
     /// than let it run away through the rest of the file.
-    fn skip_type_group(&self, open: usize) -> Option<usize> {
-        let mut closers = vec![group_close(*self.bytes.get(open)?)?];
+    fn skip_type_group(&self, open: usize) -> Option<TypeGroup> {
+        let open_byte = *self.bytes.get(open)?;
+        let parenthesised = open_byte == b'(';
+        let mut closers = vec![group_close(open_byte)?];
+        // A `=>` written directly in a parenthesised group belongs to a parameter's annotation
+        // when a `:` has already opened one, and to the group's own function type otherwise.
+        let mut annotated = false;
+        let mut conditionals = 0_u32;
+        let mut complete_function_type = false;
         let mut index = open + 1;
         while let Some(&byte) = self.bytes.get(index) {
+            let outermost = parenthesised && closers.len() == 1;
             match byte {
                 b'\'' | b'"' => index = self.skip_quote(index, byte).ok()?,
                 b'`' => index = self.skip_template_raw(index, self.bytes.len()).ok()?,
@@ -558,7 +657,29 @@ impl Scanner<'_> {
                     index = self.skip_block_comment(index).ok()?;
                 }
                 // A nested function type's `=>` ends in a `>` that closes no angle group.
-                b'=' if self.bytes.get(index + 1) == Some(&b'>') => index += 2,
+                b'=' if self.bytes.get(index + 1) == Some(&b'>') => {
+                    complete_function_type |= outermost && !annotated;
+                    index += 2;
+                }
+                // A `?` that ends its parameter marks that parameter optional: `a?: T` goes on to
+                // an annotation whose `:` opens one here, and the untyped `a?,` and `a?)` end the
+                // parameter outright. Only a `?` with a type after it opens a conditional type,
+                // whose `:` separates the branches instead of opening an annotation.
+                b'?' if outermost => {
+                    let next = self.skip_trivia(index + 1).ok()?;
+                    if !matches!(self.bytes.get(next), Some(b':' | b',' | b')')) {
+                        conditionals += 1;
+                    }
+                    index += 1;
+                }
+                b':' if outermost => {
+                    if conditionals > 0 {
+                        conditionals -= 1;
+                    } else {
+                        annotated = true;
+                    }
+                    index += 1;
+                }
                 b'(' | b'[' | b'{' | b'<' => {
                     closers.push(group_close(byte)?);
                     index += 1;
@@ -570,7 +691,7 @@ impl Scanner<'_> {
                     closers.pop();
                     index += 1;
                     if closers.is_empty() {
-                        return Some(index);
+                        return Some(TypeGroup { end: index, complete_function_type });
                     }
                 }
                 b';' if closers.last() == Some(&b'>') => return None,
@@ -622,6 +743,15 @@ impl Scanner<'_> {
         }
         index
     }
+}
+
+/// One balanced group consumed in type position.
+struct TypeGroup {
+    /// The index just past the group's closing delimiter.
+    end: usize,
+    /// The group is a function type in its own right rather than the parameter list opening one,
+    /// so a following `=>` continues something else.
+    complete_function_type: bool,
 }
 
 /// Type operators that lead the type they apply to, so consumption continues past them into it.

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -232,11 +232,21 @@ impl Scanner<'_> {
                     pending_statement_body = false;
                 }
                 b'&' if self
-                    .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                    .lazy_arrow_pattern_start(
+                        index,
+                        paren_starts.last(),
+                        previous_token,
+                        pattern_interior(&delimiters),
+                    )
                     .is_some() =>
                 {
                     let pattern_start = self
-                        .lazy_arrow_pattern_start(index, paren_starts.last(), previous_token)
+                        .lazy_arrow_pattern_start(
+                            index,
+                            paren_starts.last(),
+                            previous_token,
+                            pattern_interior(&delimiters),
+                        )
                         .ok_or(ProjectionError::StructuralMismatch)?;
                     pending_lazy_arrow_patterns.push((
                         paren_starts.last().ok_or(ProjectionError::StructuralMismatch)?,
@@ -254,6 +264,7 @@ impl Scanner<'_> {
                     .standalone_lazy_pattern_start(
                         index,
                         closed_control_paren || pending_statement_body,
+                        inside_parentheses(&delimiters),
                     )
                     .is_some() =>
                 {
@@ -261,6 +272,7 @@ impl Scanner<'_> {
                         .standalone_lazy_pattern_start(
                             index,
                             closed_control_paren || pending_statement_body,
+                            inside_parentheses(&delimiters),
                         )
                         .ok_or(ProjectionError::StructuralMismatch)?;
                     self.parser_lazy_patterns.push(ParserLazyPattern {
@@ -385,6 +397,15 @@ impl Scanner<'_> {
                         let open = self.skip_trivia(end)?;
                         self.register_lazy_catch_parameter(open)?;
                     }
+                    if identifier == b"for"
+                        && previous_significant_byte(self.bytes, index) != Some(b'.')
+                    {
+                        let mut open = self.skip_trivia(end)?;
+                        if self.bare_keyword_at(open, b"await") {
+                            open = self.skip_trivia(Self::after_bare_keyword(open, b"await"))?;
+                        }
+                        self.register_lazy_loop_target(open)?;
+                    }
                     pending_control_paren = matches!(
                         identifier,
                         b"if" | b"for" | b"while" | b"with" | b"switch" | b"catch"
@@ -464,4 +485,17 @@ impl Scanner<'_> {
         }
         Ok(index)
     }
+}
+
+/// Whether the innermost group still open is an object or array one — the interior of a
+/// destructuring pattern rather than the parameter list that encloses it. A `(` here means the
+/// cursor sits directly among the parameters, where a `:` is a type annotation.
+fn pattern_interior(delimiters: &TinyStack<(u8, bool), 16>) -> bool {
+    matches!(delimiters.last(), Some((b'}' | b']', _)))
+}
+
+/// Whether the innermost group still open is a `(` one, where a parameter list or an ordinary
+/// parenthesised expression lives and a statement cannot begin.
+fn inside_parentheses(delimiters: &TinyStack<(u8, bool), 16>) -> bool {
+    matches!(delimiters.last(), Some((b')', _)))
 }


### PR DESCRIPTION
Stacked on #39 (and #38 beneath it). Closes the medium slice of the tsrx decbe8f parity gap (see #40 for the deferred architectural remainder):

- `register_lazy_loop_target` registers `&{ }` / `&[ ]` directly after a loop header's `(` when a top-level `of`/`in` follows the balanced pattern — plain `for`, `for await`, and `@for` clause forms, annotated `@for` included
- reconstruction's parent walk accepts `ForOfStatement`/`ForInStatement`/`JSXForExpression` `left` owners
- the projection builder no longer records a degenerate zero-length segment when the sigil opens `header.left` (this is what had blocked the annotated `@for` form)
- C-style `for (init; cond; step)` headers keep their bitwise ampersands — the `of`/`in` requirement excludes them, pinned by negatives

Tests model tsrx's decbe8f shapes: for-of object, for-in array, `for await` with trivia, declared counterparts, annotated `@for` object+array, and the negative pins.

Retarget to `main` after #39 lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lazy-pattern registration, projection affine mapping, and AST reconstruction across scanner, projection, and parser engine; behavior is well pinned by tests but touches several parsing pipeline stages.
> 
> **Overview**
> Adds support for **lazy destructuring** (`&{ … }` / `&[ … ]`) when the pattern is the loop header’s assignment target with no `const`/`let`—e.g. `for (&{ a } of items)`, `for await (& …)`, and `@for (& …)` including annotated headers.
> 
> The scanner registers these via **`register_lazy_loop_target`**, which only admits a sigil directly after `(` when a balanced pattern is followed by **`of` or `in`** (so C-style `for (init; …)` and bitwise `&` in iterables stay unchanged). **`skip_balanced_pattern`** scans pattern interiors without treating strings/comments as syntax. Reconstruction treats **`ForOfStatement` / `ForInStatement` / `JSXForExpression`** `left` owners as having no declarator span—only **`lazy: true`** and pattern spans are restored. The projection builder skips a **zero-length** copy before the sigil when it opens `left`, fixing annotated `@for` header projection.
> 
> Integration tests cover bare vs declared targets, trivia, annotated `@for`, and negative cases for C-style headers and bitwise `&`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86db0f056aa3809de3c4385e45e362d657452033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->