### PR TITLE
Site: pin the freshly published wasm demo engine

### DIFF
--- a/website-oxc/wasm-pin.json
+++ b/website-oxc/wasm-pin.json
@@ -1,9 +1,9 @@
 {
   "tag": "wasm-demo-latest",
-  "inputsHash": "095a4c240e52ef0694db9309ae6db4ce313440a09bae5ecab30ce56d503c4e54",
-  "sourceCommit": "da80d0b80348e43a38daf73e3fe069473dd2d5a0",
+  "inputsHash": "73c1a3d1a000492bfc7f187be071877afb06fb1e05cd925e0421ff0ec035a748",
+  "sourceCommit": "19790bb0a2b0d18db47af4c2bcb37f76210b6a08",
   "wasm": {
-    "sha256": "a9d9d8afb84ee7c2a132b4e9f194abd82ecdbfa730dc75136a07f72848225ad0",
+    "sha256": "7dd54638714a98685f360eb3f8552b38580678347dbc5b32ea9ddaaab04b6857",
     "bytes": 9487535
   },
   "worker": {


### PR DESCRIPTION
Re-pins website-oxc/wasm-pin.json to the engine the 18:51 main run built and published to `wasm-demo-latest` (inputs hash `73c1a3d1`, wasm sha256 `7dd54638…`, worker unchanged). The workflow's own pin-commit step cannot push to protected main (GH006, bot not on the bypass list), which is why oxc.tsrx.dev has been serving the static fallback: the committed pin described the pre-merge tree, so the Vercel build's fetch correctly refused the engine and degraded to `mode: static`. With this pin the deploy fetches the engine again and the hero demo returns to live wasm mode.

Durable fix still needed: allow the github-actions app to bypass required PRs on main, or the pin will go stale again on the next parser-touching merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment metadata only; no application or engine source changes in this diff.
> 
> **Overview**
> Updates **`website-oxc/wasm-pin.json`** so the site build targets the current **`wasm-demo-latest`** release instead of an older engine.
> 
> **`inputsHash`**, **`sourceCommit`**, and the **`.wasm` sha256** are bumped to match the engine from commit `19790bb0`; the **worker** pin is unchanged. After deploy, **`fetch-docs-wasm.ts`** should pass verification again and the hero demo can run in **live wasm** mode rather than the **static fallback** that happens when the pin no longer matches the checkout or release bytes.
> 
> This is a manual pin because the workflow’s auto-commit step cannot push to protected **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e43c498eb41aff7e2d52e900c51bd6b5e242abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->