### PR TITLE
Site: correct the wasm pin inputs hash

### DIFF
--- a/website-oxc/wasm-pin.json
+++ b/website-oxc/wasm-pin.json
@@ -1,6 +1,6 @@
 {
   "tag": "wasm-demo-latest",
-  "inputsHash": "73c1a3d1a000492bfc7f187be071877afb06fb1e05cd925e0421ff0ec035a748",
+  "inputsHash": "c65449666913059189e5313edea7439dd7509aab18ab4e8e84f9325983853a74",
   "sourceCommit": "19790bb0a2b0d18db47af4c2bcb37f76210b6a08",
   "wasm": {
     "sha256": "7dd54638714a98685f360eb3f8552b38580678347dbc5b32ea9ddaaab04b6857",


### PR DESCRIPTION
The previous pin used the workflow's cache-key hash from the run log; the fetch script's own `--print-inputs-hash` over a pristine checkout of current main computes `c654496…` (verified twice; git confirms the hashed paths are byte-identical to the tree the published engine was built from). With the corrected hash the Vercel build's verification passes and the deploy leaves static mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in a pin file; no WASM bytes or application logic changes.
> 
> **Overview**
> Updates **`inputsHash`** in `website-oxc/wasm-pin.json` from the incorrect workflow cache-key value to **`c654496…`**, matching what `fetch-docs-wasm.ts --print-inputs-hash` produces on a clean checkout of the pinned `sourceCommit`.
> 
> **Wasm and worker `sha256` / byte sizes are unchanged**—only the inputs fingerprint is fixed so deploy-time pin verification succeeds and the site can leave static fallback mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97e4c8964b2d9bec5cd4d8b2e165ed05bf76fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->