### PR TITLE
test: pin the official-integration wording adopted in #42

### DIFF
--- a/packages/toolchain/README.md
+++ b/packages/toolchain/README.md
@@ -24,8 +24,7 @@ and `@for` for showing something only sometimes, or once per item in a list.
 [OXC](https://oxc.rs) is a set of fast tools for JavaScript and TypeScript,
 written in Rust. This package teaches them to read `.tsrx` too.
 
-_OXC for TSRX is the official OXC integration maintained by the TSRX project. It
-is not affiliated with, endorsed by, or a product of VoidZero or the OXC team._
+_OXC for TSRX is the official OXC integration maintained by the TSRX project._
 
 [**Docs**](https://compiled.run/oxc-tsrx) &nbsp;·&nbsp; [**Getting started**](https://compiled.run/oxc-tsrx/guide/getting-started) &nbsp;·&nbsp; [**Playground**](https://compiled.run/oxc-tsrx/playground)
 

--- a/tests/packaging/boundary.test.mjs
+++ b/tests/packaging/boundary.test.mjs
@@ -704,15 +704,19 @@ test("the maintainer guide defines a source-backed upstream transplant contract"
   ]);
   const guide = flatten(guideRaw);
 
-  assert.match(guide, /OXC for TSRX is an independent community project/i);
-  // The disclaimer is required, its exact phrasing is not.
-  assert.match(guide, /not affiliated with[^.]*(?:endorsed by|product of)/i);
-  assert.match(guide, /VoidZero/);
+  // The stance is required, its exact phrasing is not: this is the official
+  // OXC integration for TSRX, and the TSRX project is the one maintaining it.
+  assert.match(guide, /OXC for TSRX is the official OXC integration for TSRX/i);
+  assert.match(guide, /official OXC integration[^.]*maintained by the TSRX project/i);
+  // The retired non-affiliation disclaimer must not come back with a reflow.
+  assert.doesNotMatch(guide, /not affiliated with/i);
   assert.match(guide, new RegExp(pinnedOxcRevision));
   assert.match(guide, new RegExp(auditedOxcMain));
   assert.match(guide, /audited(?: on)? 2026-07-16/i);
   assert.match(guide, /no merged whole-file (?:language |parser )?hook/i);
-  assert.match(guide, /no (?:OXC )?maintainer interest(?: or endorsement)? is claimed/i);
+  // Being the official integration is not a claim that any of this transplant
+  // work is upstream business: the page still has to say so in its own words.
+  assert.match(guide, /nothing here has been submitted to OXC and nothing is scheduled/i);
   assert.match(guide, /unicode-id-start\s*=\s*[`"]1[`"]|`unicode-id-start = "1"`/);
 
   for (const path of [


### PR DESCRIPTION
Main's CI, install/arbitration lanes, and every open PR are red on one assertion: `tests/packaging/boundary.test.mjs` still requires the VoidZero non-affiliation disclaimer that #42 deliberately replaced with the official-integration wording.

- Re-pin the guide stance assertions to the new wording, with a `doesNotMatch` guard so the retired disclaimer cannot silently return.
- Replace the `no maintainer interest is claimed` pin (removed with the same sentence) with the surviving non-claim on that page (`nothing here has been submitted to OXC and nothing is scheduled`).
- Align `packages/toolchain/README.md` (the npm page) with the root README by dropping the disclaimer sentence.

`node --test tests/packaging/boundary.test.mjs`: 18/18. THIRD_PARTY_NOTICES files and their `compliance.test.mjs` pins are deliberately untouched (that contract is still true).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-assertion updates only; no runtime, packaging, or compliance-notice behavior changes.
> 
> **Overview**
> Fixes **CI failures** in `tests/packaging/boundary.test.mjs` where the upstreaming-guide contract still expected the old VoidZero **non-affiliation** disclaimer that **#42** replaced with **official-integration** language.
> 
> The boundary test now requires the guide to state that OXC for TSRX is the **official** integration **maintained by the TSRX project**, adds a **`doesNotMatch`** guard so “not affiliated with” cannot creep back via reflow, and swaps the removed “no maintainer interest is claimed” pin for the surviving line that **nothing has been submitted to OXC and nothing is scheduled**. **`packages/toolchain/README.md`** (npm page) is trimmed the same way—one sentence on official maintenance, no disclaimer—so it matches the root README.
> 
> **THIRD_PARTY_NOTICES** and compliance pins are intentionally unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5660505ee007f680eea8f31626dee96d7448e08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->