### PR TITLE
site: defer enhancements out of the first load window

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -8,6 +8,57 @@
 // (empty in a dev server that serves us unversioned) to every lazy import.
 const ASSET_VERSION = new URL(import.meta.url).search
 
+// ---------- enhancements that must stay out of the first load ----------
+// The bytes a reader is actually waiting on are the markup, the shell CSS and
+// the two web fonts. Everything else this file pulls — the hero demo's script,
+// the WebGL plume under the chart, a page warmed because the pointer crossed a
+// link — is enhancement: nothing above the fold paints differently for the
+// fraction of a second it is missing, and every one of those requests competes
+// for the same connections while the first screen is still assembling.
+//
+// They used to start during the load event, so on a first visit the browser was
+// fetching 55 KiB of demo panel (and, if the pointer happened to rest on a nav
+// link, a whole other page) before the fonts had landed. docs/verify.mjs' perf
+// budget measures exactly that window and caught it.
+//
+// So enhancements queue here instead and run once the load event is behind us
+// and the main thread has gone idle. After that first flush the queue is
+// transparent: SPA navigations, and anything a reader touches, run immediately.
+const ENHANCEMENT_DELAY_MS = 200
+const deferredEnhancements = []
+let enhancementsUnlocked = false
+
+function runEnhancements() {
+  enhancementsUnlocked = true
+  for (const task of deferredEnhancements.splice(0)) {
+    try {
+      task()
+    } catch {}
+  }
+}
+
+function afterFirstLoad(task) {
+  if (enhancementsUnlocked) task()
+  else deferredEnhancements.push(task)
+}
+
+const unlockEnhancementsWhenIdle = () =>
+  setTimeout(() => {
+    if (typeof requestIdleCallback === 'function')
+      requestIdleCallback(runEnhancements, { timeout: 2000 })
+    else runEnhancements()
+  }, ENHANCEMENT_DELAY_MS)
+
+if (document.readyState === 'complete') unlockEnhancementsWhenIdle()
+else window.addEventListener('load', unlockEnhancementsWhenIdle, { once: true })
+
+// A reader who reaches for the page before the delay is up has told us the
+// first screen is done, so stop holding anything back. Hover is deliberately
+// not on this list: the pointer can be resting on the page without the reader
+// having looked at it yet.
+for (const type of ['pointerdown', 'keydown', 'touchstart', 'wheel'])
+  window.addEventListener(type, runEnhancements, { once: true, passive: true })
+
 // ---------- theme toggle (persistent chrome) ----------
 const themeToggle = document.getElementById('theme-toggle')
 const root = document.documentElement
@@ -705,9 +756,14 @@ function initPage() {
   const demo = document.getElementById('hero-demo')
   if (demo && !demo.dataset.ready) {
     demo.dataset.ready = '1'
-    import(new URL(`./demo-panel.js${ASSET_VERSION}`, import.meta.url))
-      .then((module) => module.initDemo(demo))
-      .catch(() => {})
+    // The panel ships its example already rendered in the HTML, so this script
+    // only makes it live. Waiting for the load event costs nothing visible and
+    // keeps 55 KiB out of the first screen's way.
+    afterFirstLoad(() => {
+      import(new URL(`./demo-panel.js${ASSET_VERSION}`, import.meta.url))
+        .then((module) => module.initDemo(demo))
+        .catch(() => {})
+    })
   }
   const fuelRows = document.querySelectorAll(
     '.comp-row[data-key="oxlint"], .comp-row[data-key="oxcTsrx"], .comp-row[data-key="oxcTsrxMixed"]',
@@ -723,9 +779,14 @@ function initPage() {
       (entries) => {
         if (!entries.some((entry) => entry.isIntersecting)) return
         io.disconnect()
-        import(new URL(`./fuel.js${ASSET_VERSION}`, import.meta.url))
-          .then((module) => module.init(fuelRows, pageCleanupCallbacks))
-          .catch(() => {})
+        // In view is not the same as worth fetching yet: on a short window the
+        // chart can already be on screen at load, and the shader has no business
+        // downloading ahead of the fonts. The CSS fill is showing meanwhile.
+        afterFirstLoad(() => {
+          import(new URL(`./fuel.js${ASSET_VERSION}`, import.meta.url))
+            .then((module) => module.init(fuelRows, pageCleanupCallbacks))
+            .catch(() => {})
+        })
       },
       { rootMargin: '200px 0px' },
     )
@@ -1080,11 +1141,17 @@ if ('navigation' in window) {
     })
   })
 
-  // Warm the cache when a nav/sidebar link is hovered or touched.
+  // Warm the cache when a nav/sidebar link is hovered or touched. A guess about
+  // the next page must never take bandwidth from the one being read, so a hover
+  // that lands while the first screen is still loading queues instead: the
+  // pointer can already be resting on a link when the document arrives (a
+  // restored tab, a fresh navigation under a still pointer), and that used to
+  // pull an entire extra page into the initial load.
   document.addEventListener('pointerover', (event) => {
     const link = event.target.closest('.sidebar a, .top-nav a, .pager a, .hero-actions a')
     if (link && new URL(link.href).origin === location.origin) {
-      fetchPage(link.href).catch(() => {})
+      const href = link.href
+      afterFirstLoad(() => fetchPage(href).catch(() => {}))
     }
   })
 }


### PR DESCRIPTION
The home perf gate failed on main at b4dfac0 (274 KiB over 9 requests against the 250 KiB budget) and passed at e1137cc with only 8 KiB of headroom (242 KiB). The weight was not the plume: demo-panel.js (55 KiB) imports synchronously from initPage(), a pointerover-triggered SPA warm can pull an entire extra page into the initial load when the pointer is already resting on a hero link as the document arrives, and fuel.js starts whenever the chart sits inside the observer's 200px margin at load.

One deferral scheduler in docs/assets/app.js: enhancements queue until load + 200ms + requestIdleCallback, or unlock on the first real interaction (pointerdown/keydown/touchstart/wheel; hover deliberately excluded). Applied to the demo-panel import, the fuel import, and hover page warming. After the first flush the queue is transparent, so SPA navigations behave as before.

perf: / goes from 274 KiB over 9 requests to 190 KiB over 7. Flames still paint in both motion modes (animated normally, still frame under prefers-reduced-motion). node docs/build.mjs and node --test tests/site/verify-static.mjs (wasm mode): 186 passed, 0 failed. No budget or gate changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site client scheduling only; core routing and shell behavior stay the same, with a short delay before demo, WebGL plume, and prefetch on cold first load unless the user interacts.
> 
> **Overview**
> Adds a **deferred enhancement queue** in `docs/assets/app.js` so optional work no longer competes with markup, shell CSS, and fonts during the initial perf window measured by `docs/verify.mjs`.
> 
> Heavy imports and prefetch are wrapped in `afterFirstLoad()`: **hero `demo-panel.js`**, **chart `fuel.js`** (still gated by `IntersectionObserver`), and **SPA hover page warming** via `fetchPage`. The queue flushes after `load` + 200ms + `requestIdleCallback` (with a 2s timeout), or immediately on the first **pointerdown / keydown / touchstart / wheel**—**hover is intentionally excluded** so a resting pointer cannot prefetch another page on arrival. After the first flush, queued tasks run synchronously so SPA navigations behave as before.
> 
> Reported home perf: **274 KiB / 9 requests → 190 KiB / 7 requests** against the existing budget; no gate or budget changes in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f163e4f0bad825cbb0033e9735c1a7a275ce601f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->