### PR TITLE
Fix parser-only syntax in tooling projections (#46 + review fixes)

### DIFF
--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -1107,6 +1107,25 @@ mod tests {
         assert!(!first.code.contains("_t"), "{}", first.code);
     }
 
+    /// Formatting runs the parser scan, so a decorator whose name only begins with a control
+    /// keyword has to survive it. The escaped spellings are the ones that regressed: `\` ends no
+    /// identifier, so a raw-byte keyword boundary read `@for` out of `@forπ` and rejected the
+    /// file for a missing `(`. A `.tsrx` file has to format exactly as the same bytes do as `.tsx`.
+    #[test]
+    fn decorators_named_after_control_keywords_format_like_ordinary_tsx() {
+        for source in [
+            "@if\u{03c0}\nclass Decorated{method( ){return 1}}\n",
+            "@for\\u03c0\nclass Decorated{method( ){return 1}}\n",
+            "@try\\u{1D49C}\nclass Decorated{method( ){return 1}}\n",
+        ] {
+            let through_tsrx = format_text(Path::new("Decorated.tsrx"), source)
+                .unwrap_or_else(|error| panic!("{source:?}: {error}"));
+            let canonical = format_text(Path::new("Decorated.tsx"), source)
+                .unwrap_or_else(|error| panic!("{source:?}: {error}"));
+            assert_eq!(through_tsrx.code, canonical.code, "{source:?}");
+        }
+    }
+
     #[test]
     fn embedded_css_boundary_is_keep_raw_without_hidden_work() {
         let payload = "/* spacing is authored */ .card{color:oklch(62% .2 25);  margin:0  1rem}";

--- a/crates/tsrx_format/src/lib.rs
+++ b/crates/tsrx_format/src/lib.rs
@@ -16,7 +16,7 @@ use oxc_adapter::{
 };
 use serde::Deserialize;
 use serde_json::Value;
-use tsrx_syntax::{lift_formatted, project_for_format, scan};
+use tsrx_syntax::{lift_formatted, project_for_format, scan_for_parser};
 
 pub use error::{ConfigScope, FormatError, GlobField};
 pub use oxc_adapter::OXC_REVISION;
@@ -577,7 +577,7 @@ fn format_text_with_options(
 
     let mut timings = FormatTimings::default();
     let started = Instant::now();
-    let overlay = scan(source)?;
+    let overlay = scan_for_parser(source)?;
     timings.scan_ns = elapsed_ns(started);
 
     let started = Instant::now();
@@ -1136,6 +1136,31 @@ mod tests {
         assert!(first.code.contains("function View({ ready }: { ready: boolean }) @{"));
         assert!(first.code.contains("@if (ready) {"));
         assert!(first.code.contains("} @else {"));
+
+        let second = format_text(Path::new("View.tsrx"), &first.code).unwrap();
+        assert_eq!(second.code, first.code);
+        assert!(!second.changed);
+    }
+
+    #[test]
+    fn formats_parser_only_code_blocks_shorthand_and_lazy_patterns() {
+        let source = concat!(
+            "export function View(props:Props) @{\n",
+            "const title=@{const prefix='Hi';`${prefix} ${props.name}`};\n",
+            "const &{value=1,...rest}=props;\n",
+            "&[first,...tail]=props.items;\n",
+            "<main {title}><script>if (ready) console.log(\"raw\");</script>",
+            "@{const label=rest.label;<p>{label}{value}{first}{tail.length}</p>}</main>\n",
+            "}\n",
+        );
+        let first = format_text(Path::new("View.tsrx"), source).unwrap();
+        assert!(first.code.contains("const title = @{"), "{}", first.code);
+        assert!(first.code.contains("const &{ value = 1, ...rest } = props;"), "{}", first.code);
+        assert!(first.code.contains("&[first, ...tail] = props.items;"), "{}", first.code);
+        assert!(first.code.contains("<main {title}>"), "{}", first.code);
+        assert!(first.code.contains("if (ready) console.log(\"raw\");"), "{}", first.code);
+        assert!(first.code.contains("@{"), "{}", first.code);
+        assert!(!first.code.contains("_t"), "{}", first.code);
 
         let second = format_text(Path::new("View.tsrx"), &first.code).unwrap();
         assert_eq!(second.code, first.code);

--- a/crates/tsrx_lint/src/fixes.rs
+++ b/crates/tsrx_lint/src/fixes.rs
@@ -3,7 +3,7 @@
 use std::{cmp::Reverse, collections::HashSet, fs, path::Path};
 
 use oxc_adapter::{DynamicTagContract, EngineDiagnostic, LintRequest, SourceKind};
-use tsrx_syntax::{MappedProjection, project_for_lint, scan};
+use tsrx_syntax::{MappedProjection, project_for_lint, scan_for_parser};
 
 use crate::{
     error::LintError,
@@ -107,7 +107,8 @@ fn validate_fixed(
     is_tsrx: bool,
     source_kind: SourceKind,
 ) -> Result<(), LintError> {
-    let projection = if is_tsrx { Some(project_for_lint(fixed, &scan(fixed)?)?) } else { None };
+    let projection =
+        if is_tsrx { Some(project_for_lint(fixed, &scan_for_parser(fixed)?)?) } else { None };
     let parse_source = projection.as_ref().map_or(fixed, MappedProjection::source);
     session.engine.lint(&LintRequest {
         path,

--- a/crates/tsrx_lint/src/pipeline.rs
+++ b/crates/tsrx_lint/src/pipeline.rs
@@ -11,7 +11,9 @@ use oxc_adapter::{
     DynamicTagContract, EngineDiagnostic, LintRequest, LintResult, OXC_REVISION, SourceKind,
     TypeBatchFile,
 };
-use tsrx_syntax::{MappedProjection, TypeProjection, project_for_lint, project_for_types, scan};
+use tsrx_syntax::{
+    MappedProjection, TypeProjection, project_for_lint, project_for_types, scan_for_parser,
+};
 
 use crate::{
     error::LintError,
@@ -237,7 +239,7 @@ fn prepare_source(
         });
     }
     let started = Instant::now();
-    let overlay = scan(source)?;
+    let overlay = scan_for_parser(source)?;
     timings.scan_ns = elapsed_ns(started);
     let started = Instant::now();
     let projection = project_for_lint(source, &overlay)?;

--- a/crates/tsrx_lint/src/session.rs
+++ b/crates/tsrx_lint/src/session.rs
@@ -329,6 +329,43 @@ mod tests {
     }
 
     #[test]
+    fn parser_only_scaffolds_remain_lintable_and_map_authored_diagnostics() {
+        let source = concat!(
+            "export function View(props: Props) @{\n",
+            "  const title = @{ console.log(props.name); props.name };\n",
+            "  const &{ value = 1, ...rest } = props;\n",
+            "  &[first, ...tail] = props.items;\n",
+            "  <main {title}>@{ debugger; <p>{value}{rest.label}{first}{tail.length}</p> }</main>\n",
+            "}\n",
+        );
+        let session = LintSession::new(
+            Path::new("."),
+            None,
+            &[
+                RuleFilter { severity: RuleSeverity::Deny, name: "no-console".to_string() },
+                RuleFilter { severity: RuleSeverity::Deny, name: "no-debugger".to_string() },
+            ],
+            false,
+        )
+        .unwrap();
+        let output = session.lint_text(Path::new("parser-scaffolds.tsrx"), source).unwrap();
+        for (rule, needle) in [("no-console", "console.log"), ("no-debugger", "debugger")] {
+            let diagnostic = output
+                .diagnostics
+                .iter()
+                .find(|diagnostic| diagnostic.rule == rule)
+                .unwrap_or_else(|| panic!("missing {rule}: {:?}", output.diagnostics));
+            assert!(
+                diagnostic
+                    .labels
+                    .iter()
+                    .any(|label| label.span.offset as usize == source.find(needle).unwrap()),
+                "{diagnostic:?}"
+            );
+        }
+    }
+
+    #[test]
     fn one_unprojectable_file_keeps_the_rest_of_the_batch_reporting() {
         let directory = std::env::temp_dir().join("oxc-tsrx-lint-batch-continues");
         std::fs::create_dir_all(&directory).expect("temp directory");

--- a/crates/tsrx_lint/src/translate.rs
+++ b/crates/tsrx_lint/src/translate.rs
@@ -2,7 +2,7 @@
 //! the ones that landed in generated scaffolding the author never wrote.
 
 use oxc_adapter::EngineDiagnostic;
-use tsrx_syntax::{MappedProjection, TypeProjection, project_for_lint, scan};
+use tsrx_syntax::{MappedProjection, TypeProjection, project_for_lint, scan_for_parser};
 
 /// One diagnostic label range, in bytes.
 ///
@@ -34,7 +34,7 @@ impl PluginProjection {
     /// projected. The native lane reports that failure as the file's own diagnostic already, so
     /// the plugin lane simply contributes nothing for such a file.
     pub fn new(source: &str) -> Result<Self, String> {
-        let overlay = scan(source).map_err(|error| error.to_string())?;
+        let overlay = scan_for_parser(source).map_err(|error| error.to_string())?;
         let projection = project_for_lint(source, &overlay).map_err(|error| error.to_string())?;
         Ok(Self { projection })
     }

--- a/crates/tsrx_syntax/src/lib.rs
+++ b/crates/tsrx_syntax/src/lib.rs
@@ -65,7 +65,8 @@ pub fn scan(source: &str) -> Result<Overlay, ProjectionError> {
     Scanner::new(source).finish()
 }
 
-/// Performs the parser-specific scan, including nested dynamic names and JSX code blocks.
+/// Performs the parser/tooling scan, including nested dynamic names, JSX code blocks,
+/// shorthand attributes, lazy patterns, and raw script regions.
 ///
 /// # Errors
 ///

--- a/crates/tsrx_syntax/src/model.rs
+++ b/crates/tsrx_syntax/src/model.rs
@@ -294,6 +294,7 @@ pub struct OverlayView<'a> {
 pub struct Overlay {
     pub(crate) source_len: u32,
     pub(crate) source_fingerprint: u128,
+    pub(crate) parser_metadata: bool,
     pub(crate) tokens: Vec<StructuralToken>,
     pub(crate) nodes: Vec<SyntaxNode>,
     pub(crate) clauses: Vec<Clause>,
@@ -315,6 +316,10 @@ pub struct Overlay {
 }
 
 impl Overlay {
+    pub(crate) const fn has_parser_metadata(&self) -> bool {
+        self.parser_metadata
+    }
+
     /// Borrows every reconstruction-relevant flat table without allocating another graph.
     #[must_use]
     pub fn view(&self) -> OverlayView<'_> {

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -705,13 +705,13 @@ impl Scanner<'_> {
         let end = index + 1 + keyword.len();
         self.bytes.get(index) == Some(&b'@')
             && self.bytes.get(index + 1..end) == Some(keyword)
-            && identifier_continue_width(self.bytes, end).is_none()
+            && keyword_boundary(self.bytes, end)
     }
 
     pub(super) fn bare_keyword_at(&self, index: usize, keyword: &[u8]) -> bool {
         let end = index + keyword.len();
         self.bytes.get(index..end) == Some(keyword)
-            && identifier_continue_width(self.bytes, end).is_none()
+            && keyword_boundary(self.bytes, end)
             && !identifier_continue_before(self.bytes, index)
     }
 
@@ -783,9 +783,8 @@ pub(super) fn unsupported_at_construct(bytes: &[u8], index: usize) -> Option<&'s
     const UNSUPPORTED: [(&[u8], &str); 1] = [(b"await", "@await control flow")];
     UNSUPPORTED.iter().find_map(|(keyword, construct)| {
         let end = index + 1 + keyword.len();
-        (bytes.get(index + 1..end) == Some(*keyword)
-            && identifier_continue_width(bytes, end).is_none())
-        .then_some(*construct)
+        (bytes.get(index + 1..end) == Some(*keyword) && keyword_boundary(bytes, end))
+            .then_some(*construct)
     })
 }
 
@@ -817,6 +816,71 @@ pub(super) fn identifier_continue_width(bytes: &[u8], index: usize) -> Option<us
         return None;
     }
     decode_non_ascii_utf8(bytes, index).map(|(_, width)| width)
+}
+
+/// Reports whether a keyword ending at `index` actually ends there.
+///
+/// `identifier_continue_width` answers that for raw bytes, but `\` is neither an identifier byte
+/// nor the start of a UTF-8 scalar, so on its own it reads a trailing `\u` escape as a boundary
+/// and turns the decorator `@for\u{03c0}` into the `@for` keyword — which then demands the `(` of a
+/// loop header. The base scanner decodes the escape for exactly this reason, and the parser lane
+/// has to agree with it, or format and lint reject a decorator the parser accepts.
+#[inline]
+fn keyword_boundary(bytes: &[u8], index: usize) -> bool {
+    if identifier_continue_width(bytes, index).is_some() {
+        return false;
+    }
+    bytes.get(index) != Some(&b'\\') || !escaped_identifier_continue(&bytes[index..])
+}
+
+/// Reports whether a leading `\uXXXX` or `\u{...}` escape names a scalar that continues an
+/// identifier. Classification deliberately mirrors `identifier_continue_width`'s raw-byte answer
+/// rather than the stricter `ID_Continue` table, so an escape and the character it spells always
+/// land on the same side of a keyword boundary. A malformed, incomplete, or out-of-range escape is
+/// not an identifier continuation, which leaves the keyword ending where it looked like it ended.
+#[cold]
+#[inline(never)]
+fn escaped_identifier_continue(suffix: &[u8]) -> bool {
+    let Some(character) = decode_unicode_escape(suffix).and_then(char::from_u32) else {
+        return false;
+    };
+    if character.is_ascii() { is_identifier_continue(character as u8) } else { true }
+}
+
+/// Decodes the code point of a leading `\uXXXX` or `\u{...}` escape, without validating that it is
+/// a scalar value; lone surrogates fall out at the `char::from_u32` that follows.
+fn decode_unicode_escape(suffix: &[u8]) -> Option<u32> {
+    if suffix.first() != Some(&b'\\') || suffix.get(1) != Some(&b'u') {
+        return None;
+    }
+    if suffix.get(2) != Some(&b'{') {
+        return suffix
+            .get(2..6)?
+            .iter()
+            .try_fold(0_u32, |value, &byte| Some(value * 16 + hex_digit(byte)?));
+    }
+    let mut value = 0_u32;
+    let mut has_digit = false;
+    for &byte in suffix.get(3..)? {
+        if byte == b'}' {
+            return has_digit.then_some(value);
+        }
+        value = value.checked_mul(16)?.checked_add(hex_digit(byte)?)?;
+        if value > 0x10_FFFF {
+            return None;
+        }
+        has_digit = true;
+    }
+    None
+}
+
+const fn hex_digit(byte: u8) -> Option<u32> {
+    match byte {
+        b'0'..=b'9' => Some((byte - b'0') as u32),
+        b'a'..=b'f' => Some((byte - b'a' + 10) as u32),
+        b'A'..=b'F' => Some((byte - b'A' + 10) as u32),
+        _ => None,
+    }
 }
 
 fn identifier_continue_before(bytes: &[u8], index: usize) -> bool {
@@ -862,4 +926,84 @@ pub(crate) const fn is_identifier_start(byte: u8) -> bool {
 
 pub(crate) const fn is_identifier_continue(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::Scanner, keyword_boundary, unsupported_at_construct};
+
+    fn boundary(suffix: &[u8]) -> bool {
+        let mut bytes = b"if".to_vec();
+        bytes.extend_from_slice(suffix);
+        keyword_boundary(&bytes, 2)
+    }
+
+    #[test]
+    fn malformed_escapes_and_non_identifier_scalars_remain_boundaries() {
+        for suffix in [
+            b"(".as_slice(),
+            b"",
+            b"\\u{}",
+            b"\\u{110000}",
+            b"\\u{2d}",
+            b"\\u002d",
+            b"\\x70",
+            b"\\u{xyz}",
+            b"\\u{3c0",
+            b"\\u03c",
+            b"\\",
+            b"\\n",
+        ] {
+            assert!(boundary(suffix), "{suffix:?}");
+        }
+    }
+
+    #[test]
+    fn escaped_identifier_continuations_are_not_boundaries() {
+        for suffix in [
+            b"\\u03c0".as_slice(),
+            b"\\u0301",
+            b"\\u200c",
+            b"\\u200d",
+            b"\\u0030",
+            b"\\u005f",
+            b"\\u0024",
+            b"\\u{1D49C}",
+            b"\\u{000003c0}",
+        ] {
+            assert!(!boundary(suffix), "{suffix:?}");
+        }
+    }
+
+    /// The escape and the character it spells have to land on the same side of the boundary, so
+    /// the parser lane keeps `identifier_continue_width`'s conservative reading of a lone
+    /// surrogate: `\uD800` decodes to no scalar and ends the keyword, exactly as the raw bytes do.
+    #[test]
+    fn lone_surrogate_escapes_end_the_keyword() {
+        assert!(boundary(b"\\uD800"));
+    }
+
+    #[test]
+    fn keyword_checks_reject_escaped_identifier_suffixes() {
+        for source in ["@for\\u03c0", "@for\u{03c0}", r"@try\u{1D49C}", "@try\u{1D49C}"] {
+            assert!(!Scanner::new_for_parser(source).keyword_at(0, b"for"), "{source}");
+            assert!(!Scanner::new_for_parser(source).keyword_at(0, b"try"), "{source}");
+        }
+        assert!(Scanner::new_for_parser("@for (").keyword_at(0, b"for"));
+
+        for source in ["is\\u03c0", "is\u{03c0}"] {
+            assert!(!Scanner::new_for_parser(source).bare_keyword_at(0, b"is"), "{source}");
+        }
+        assert!(Scanner::new_for_parser("is string").bare_keyword_at(0, b"is"));
+    }
+
+    /// `@await` is refused by name, so its boundary has to agree with every other keyword's:
+    /// `@awaitπ` is a decorator, not an unsupported control.
+    #[test]
+    fn unsupported_construct_detection_shares_the_keyword_boundary() {
+        for source in ["@await\\u03c0", "@await\u{03c0}", r"@await\u{1D49C}"] {
+            assert!(unsupported_at_construct(source.as_bytes(), 0).is_none(), "{source}");
+        }
+        assert_eq!(unsupported_at_construct(b"@await (", 0), Some("@await control flow"));
+    }
 }

--- a/crates/tsrx_syntax/src/parser_scanner/overlay.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/overlay.rs
@@ -36,6 +36,7 @@ impl Scanner<'_> {
         Overlay {
             source_len,
             source_fingerprint: source_fingerprint(self.bytes),
+            parser_metadata: true,
             tokens: self.tokens,
             nodes: self.nodes,
             clauses: self.clauses,

--- a/crates/tsrx_syntax/src/projection/builder.rs
+++ b/crates/tsrx_syntax/src/projection/builder.rs
@@ -471,7 +471,11 @@ impl<'a> Builder<'a> {
         {
             self.output.push_str("const ");
         }
-        self.copy_original(header.left)?;
+        // The lazy sigil has to be spent here, exactly as the non-type header spends it. Rewriting
+        // the header at all moves the cursor past the whole clause, and `PendingActions::next`
+        // then skips every lazy pattern behind that cursor — so an `&` copied verbatim is an `&`
+        // no later action will rewrite, and the type projection emits `const &{…}`.
+        self.copy_original_with_lazy_markers(header.left)?;
         self.output.push_str(" of ");
         self.copy_original(header.right)?;
         self.output.push(')');

--- a/crates/tsrx_syntax/src/projection/builder.rs
+++ b/crates/tsrx_syntax/src/projection/builder.rs
@@ -4,7 +4,7 @@ use crate::{
     diagnostics::{ProjectionError, to_u32},
     model::{
         ByteSpan, ClauseRole, ControlContext, ControlKind, EmbeddedKind, NONE, Overlay,
-        StructuralKind,
+        ParserCodeBlockKind, StructuralKind,
     },
 };
 
@@ -18,12 +18,15 @@ use crate::projection_view::ProjectionSegment;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Action {
     TryEnd(u32),
+    ParserCodeBlockEnd(u32),
     WrapperEnd(u32),
     WrapperStart(u32),
     Token(u32),
     Header { clause: u32, ordinal: u32 },
     ForBody(u32),
     Embedded(u32),
+    ParserShorthand(u32),
+    ParserLazyPattern(u32),
     StatementBoundary(u32),
 }
 
@@ -31,6 +34,9 @@ impl Action {
     fn key(self, overlay: &Overlay) -> (u32, u8) {
         match self {
             Self::TryEnd(node) => (overlay.nodes[node as usize].span.end, 0),
+            Self::ParserCodeBlockEnd(block) => {
+                (overlay.parser_code_blocks[block as usize].body.end.saturating_sub(1), 0)
+            }
             Self::WrapperEnd(node) => (overlay.nodes[node as usize].span.end, 1),
             Self::WrapperStart(node) => (overlay.nodes[node as usize].span.start, 2),
             Self::Token(token) => (overlay.tokens[token as usize].span.start, 3),
@@ -39,6 +45,12 @@ impl Action {
                 (overlay.clauses[clause as usize].body.start.saturating_add(1), 0)
             }
             Self::Embedded(token) => (overlay.embedded_tokens[token as usize].span.start, 3),
+            Self::ParserShorthand(attribute) => {
+                (overlay.parser_shorthand_attributes[attribute as usize].span.start, 2)
+            }
+            Self::ParserLazyPattern(pattern) => {
+                (overlay.parser_lazy_patterns[pattern as usize].ampersand, 2)
+            }
             // The boundary precedes everything else written at the same markup opening.
             Self::StatementBoundary(boundary) => {
                 (overlay.statement_boundaries[boundary as usize], 0)
@@ -167,6 +179,20 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
+    fn copy_original_with_lazy_markers(&mut self, span: ByteSpan) -> Result<(), ProjectionError> {
+        let mut cursor = span.start;
+        for (index, pattern) in self.overlay.parser_lazy_patterns.iter().enumerate() {
+            if pattern.ampersand < span.start || pattern.ampersand >= span.end {
+                continue;
+            }
+            self.copy_original(ByteSpan::new(cursor, pattern.ampersand))?;
+            write!(self.output, "/*{}Y{index}__*/", self.prefix)
+                .expect("writing to a String cannot fail");
+            cursor = pattern.ampersand.saturating_add(1);
+        }
+        self.copy_original(ByteSpan::new(cursor, span.end))
+    }
+
     fn wrapper_start(&mut self, node_index: u32) -> Result<(), ProjectionError> {
         let node = self.overlay.nodes[node_index as usize];
         self.copy_to(node.span.start as usize)?;
@@ -229,6 +255,12 @@ impl<'a> Builder<'a> {
             return Err(ProjectionError::SourceChanged { offset: token.span.start });
         }
         match token.kind {
+            StructuralKind::FunctionBody if self.parser_code_block_index(token_index).is_some() => {
+                let block_index = self
+                    .parser_code_block_index(token_index)
+                    .ok_or(ProjectionError::StructuralMismatch)?;
+                self.parser_code_block_start(token_index, block_index, start)?;
+            }
             StructuralKind::FunctionBody if self.type_semantic => {
                 write!(self.output, "/*{}{token_index}*/", self.prefix)
                     .expect("writing to a String cannot fail");
@@ -292,6 +324,81 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
+    fn parser_code_block_index(&self, token: u32) -> Option<u32> {
+        self.overlay
+            .parser_code_blocks
+            .binary_search_by_key(&token, |block| block.token)
+            .ok()
+            .and_then(|index| u32::try_from(index).ok())
+    }
+
+    fn parser_code_block_start(
+        &mut self,
+        token_index: u32,
+        block_index: u32,
+        start: usize,
+    ) -> Result<(), ProjectionError> {
+        let block = self
+            .overlay
+            .parser_code_blocks
+            .get(block_index as usize)
+            .ok_or(ProjectionError::StructuralMismatch)?;
+        self.cursor = start + 1;
+        match block.kind {
+            ParserCodeBlockKind::JsxChild => {
+                self.copy_to(start + 2)?;
+                write!(
+                    self.output,
+                    "/*{}X{block_index}P__*/(async function*(){{/*{}{token_index}*//*{}X{block_index}S__*/",
+                    self.prefix, self.prefix, self.prefix
+                )
+                .expect("writing to a String cannot fail");
+            }
+            ParserCodeBlockKind::Expression => {
+                write!(self.output, "/*{}X{block_index}P__*/void async function*()", self.prefix)
+                    .expect("writing to a String cannot fail");
+                self.copy_to(start + 2)?;
+                write!(
+                    self.output,
+                    "/*{}{token_index}*//*{}X{block_index}S__*/",
+                    self.prefix, self.prefix
+                )
+                .expect("writing to a String cannot fail");
+            }
+        }
+        Ok(())
+    }
+
+    fn parser_code_block_end(&mut self, block_index: u32) -> Result<(), ProjectionError> {
+        let block = self
+            .overlay
+            .parser_code_blocks
+            .get(block_index as usize)
+            .ok_or(ProjectionError::StructuralMismatch)?;
+        let closing =
+            block.body.end.checked_sub(1).ok_or(ProjectionError::StructuralMismatch)? as usize;
+        if self.source.as_bytes().get(closing) != Some(&b'}') {
+            return Err(ProjectionError::SourceChanged {
+                offset: block.body.end.saturating_sub(1),
+            });
+        }
+        self.copy_to(closing)?;
+        write!(self.output, "/*{}X{block_index}C__*/", self.prefix)
+            .expect("writing to a String cannot fail");
+        match block.kind {
+            ParserCodeBlockKind::JsxChild => {
+                write!(self.output, "}})/*{}X{block_index}E__*/", self.prefix)
+                    .expect("writing to a String cannot fail");
+            }
+            ParserCodeBlockKind::Expression => {
+                self.copy_to(block.body.end as usize)?;
+                write!(self.output, "/*{}X{block_index}E__*/", self.prefix)
+                    .expect("writing to a String cannot fail");
+            }
+        }
+        Ok(())
+    }
+
     fn catch_has_header(&self, node: u32) -> Result<bool, ProjectionError> {
         let mut clause = self.overlay.nodes[node as usize].first_clause;
         while clause != NONE {
@@ -315,7 +422,7 @@ impl<'a> Builder<'a> {
         }
         self.copy_to(clause.header.start as usize)?;
         self.output.push('(');
-        self.copy_original(header.left)?;
+        self.copy_original_with_lazy_markers(header.left)?;
         write!(self.output, " of {}H{ordinal}_(/*{}R{ordinal}S__*/", self.prefix, self.prefix)
             .expect("writing to a String cannot fail");
         self.copy_original(header.right)?;
@@ -501,9 +608,70 @@ impl<'a> Builder<'a> {
                 self.cursor = span_end;
             }
             EmbeddedKind::ScriptContent => {
-                return Err(ProjectionError::StructuralMismatch);
+                let script = self
+                    .overlay
+                    .script_blocks
+                    .get(token.owner as usize)
+                    .ok_or(ProjectionError::StructuralMismatch)?;
+                if script.content != token.span {
+                    return Err(ProjectionError::StructuralMismatch);
+                }
+                write!(self.output, "{{/*{}L{}__*/ null}}", self.prefix, token.owner)
+                    .expect("writing to a String cannot fail");
+                self.cursor = span_end;
             }
         }
+        Ok(())
+    }
+
+    fn parser_shorthand(&mut self, attribute_index: u32) -> Result<(), ProjectionError> {
+        let attribute = self
+            .overlay
+            .parser_shorthand_attributes
+            .get(attribute_index as usize)
+            .ok_or(ProjectionError::StructuralMismatch)?;
+        if attribute.span.start.saturating_add(1) != attribute.identifier.start
+            || attribute.identifier.end.saturating_add(1) != attribute.span.end
+            || self.source.as_bytes().get(attribute.span.start as usize) != Some(&b'{')
+            || self.source.as_bytes().get(attribute.identifier.end as usize) != Some(&b'}')
+        {
+            return Err(ProjectionError::StructuralMismatch);
+        }
+        self.copy_to(attribute.span.start as usize)?;
+        if self.type_semantic {
+            let name = self
+                .source
+                .get(attribute.identifier.start as usize..attribute.identifier.end as usize)
+                .ok_or(ProjectionError::SourceChanged { offset: attribute.identifier.start })?;
+            self.output.push_str(name);
+            self.output.push('=');
+        } else {
+            write!(self.output, "{}V{attribute_index}_=", self.prefix)
+                .expect("writing to a String cannot fail");
+        }
+        self.copy_original(attribute.span)?;
+        self.cursor = attribute.span.end as usize;
+        Ok(())
+    }
+
+    fn parser_lazy_pattern(&mut self, pattern_index: u32) -> Result<(), ProjectionError> {
+        let pattern = self
+            .overlay
+            .parser_lazy_patterns
+            .get(pattern_index as usize)
+            .ok_or(ProjectionError::StructuralMismatch)?;
+        if pattern.pattern_start <= pattern.ampersand
+            || self.source.as_bytes().get(pattern.ampersand as usize) != Some(&b'&')
+        {
+            return Err(ProjectionError::StructuralMismatch);
+        }
+        self.copy_to(pattern.ampersand as usize)?;
+        if pattern.standalone {
+            self.output.push_str("var ");
+        }
+        write!(self.output, "/*{}Y{pattern_index}__*/", self.prefix)
+            .expect("writing to a String cannot fail");
+        self.cursor = pattern.ampersand.saturating_add(1) as usize;
         Ok(())
     }
 }
@@ -522,6 +690,137 @@ pub(super) enum ProjectionPurpose {
     Types,
 }
 
+struct PendingActions<'a> {
+    overlay: &'a Overlay,
+    wrappers: &'a [Action],
+    try_ends: &'a [Action],
+    code_block_ends: &'a [Action],
+    headers: &'a [Action],
+    wrapper: usize,
+    try_end: usize,
+    code_block_end: usize,
+    token: usize,
+    header: usize,
+    embedded: usize,
+    shorthand: usize,
+    lazy_pattern: usize,
+    statement_boundary: usize,
+}
+
+impl<'a> PendingActions<'a> {
+    fn new(
+        overlay: &'a Overlay,
+        wrappers: &'a [Action],
+        try_ends: &'a [Action],
+        code_block_ends: &'a [Action],
+        headers: &'a [Action],
+    ) -> Self {
+        Self {
+            overlay,
+            wrappers,
+            try_ends,
+            code_block_ends,
+            headers,
+            wrapper: 0,
+            try_end: 0,
+            code_block_end: 0,
+            token: 0,
+            header: 0,
+            embedded: 0,
+            shorthand: 0,
+            lazy_pattern: 0,
+            statement_boundary: 0,
+        }
+    }
+
+    fn next(&mut self, original_cursor: usize) -> Result<Option<Action>, ProjectionError> {
+        while self.overlay.parser_lazy_patterns.get(self.lazy_pattern).is_some_and(|pattern| {
+            usize::try_from(pattern.ampersand).is_ok_and(|ampersand| ampersand < original_cursor)
+        }) {
+            self.lazy_pattern += 1;
+        }
+        let token = (self.token < self.overlay.tokens.len())
+            .then(|| to_u32(self.token).map(Action::Token))
+            .transpose()?;
+        let embedded = (self.embedded < self.overlay.embedded_tokens.len())
+            .then(|| to_u32(self.embedded).map(Action::Embedded))
+            .transpose()?;
+        let shorthand = (self.shorthand < self.overlay.parser_shorthand_attributes.len())
+            .then(|| to_u32(self.shorthand).map(Action::ParserShorthand))
+            .transpose()?;
+        let lazy_pattern = (self.lazy_pattern < self.overlay.parser_lazy_patterns.len())
+            .then(|| to_u32(self.lazy_pattern).map(Action::ParserLazyPattern))
+            .transpose()?;
+        let statement_boundary = (self.statement_boundary
+            < self.overlay.statement_boundaries.len())
+        .then(|| to_u32(self.statement_boundary).map(Action::StatementBoundary))
+        .transpose()?;
+        Ok([
+            self.wrappers.get(self.wrapper).copied(),
+            self.try_ends.get(self.try_end).copied(),
+            self.code_block_ends.get(self.code_block_end).copied(),
+            token,
+            self.headers.get(self.header).copied(),
+            embedded,
+            shorthand,
+            lazy_pattern,
+            statement_boundary,
+        ]
+        .into_iter()
+        .flatten()
+        .min_by_key(|action| action.key(self.overlay)))
+    }
+
+    fn apply(&mut self, builder: &mut Builder<'_>, action: Action) -> Result<(), ProjectionError> {
+        match action {
+            Action::TryEnd(node) => {
+                self.try_end += 1;
+                builder.try_end(node)
+            }
+            Action::ParserCodeBlockEnd(block) => {
+                self.code_block_end += 1;
+                builder.parser_code_block_end(block)
+            }
+            Action::WrapperEnd(node) => {
+                self.wrapper += 1;
+                builder.wrapper_end(node)
+            }
+            Action::WrapperStart(node) => {
+                self.wrapper += 1;
+                builder.wrapper_start(node)
+            }
+            Action::Token(token) => {
+                self.token += 1;
+                builder.token(token)
+            }
+            Action::Header { clause, ordinal } => {
+                self.header += 1;
+                builder.header(clause, ordinal)
+            }
+            Action::ForBody(clause) => {
+                self.header += 1;
+                builder.for_body(clause)
+            }
+            Action::Embedded(token) => {
+                self.embedded += 1;
+                builder.embedded(token)
+            }
+            Action::ParserShorthand(attribute) => {
+                self.shorthand += 1;
+                builder.parser_shorthand(attribute)
+            }
+            Action::ParserLazyPattern(pattern) => {
+                self.lazy_pattern += 1;
+                builder.parser_lazy_pattern(pattern)
+            }
+            Action::StatementBoundary(boundary) => {
+                self.statement_boundary += 1;
+                builder.statement_boundary(boundary)
+            }
+        }
+    }
+}
+
 pub(super) fn build_projection_with_purpose(
     source: &str,
     overlay: &Overlay,
@@ -536,6 +835,13 @@ pub(super) fn build_projection_with_purpose(
 
     let (header_actions, headers) =
         build_header_actions(overlay, purpose == ProjectionPurpose::Types)?;
+    let mut parser_code_block_end_actions = overlay
+        .parser_code_blocks
+        .iter()
+        .enumerate()
+        .map(|(index, _)| to_u32(index).map(Action::ParserCodeBlockEnd))
+        .collect::<Result<Vec<_>, _>>()?;
+    parser_code_block_end_actions.sort_unstable_by_key(|action| action.key(overlay));
 
     let mut builder = Builder::new(
         source,
@@ -544,66 +850,15 @@ pub(super) fn build_projection_with_purpose(
         record_segments,
         purpose == ProjectionPurpose::Types,
     );
-    let mut wrapper_cursor = 0usize;
-    let mut try_end_cursor = 0usize;
-    let mut token_cursor = 0usize;
-    let mut header_cursor = 0usize;
-    let mut embedded_cursor = 0usize;
-    let mut statement_boundary_cursor = 0usize;
-    loop {
-        let wrapper = wrapper_actions.get(wrapper_cursor).copied();
-        let try_end = try_end_actions.get(try_end_cursor).copied();
-        let token = (token_cursor < overlay.tokens.len())
-            .then(|| to_u32(token_cursor).map(Action::Token))
-            .transpose()?;
-        let header = header_actions.get(header_cursor).copied();
-        let embedded = (embedded_cursor < overlay.embedded_tokens.len())
-            .then(|| to_u32(embedded_cursor).map(Action::Embedded))
-            .transpose()?;
-        let statement_boundary = (statement_boundary_cursor < overlay.statement_boundaries.len())
-            .then(|| to_u32(statement_boundary_cursor).map(Action::StatementBoundary))
-            .transpose()?;
-        let Some(action) = [wrapper, try_end, token, header, embedded, statement_boundary]
-            .into_iter()
-            .flatten()
-            .min_by_key(|action| action.key(overlay))
-        else {
-            break;
-        };
-        match action {
-            Action::TryEnd(node) => {
-                try_end_cursor += 1;
-                builder.try_end(node)?;
-            }
-            Action::WrapperEnd(node) => {
-                wrapper_cursor += 1;
-                builder.wrapper_end(node)?;
-            }
-            Action::WrapperStart(node) => {
-                wrapper_cursor += 1;
-                builder.wrapper_start(node)?;
-            }
-            Action::Token(token) => {
-                token_cursor += 1;
-                builder.token(token)?;
-            }
-            Action::Header { clause, ordinal } => {
-                header_cursor += 1;
-                builder.header(clause, ordinal)?;
-            }
-            Action::ForBody(clause) => {
-                header_cursor += 1;
-                builder.for_body(clause)?;
-            }
-            Action::Embedded(token) => {
-                embedded_cursor += 1;
-                builder.embedded(token)?;
-            }
-            Action::StatementBoundary(boundary) => {
-                statement_boundary_cursor += 1;
-                builder.statement_boundary(boundary)?;
-            }
-        }
+    let mut pending = PendingActions::new(
+        overlay,
+        &wrapper_actions,
+        &try_end_actions,
+        &parser_code_block_end_actions,
+        &header_actions,
+    );
+    while let Some(action) = pending.next(builder.cursor)? {
+        pending.apply(&mut builder, action)?;
     }
     let mut mapped = builder.finish()?;
     mapped.synthetic_generator_spans = overlay

--- a/crates/tsrx_syntax/src/projection/format.rs
+++ b/crates/tsrx_syntax/src/projection/format.rs
@@ -1,9 +1,12 @@
 use crate::{
     diagnostics::{ProjectionError, to_u32},
-    model::{ByteSpan, ControlContext, NONE, Overlay, StructuralKind},
+    model::{
+        ByteSpan, ControlContext, NONE, Overlay, ParserCodeBlock, ParserLazyPattern,
+        ParserShorthandAttribute, StructuralKind,
+    },
 };
 
-use super::{builder::build_projection, marker::structural_fingerprint};
+use super::{builder::build_projection, marker::structural_fingerprint, parser_overlay};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct WrapperManifest {
@@ -38,6 +41,11 @@ pub(super) struct DynamicManifest {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct StyleManifest {
+    pub(super) payload: ByteSpan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ScriptManifest {
     pub(super) payload: ByteSpan,
 }
 
@@ -79,6 +87,10 @@ pub struct FormatProjection {
     dynamic_offsets: Vec<u32>,
     pub(super) dynamic_comments: Vec<ByteSpan>,
     pub(super) styles: Vec<StyleManifest>,
+    pub(super) scripts: Vec<ScriptManifest>,
+    pub(super) parser_code_blocks: Vec<ParserCodeBlock>,
+    pub(super) parser_shorthand_attributes: Vec<ParserShorthandAttribute>,
+    pub(super) parser_lazy_patterns: Vec<ParserLazyPattern>,
     pub(super) shape_fingerprint: u128,
 }
 
@@ -90,7 +102,14 @@ impl FormatProjection {
 
     #[must_use]
     pub fn marker_count(&self) -> usize {
-        self.tokens.len() + self.dynamics.len() + self.dynamic_comments.len() + self.styles.len()
+        self.tokens.len()
+            + self.dynamics.len()
+            + self.dynamic_comments.len()
+            + self.styles.len()
+            + self.scripts.len()
+            + self.parser_code_blocks.len()
+            + self.parser_shorthand_attributes.len()
+            + self.parser_lazy_patterns.len()
     }
 
     #[must_use]
@@ -111,6 +130,10 @@ impl FormatProjection {
 
 /// Builds a legal-TSX formatter projection and checked lift manifest.
 ///
+/// A base [`crate::scan`] overlay is upgraded to the richer parser/tooling
+/// overlay for compatibility. Hot paths should pass [`crate::scan_for_parser`]
+/// output to avoid a second scan.
+///
 /// # Errors
 ///
 /// Returns an error for a stale overlay or a projection scaffold collision.
@@ -118,6 +141,8 @@ pub fn project_for_format(
     source: &str,
     overlay: &Overlay,
 ) -> Result<FormatProjection, ProjectionError> {
+    let overlay = parser_overlay(source, overlay)?;
+    let overlay = overlay.as_ref();
     let built = build_projection(source, overlay, false)?;
     let mut try_slots = vec![NONE; overlay.nodes.len()];
     for (slot, manifest) in built.tries.iter().enumerate() {
@@ -125,6 +150,11 @@ pub fn project_for_format(
     }
     let styles =
         overlay.style_blocks.iter().map(|style| StyleManifest { payload: style.content }).collect();
+    let scripts = overlay
+        .script_blocks
+        .iter()
+        .map(|script| ScriptManifest { payload: script.content })
+        .collect();
     let dynamic_count = to_u32(overlay.dynamic_tags.len())?;
     Ok(FormatProjection {
         projected: built.mapped.projected,
@@ -147,6 +177,10 @@ pub fn project_for_format(
         dynamic_offsets: overlay.dynamic_tags.iter().map(|tag| tag.expression.start).collect(),
         dynamic_comments: overlay.dynamic_comments.clone(),
         styles,
+        scripts,
+        parser_code_blocks: overlay.parser_code_blocks.clone(),
+        parser_shorthand_attributes: overlay.parser_shorthand_attributes.clone(),
+        parser_lazy_patterns: overlay.parser_lazy_patterns.clone(),
         shape_fingerprint: structural_fingerprint(overlay),
     })
 }
@@ -156,7 +190,8 @@ mod layout_tests {
     use std::mem::size_of;
 
     use super::{
-        DynamicManifest, HeaderManifest, StyleManifest, TokenManifest, TryManifest, WrapperManifest,
+        DynamicManifest, HeaderManifest, ScriptManifest, StyleManifest, TokenManifest, TryManifest,
+        WrapperManifest,
     };
 
     #[test]
@@ -167,5 +202,6 @@ mod layout_tests {
         assert_eq!(size_of::<TryManifest>(), 8);
         assert_eq!(size_of::<DynamicManifest>(), 1);
         assert_eq!(size_of::<StyleManifest>(), 8);
+        assert_eq!(size_of::<ScriptManifest>(), 8);
     }
 }

--- a/crates/tsrx_syntax/src/projection/lift/embedded.rs
+++ b/crates/tsrx_syntax/src/projection/lift/embedded.rs
@@ -19,15 +19,23 @@ pub(super) fn lift_embedded(
     let dynamic_close = format!("</{}D", projection.prefix);
     let comment_marker = format!("{{/*{}Q", projection.prefix);
     let style_marker = format!("{{/*{}S", projection.prefix);
+    let script_marker = format!("{{/*{}L", projection.prefix);
     let mut expressions = vec![ScaffoldSpan::MISSING; projection.dynamics.len()];
     let mut opened = vec![false; projection.dynamics.len()];
     let mut closed = vec![false; projection.dynamics.len()];
     let mut comments = vec![false; projection.dynamic_comments.len()];
     let mut styles = vec![false; projection.styles.len()];
+    let mut scripts = vec![false; projection.scripts.len()];
     let restored_bytes = projection
         .styles
         .iter()
         .map(|manifest| (manifest.payload.end - manifest.payload.start) as usize)
+        .chain(
+            projection
+                .scripts
+                .iter()
+                .map(|manifest| (manifest.payload.end - manifest.payload.start) as usize),
+        )
         .chain(projection.dynamic_comments.iter().map(|span| (span.end - span.start) as usize))
         .fold(0usize, usize::saturating_add);
     let mut output = String::with_capacity(source.len().saturating_add(restored_bytes));
@@ -150,6 +158,28 @@ pub(super) fn lift_embedded(
             styles[index] = true;
             continue;
         }
+        if source[cursor..].starts_with(&script_marker) {
+            let digits_start = cursor + script_marker.len();
+            let (ordinal, digits_end) =
+                parse_decimal(bytes, digits_start).ok_or(ProjectionError::MarkerResidual)?;
+            let index = ordinal as usize;
+            let manifest = projection.scripts.get(index).ok_or(ProjectionError::MarkerResidual)?;
+            if scripts[index] || source.as_bytes().get(digits_end..digits_end + 4) != Some(b"__*/")
+            {
+                return Err(ProjectionError::ScaffoldMismatch { index });
+            }
+            let mut end = expect_word_after_whitespace(source, digits_end + 4, b"null", index)?;
+            end = expect_byte_after_whitespace(source, end, b'}', index)?;
+            let payload = original_source
+                .get(manifest.payload.start as usize..manifest.payload.end as usize)
+                .ok_or(ProjectionError::StructuralMismatch)?;
+            output.push_str(&source[copied..cursor]);
+            output.push_str(payload);
+            copied = end;
+            cursor = end;
+            scripts[index] = true;
+            continue;
+        }
         cursor += source[cursor..].chars().next().map_or(1, char::len_utf8);
     }
     output.push_str(&source[copied..]);
@@ -165,6 +195,10 @@ pub(super) fn lift_embedded(
     }
     if comments.iter().any(|seen| !seen) {
         let index = comments.iter().position(|seen| !seen).unwrap_or(0);
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    if scripts.iter().any(|seen| !seen) {
+        let index = scripts.iter().position(|seen| !seen).unwrap_or(0);
         return Err(ProjectionError::ScaffoldMismatch { index });
     }
     Ok(output)

--- a/crates/tsrx_syntax/src/projection/lift/mod.rs
+++ b/crates/tsrx_syntax/src/projection/lift/mod.rs
@@ -1,13 +1,15 @@
 mod embedded;
+mod parser;
 mod scaffold;
 mod text;
 mod tokens;
 mod writer;
 
-use crate::{diagnostics::ProjectionError, scanner::Scanner};
+use crate::{diagnostics::ProjectionError, parser_scanner::Scanner};
 
 use super::{format::FormatProjection, marker::structural_fingerprint};
 use embedded::lift_embedded;
+use parser::lift_parser_scaffolds;
 use scaffold::lift_scaffolds;
 use tokens::lift_tokens;
 
@@ -38,10 +40,12 @@ pub fn lift_formatted(
     original_source: &str,
     projection: &FormatProjection,
 ) -> Result<String, ProjectionError> {
-    let lifted = lift_scaffolds(formatted, projection)?;
+    let lifted = lift_parser_scaffolds(formatted, projection)?;
+    let lifted = lift_scaffolds(&lifted, projection)?;
     let lifted = if projection.dynamics.is_empty()
         && projection.dynamic_comments.is_empty()
         && projection.styles.is_empty()
+        && projection.scripts.is_empty()
     {
         lifted
     } else {
@@ -51,7 +55,7 @@ pub fn lift_formatted(
     if lifted.contains(&projection.prefix) {
         return Err(ProjectionError::MarkerResidual);
     }
-    let rescanned = Scanner::new(&lifted).finish()?;
+    let rescanned = Scanner::new_for_parser(&lifted).finish()?;
     if structural_fingerprint(&rescanned) != projection.shape_fingerprint {
         return Err(ProjectionError::StructuralMismatch);
     }

--- a/crates/tsrx_syntax/src/projection/lift/parser.rs
+++ b/crates/tsrx_syntax/src/projection/lift/parser.rs
@@ -1,0 +1,201 @@
+use crate::{diagnostics::ProjectionError, model::ParserCodeBlockKind};
+
+use super::{
+    super::format::FormatProjection,
+    ScaffoldSpan,
+    text::{
+        expect_byte_after_whitespace, expect_word_after_whitespace, previous_non_whitespace,
+        skip_ascii_whitespace,
+    },
+};
+
+pub(super) fn lift_parser_scaffolds(
+    formatted: &str,
+    projection: &FormatProjection,
+) -> Result<String, ProjectionError> {
+    if projection.parser_code_blocks.is_empty()
+        && projection.parser_shorthand_attributes.is_empty()
+        && projection.parser_lazy_patterns.is_empty()
+    {
+        return Ok(formatted.to_string());
+    }
+
+    let mut lifted = formatted.to_string();
+    for index in (0..projection.parser_code_blocks.len()).rev() {
+        lifted = lift_code_block(&lifted, projection, index)?;
+    }
+    for index in (0..projection.parser_shorthand_attributes.len()).rev() {
+        lifted = lift_shorthand(&lifted, projection, index)?;
+    }
+    for index in (0..projection.parser_lazy_patterns.len()).rev() {
+        lifted = lift_lazy_pattern(&lifted, projection, index)?;
+    }
+    Ok(lifted)
+}
+
+fn lift_code_block(
+    source: &str,
+    projection: &FormatProjection,
+    index: usize,
+) -> Result<String, ProjectionError> {
+    let block = projection
+        .parser_code_blocks
+        .get(index)
+        .ok_or(ProjectionError::ScaffoldMismatch { index })?;
+    let prefix = &projection.prefix;
+    let prefix_marker = unique_marker(source, &format!("/*{prefix}X{index}P__*/"), index)?;
+    let start_marker = unique_marker(source, &format!("/*{prefix}X{index}S__*/"), index)?;
+    let close_marker = unique_marker(source, &format!("/*{prefix}X{index}C__*/"), index)?;
+    let end_marker = unique_marker(source, &format!("/*{prefix}X{index}E__*/"), index)?;
+    let token_marker = unique_marker(source, &format!("/*{prefix}{}*/", block.token), index)?;
+
+    let mut cursor = prefix_marker.end;
+    let (replace_start, parenthesized) = match block.kind {
+        ParserCodeBlockKind::JsxChild => {
+            let open = previous_non_whitespace(source, prefix_marker.start)
+                .filter(|position| source.as_bytes()[*position] == b'{')
+                .ok_or(ProjectionError::ScaffoldMismatch { index })?;
+            let candidate = skip_ascii_whitespace(source, cursor);
+            let parenthesized = source.as_bytes().get(candidate) == Some(&b'(');
+            if parenthesized {
+                cursor = candidate + 1;
+            }
+            (open, parenthesized)
+        }
+        ParserCodeBlockKind::Expression => {
+            cursor = expect_word_after_whitespace(source, cursor, b"void", index)?;
+            (prefix_marker.start, false)
+        }
+    };
+    cursor = expect_word_after_whitespace(source, cursor, b"async", index)?;
+    cursor = expect_word_after_whitespace(source, cursor, b"function", index)?;
+    cursor = expect_byte_after_whitespace(source, cursor, b'*', index)?;
+    cursor = expect_byte_after_whitespace(source, cursor, b'(', index)?;
+    cursor = expect_byte_after_whitespace(source, cursor, b')', index)?;
+    cursor = expect_byte_after_whitespace(source, cursor, b'{', index)?;
+    cursor = expect_span_after_whitespace(source, cursor, token_marker, index)?;
+    let _ = expect_span_after_whitespace(source, cursor, start_marker, index)?;
+
+    if !(start_marker.end <= close_marker.start && close_marker.end <= end_marker.start) {
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    cursor = expect_byte_after_whitespace(source, close_marker.end, b'}', index)?;
+    if parenthesized {
+        cursor = expect_byte_after_whitespace(source, cursor, b')', index)?;
+    }
+    let semicolon = skip_ascii_whitespace(source, cursor);
+    let preserve_semicolon = source.as_bytes().get(semicolon) == Some(&b';');
+    if preserve_semicolon {
+        cursor = semicolon + 1;
+    }
+    cursor = expect_span_after_whitespace(source, cursor, end_marker, index)?;
+    let replace_end = if block.kind == ParserCodeBlockKind::JsxChild {
+        expect_byte_after_whitespace(source, cursor, b'}', index)?
+    } else {
+        cursor
+    };
+
+    let mut replacement = String::with_capacity(
+        token_marker
+            .end
+            .saturating_sub(token_marker.start)
+            .saturating_add(close_marker.start.saturating_sub(start_marker.end))
+            .saturating_add(2),
+    );
+    replacement.push_str(&source[token_marker.start..token_marker.end]);
+    replacement.push('{');
+    replacement.push_str(&source[start_marker.end..close_marker.start]);
+    replacement.push('}');
+    if preserve_semicolon {
+        replacement.push(';');
+    }
+    replace_range(source, replace_start, replace_end, &replacement, index)
+}
+
+fn lift_shorthand(
+    source: &str,
+    projection: &FormatProjection,
+    index: usize,
+) -> Result<String, ProjectionError> {
+    let marker = unique_marker(source, &format!("{}V{index}_", projection.prefix), index)?;
+    let end = expect_byte_after_whitespace(source, marker.end, b'=', index)?;
+    let expression = skip_ascii_whitespace(source, end);
+    if source.as_bytes().get(expression) != Some(&b'{') {
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    replace_range(source, marker.start, end, "", index)
+}
+
+fn lift_lazy_pattern(
+    source: &str,
+    projection: &FormatProjection,
+    index: usize,
+) -> Result<String, ProjectionError> {
+    let pattern = projection
+        .parser_lazy_patterns
+        .get(index)
+        .ok_or(ProjectionError::ScaffoldMismatch { index })?;
+    let marker = unique_marker(source, &format!("/*{}Y{index}__*/", projection.prefix), index)?;
+    let pattern_start = skip_ascii_whitespace(source, marker.end);
+    if !matches!(source.as_bytes().get(pattern_start), Some(b'{' | b'[')) {
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    let replace_start = if pattern.standalone {
+        let var_end = previous_non_whitespace(source, marker.start)
+            .ok_or(ProjectionError::ScaffoldMismatch { index })?
+            .saturating_add(1);
+        let var_start = var_end.saturating_sub(3);
+        if source.as_bytes().get(var_start..var_end) != Some(b"var")
+            || var_start > 0 && source.as_bytes()[var_start - 1].is_ascii_alphanumeric()
+        {
+            return Err(ProjectionError::ScaffoldMismatch { index });
+        }
+        var_start
+    } else {
+        marker.start
+    };
+    replace_range(source, replace_start, pattern_start, "&", index)
+}
+
+fn unique_marker(
+    source: &str,
+    needle: &str,
+    index: usize,
+) -> Result<ScaffoldSpan, ProjectionError> {
+    let start = source.find(needle).ok_or(ProjectionError::ScaffoldMismatch { index })?;
+    if source[start + needle.len()..].contains(needle) {
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    Ok(ScaffoldSpan { start, end: start + needle.len() })
+}
+
+fn expect_span_after_whitespace(
+    source: &str,
+    cursor: usize,
+    expected: ScaffoldSpan,
+    index: usize,
+) -> Result<usize, ProjectionError> {
+    if skip_ascii_whitespace(source, cursor) != expected.start {
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    Ok(expected.end)
+}
+
+fn replace_range(
+    source: &str,
+    start: usize,
+    end: usize,
+    replacement: &str,
+    index: usize,
+) -> Result<String, ProjectionError> {
+    if start > end || end > source.len() {
+        return Err(ProjectionError::ScaffoldMismatch { index });
+    }
+    let mut output = String::with_capacity(
+        source.len().saturating_sub(end - start).saturating_add(replacement.len()),
+    );
+    output.push_str(&source[..start]);
+    output.push_str(replacement);
+    output.push_str(&source[end..]);
+    Ok(output)
+}

--- a/crates/tsrx_syntax/src/projection/lift/scaffold.rs
+++ b/crates/tsrx_syntax/src/projection/lift/scaffold.rs
@@ -339,7 +339,7 @@ fn index_scaffolds(
                 };
                 set_scaffold_span(target, span, node as usize)?;
             }
-            b'D' | b'A' | b'Z' | b'Q' | b'S' => {}
+            b'D' | b'A' | b'Z' | b'Q' | b'S' | b'L' => {}
             _ => return Err(ProjectionError::MarkerResidual),
         }
         cursor = suffix_start + 1;

--- a/crates/tsrx_syntax/src/projection/lint.rs
+++ b/crates/tsrx_syntax/src/projection/lint.rs
@@ -2,6 +2,7 @@ use crate::{diagnostics::ProjectionError, model::Overlay};
 
 use super::{
     builder::build_projection, mapping::MappedProjection, marker::validate_overlay_source,
+    parser_overlay,
 };
 
 /// Performs the legacy equal-width projection used by standard-syntax control baselines.
@@ -29,6 +30,10 @@ pub fn project(source: &str, overlay: &Overlay) -> Result<String, ProjectionErro
 
 /// Builds a legal-TSX projection with explicit affine source-map segments.
 ///
+/// A base [`crate::scan`] overlay is upgraded to the richer parser/tooling
+/// overlay for compatibility. Hot paths should pass [`crate::scan_for_parser`]
+/// output to avoid a second scan.
+///
 /// # Errors
 ///
 /// Returns an error for a stale overlay or a projection scaffold collision.
@@ -36,5 +41,6 @@ pub fn project_for_lint(
     source: &str,
     overlay: &Overlay,
 ) -> Result<MappedProjection, ProjectionError> {
-    Ok(build_projection(source, overlay, true)?.mapped)
+    let overlay = parser_overlay(source, overlay)?;
+    Ok(build_projection(source, overlay.as_ref(), true)?.mapped)
 }

--- a/crates/tsrx_syntax/src/projection/mod.rs
+++ b/crates/tsrx_syntax/src/projection/mod.rs
@@ -6,8 +6,24 @@ mod mapping;
 mod marker;
 mod types;
 
+use std::borrow::Cow;
+
+use crate::{diagnostics::ProjectionError, model::Overlay};
+
 pub use format::{FormatProjection, project_for_format};
 pub use lift::lift_formatted;
 pub use lint::{project, project_for_lint};
 pub use mapping::{MappedProjection, TypeProjection};
 pub use types::project_for_types;
+
+fn parser_overlay<'a>(
+    source: &str,
+    overlay: &'a Overlay,
+) -> Result<Cow<'a, Overlay>, ProjectionError> {
+    marker::validate_overlay_source(source, overlay)?;
+    if overlay.has_parser_metadata() {
+        Ok(Cow::Borrowed(overlay))
+    } else {
+        crate::scan_for_parser(source).map(Cow::Owned)
+    }
+}

--- a/crates/tsrx_syntax/src/projection/types.rs
+++ b/crates/tsrx_syntax/src/projection/types.rs
@@ -8,6 +8,7 @@ use crate::{
 use super::{
     builder::{ProjectionPurpose, build_projection_with_purpose},
     mapping::TypeProjection,
+    parser_overlay,
 };
 
 /// Builds the Rust-native TypeScript-Go projection.
@@ -15,6 +16,8 @@ use super::{
 /// Synthetic helpers are declared after the projected module. Keeping the declarations at the end
 /// preserves every authored/scaffold offset shared with the normal syntax-lint projection, which
 /// lets one OXC parse supply disable-directive spans without a second parser pass.
+/// A base [`crate::scan`] overlay is upgraded for compatibility; hot paths
+/// should pass [`crate::scan_for_parser`] output.
 ///
 /// # Errors
 ///
@@ -23,6 +26,8 @@ pub fn project_for_types(
     source: &str,
     overlay: &Overlay,
 ) -> Result<TypeProjection, ProjectionError> {
+    let overlay = parser_overlay(source, overlay)?;
+    let overlay = overlay.as_ref();
     let built = build_projection_with_purpose(source, overlay, true, ProjectionPurpose::Types)?;
     let mut projected = built.mapped.projected;
     append_type_helper_declarations(&mut projected, overlay, &built.prefix);

--- a/crates/tsrx_syntax/src/scanner/mod.rs
+++ b/crates/tsrx_syntax/src/scanner/mod.rs
@@ -73,6 +73,7 @@ impl<'a> Scanner<'a> {
         Ok(Overlay {
             source_len,
             source_fingerprint: source_fingerprint(self.bytes),
+            parser_metadata: false,
             tokens: self.tokens,
             nodes: self.nodes,
             clauses: self.clauses,

--- a/crates/tsrx_syntax/tests/architecture.rs
+++ b/crates/tsrx_syntax/tests/architecture.rs
@@ -86,10 +86,10 @@ fn the_parser_lanes_mirror_the_base_scanner_and_projection_module_boundaries() {
 
 #[test]
 fn the_parser_lanes_carry_no_switch_between_a_configuration_they_are_never_built_in() {
-    // `scan()` and every `project*` entry point but `scan_for_parser` / `project_for_parser` run
-    // the base lanes in `src/scanner` and `src/projection`. The parser lanes therefore only ever
-    // run in one configuration, and a switch naming the other one is dead code rustc cannot see,
-    // because a comparison counts as a use.
+    // `scan_for_parser` supplies the richer overlay used by the parser and tooling projections;
+    // compatibility calls that pass a base `scan()` overlay to lint/format are upgraded before
+    // projection. The parser lanes still only ever run in one configuration, and a switch naming
+    // another one is dead code rustc cannot see, because a comparison counts as a use.
     let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     for (lane, switch) in [
         ("src/parser_scanner", "parser_mode"),

--- a/crates/tsrx_syntax/tests/public_api.rs
+++ b/crates/tsrx_syntax/tests/public_api.rs
@@ -2,7 +2,7 @@ use std::fmt::Write as _;
 
 use tsrx_syntax::{
     ProjectionError, StructuralKind, lift_formatted, project, project_for_format, project_for_lint,
-    project_for_types, scan,
+    project_for_types, scan, scan_for_parser,
 };
 
 #[test]
@@ -112,6 +112,64 @@ fn type_projection_preserves_loop_bindings_and_identity_fix_boundaries() {
     );
     let wrapper = u32::try_from(projection.source().find("W0_").unwrap()).unwrap();
     assert!(projection.map_fix_range(wrapper..wrapper + 3).is_none());
+}
+
+/// An annotated `@for` rewrites its header clause by clause, and the type lane rewrites it a
+/// second, different way. Both have to spend the lazy sigil: the shared action queue skips every
+/// lazy pattern the header already passed, so a `&` the type lane copies verbatim is a `&` nothing
+/// downstream will ever rewrite, and the projection lands on TypeScript that cannot parse.
+#[test]
+fn type_projection_rewrites_lazy_sigils_in_annotated_for_headers() {
+    let source = concat!(
+        "declare const items:{id:string;label:string}[];",
+        "function View() @{<ol>@for(&{id, label} of items;index i;key id){",
+        "<li>{i}{label}</li>}</ol>}"
+    );
+    let overlay = scan_for_parser(source).unwrap();
+    let projection = project_for_types(source, &overlay).unwrap();
+
+    assert!(!projection.source().contains('&'), "{}", projection.source());
+    assert!(!projection.source().contains("const &"), "{}", projection.source());
+    assert!(projection.source().contains(" of items)"), "{}", projection.source());
+    assert!(projection.source().contains("let i = 0;"), "{}", projection.source());
+
+    // The pattern's own bindings survive the rewrite, so type checking still sees them.
+    assert!(projection.source().contains("label"), "{}", projection.source());
+
+    // Rewriting the sigil must not shear the mapping: `label` inside the body still points at the
+    // authored `label` it came from, not at an offset shifted by the marker comment.
+    let projected = u32::try_from(projection.source().rfind("label").unwrap()).unwrap();
+    let authored = u32::try_from(source.rfind("label").unwrap()).unwrap();
+    assert_eq!(
+        projection.map_range(projected..projected + 5),
+        Some(authored..authored + 5),
+        "{}",
+        projection.source()
+    );
+
+    // An array pattern reaches the same rewrite through a different sigil position, and an
+    // `index`-only header exercises it without a `key` clause following.
+    let array = concat!(
+        "declare const pairs:string[][];",
+        "function View() @{<ul>@for(&[head] of pairs;index j){<li>{j}{head}</li>}</ul>}"
+    );
+    let array_projection = project_for_types(array, &scan_for_parser(array).unwrap()).unwrap();
+    assert!(!array_projection.source().contains('&'), "{}", array_projection.source());
+    assert!(
+        array_projection.source().contains("[head] of pairs)"),
+        "{}",
+        array_projection.source()
+    );
+
+    // A header with no lazy sigil is untouched by the rewrite, so the marker only ever appears
+    // where the author wrote an ampersand.
+    let plain = concat!(
+        "declare const items:{id:string}[];",
+        "function View() @{<ol>@for(const item of items;index i){<li>{i}{item.id}</li>}</ol>}"
+    );
+    let plain_projection = project_for_types(plain, &scan_for_parser(plain).unwrap()).unwrap();
+    assert!(plain_projection.source().contains("for(const item of items)"));
+    assert!(!plain_projection.source().contains("Y0__"), "{}", plain_projection.source());
 }
 
 #[test]
@@ -495,6 +553,54 @@ fn checked_lift_rejects_changed_wrapper_identity() {
         lift_formatted(&changed, source, &projection),
         Err(ProjectionError::ScaffoldMismatch { .. })
     ));
+}
+
+/// The parser lane backs format and lint, so a decorator whose name merely starts with a control
+/// keyword has to stay an identifier there too. Escaped continuations are the sharp edge: `\` is
+/// not an identifier byte, so a boundary check that only reads raw bytes sees `@for` in
+/// `@for\u{03c0}` and then rejects the file for a missing `(`.
+#[test]
+fn unicode_identifier_suffixes_do_not_form_tsrx_controls_on_the_parser_lane() {
+    const KEYWORDS: [&str; 11] = [
+        "if", "else", "for", "empty", "switch", "case", "default", "try", "pending", "catch",
+        "await",
+    ];
+    const SUFFIXES: [(&str, &str); 14] = [
+        ("raw pi", "\u{03c0}"),
+        ("escaped pi", "\\u03c0"),
+        ("raw combining mark", "\u{0301}"),
+        ("escaped combining mark", "\\u0301"),
+        ("raw ZWNJ", "\u{200c}"),
+        ("escaped ZWNJ", "\\u200c"),
+        ("raw ZWJ", "\u{200d}"),
+        ("escaped ZWJ", "\\u200d"),
+        ("escaped digit", "\\u0030"),
+        ("escaped underscore", "\\u005f"),
+        ("escaped dollar", "\\u0024"),
+        ("raw astral identifier", "\u{1D49C}"),
+        ("escaped astral identifier", r"\u{1D49C}"),
+        ("long braced escape with leading zeroes", r"\u{000003c0}"),
+    ];
+
+    for keyword in KEYWORDS {
+        for (case, suffix) in SUFFIXES {
+            let source = format!("@{keyword}{suffix}\nclass Decorated {{ method() {{}} }}\n");
+            let overlay = scan_for_parser(&source)
+                .unwrap_or_else(|error| panic!("{case} after @{keyword}: {error}"));
+            assert!(overlay.tokens().is_empty(), "{case} after @{keyword}");
+        }
+    }
+
+    for suffix in ["\u{03c0}", "\\u03c0", "\u{200d}", r"\u{1D49C}"] {
+        let source = format!("function View() @{{<main>@if{suffix} is JSX text</main>}}");
+        let overlay =
+            scan_for_parser(&source).unwrap_or_else(|error| panic!("JSX text {suffix}: {error}"));
+        assert_eq!(
+            overlay.tokens().iter().map(|token| token.kind).collect::<Vec<_>>(),
+            [StructuralKind::FunctionBody],
+            "JSX text {suffix}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tsrx_syntax/tests/public_api.rs
+++ b/crates/tsrx_syntax/tests/public_api.rs
@@ -275,6 +275,79 @@ fn unformatted_projection_round_trips_through_checked_lift() {
 }
 
 #[test]
+fn parser_only_scaffolds_round_trip_through_the_format_projection() {
+    for source in [
+        "const value = @{ const ready = true; ready };\n",
+        "const view = <main>@{ const ready = true; <p>{ready}</p> }</main>;\n",
+        "const view = <Card {label} />;\n",
+        "const &{ value = 1, ...rest } = source;\n",
+        "&[first, ...rest] = source;\n",
+        "const rows = <List>{items.map((&{ id, label }) => <p>{id}{label}</p>)}</List>;\n",
+        "const view = <main>@{ const &{ value } = source; <p {value} /> }</main>;\n",
+        "const view = <script>if (ready) console.log(\"raw\");</script>;\n",
+    ] {
+        let projection =
+            project_for_format(source, &tsrx_syntax::scan_for_parser(source).unwrap()).unwrap();
+        let lifted = lift_formatted(projection.source(), source, &projection)
+            .unwrap_or_else(|error| panic!("failed to lift {source:?}: {error}"));
+        assert_eq!(lifted, source);
+    }
+}
+
+#[test]
+fn lint_projection_maps_authored_parser_leaves_but_not_scaffolding() {
+    let source = concat!(
+        "const value = @{ console.log(input); input };\n",
+        "const &{ label } = props;\n",
+        "const view = <Card {label} />;\n",
+        "const raw = <script>console.log('opaque');</script>;\n",
+    );
+    let projection = project_for_lint(source, &scan(source).unwrap()).unwrap();
+    for needle in ["console.log(input)", "{ label }", "{label}"] {
+        let projected = projection.source().find(needle).unwrap();
+        let authored = source.find(needle).unwrap();
+        let mapped = projection
+            .map_range(
+                u32::try_from(projected).unwrap()..u32::try_from(projected + needle.len()).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(
+            mapped,
+            u32::try_from(authored).unwrap()..u32::try_from(authored + needle.len()).unwrap(),
+            "{needle}"
+        );
+    }
+    let generated = projection.source().find("_t0_").unwrap();
+    assert!(
+        projection
+            .map_range(
+                u32::try_from(generated).unwrap()..u32::try_from(generated + "_t0_".len()).unwrap()
+            )
+            .is_none()
+    );
+    assert!(!projection.source().contains("console.log('opaque')"));
+}
+
+#[test]
+fn checked_lift_rejects_changed_parser_scaffold_identity() {
+    let source = concat!(
+        "const value = @{ input };\n",
+        "const &{ label } = props;\n",
+        "const view = <Card {label}><script>raw()</script></Card>;\n",
+    );
+    let projection =
+        project_for_format(source, &tsrx_syntax::scan_for_parser(source).unwrap()).unwrap();
+    for changed in [
+        projection.source().replacen("_t0_X0P__", "_t0_X9P__", 1),
+        projection.source().replacen("_t0_Y0__", "_t0_Y9__", 1),
+        projection.source().replacen("_t0_V0_", "_t0_V9_", 1),
+        projection.source().replacen("_t0_L0__", "_t0_L9__", 1),
+    ] {
+        assert!(lift_formatted(&changed, source, &projection).is_err(), "{changed}");
+    }
+}
+
+#[test]
 fn switch_try_projection_round_trips_and_checks_method_identity() {
     let source = concat!(
         "function View() @{<main>@switch(value){@case 0:{@try{<b/>}",


### PR DESCRIPTION
Carries #46 (ryansolid, head 21a88952 — reachable from this branch, so #46 marks merged when this lands) plus the two fixes review found:

**1. Escaped keyword boundaries in the parser scanner** (unblocks both Product floor lanes, tests/native-format.test.mjs:296): with format/lint now calling scan_for_parser(), `@for\u03c0` failed with "malformed TSRX at byte 4: expected `(`" because keyword_at/bare_keyword_at (and unsupported_at_construct) treated a trailing `\u` escape as a keyword boundary. New keyword_boundary + escape decoding mirrors the base scanner's boundary handling while keeping the parser lane's own scalar classification (reusing the base helper would have changed `@if🙂` from identifier to keyword on this lane). Malformed/incomplete/out-of-range escapes stay boundaries.

**2. Lazy sigil leaking into type projections** (Bugbot Medium on builder.rs): type_header copied an annotated `@for` header's left pattern with copy_original, so type-aware lint emitted invalid TypeScript like `const &{…}`. It now uses copy_original_with_lazy_markers, matching the non-type header path.

Regression tests for both, each proven non-vacuous (fails with the exact reported symptom when its fix is reverted). Verify: cargo fmt --check, clippy -D warnings and tests for tsrx_syntax/tsrx_lint/tsrx_format, plus the full workspace (42 test binaries, 0 failures).

Pre-existing and untouched (reproduces on b4dfac0): project_for_types returns StructuralMismatch for any unannotated @for; issue to follow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scan/projection/lift paths used by format and lint on every `.tsrx` file; behavior shifts are broad but covered by extensive regression tests.
> 
> **Overview**
> **Format and lint now use `scan_for_parser`**, so TSRX files with parser-only syntax (JSX `@{…}` blocks, `{attr}` shorthand, lazy `&{…}` / `&[…]` patterns, and opaque `<script>` bodies) can be projected, formatted, linted, and lifted instead of failing or mis-scanning.
> 
> **Projection and lift grow parser scaffolding**: the builder emits and reverses markers for those constructs; raw scripts are stubbed like styles; `project_for_format` / `project_for_lint` / `project_for_types` upgrade a plain `scan()` overlay via `parser_overlay` when needed. **Keyword boundaries** on the parser lane now treat trailing `\u` escapes as identifier continuation, so decorators like `@forπ` / `@for\u03c0` are not parsed as `@for` control flow—matching what the parser accepts and aligning `.tsrx` format output with `.tsx`.
> 
> **Type-aware lint** rewrites lazy sigils in annotated `@for` headers via `copy_original_with_lazy_markers`, avoiding invalid projected TypeScript such as `const &{…}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c0bdc79fa4e457d6fc7c87d5df224d261b6c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->