### PR TITLE
site: pin wasm demo engine 9e24fe0

### DIFF
--- a/website-oxc/wasm-pin.json
+++ b/website-oxc/wasm-pin.json
@@ -1,10 +1,10 @@
 {
   "tag": "wasm-demo-latest",
-  "inputsHash": "c65449666913059189e5313edea7439dd7509aab18ab4e8e84f9325983853a74",
-  "sourceCommit": "19790bb0a2b0d18db47af4c2bcb37f76210b6a08",
+  "inputsHash": "e6318cf8c254477386fdb06c1772172cd2224d75821579c5db370e621fa3b468",
+  "sourceCommit": "9e24fe099ec255471f5be6bfbd764519b5b0ca1d",
   "wasm": {
-    "sha256": "7dd54638714a98685f360eb3f8552b38580678347dbc5b32ea9ddaaab04b6857",
-    "bytes": 9487535
+    "sha256": "28e3bef4b602d3808ee97adcfb070624f56935ca6244e492d1ecad9bbc381472",
+    "bytes": 9555006
   },
   "worker": {
     "sha256": "9e8064c5af1619769984b28fe66e5400cdf8b46ab4678f45cdb4f1b5a2441f47",


### PR DESCRIPTION
Post-0.8.0 re-pin (same procedure as #43/#44). The release commit relocked `docs/tools/demo-wasm/Cargo.lock`, invalidating the pin's `inputsHash`; the site-artifact pin-commit step was again rejected by GH006 on protected main (observed in run 33264149087's log), so the deployed site would degrade to static without this.

- Engine assets from `wasm-demo-latest` as refreshed by run 33264149087 (headSha 9e24fe0, post-release main): wasm `28e3bef4…1472` (9,555,006 bytes, changed), worker unchanged.
- `inputsHash` computed via `node scripts/fetch-docs-wasm.ts --print-inputs-hash` on a pristine `git archive` of origin/main, twice in independent temp dirs, equal.
- End-to-end: `fetch-docs-wasm.ts` fetches and verifies the engine with the new pin; the stale pin fails the same check (negative control).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only pin update for WASM demo assets; no application logic or security-sensitive code changes.
> 
> **Overview**
> Updates **`website-oxc/wasm-pin.json`** so the docs site build can fetch and verify the current **`wasm-demo-latest`** demo engine instead of falling back to static-only behavior when the pin is stale.
> 
> **`sourceCommit`** and **`inputsHash`** move to **`9e24fe0`** / the new hash because post-0.8.0 **`Cargo.lock`** changes invalidated the previous inputs hash. The pinned **`.wasm`** artifact is refreshed (**new sha256**, ~**9.56 MB**, up from ~**9.49 MB**); the **worker** pin is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df841f2a8dcfdeb1172ff5641dd05a1f5a70f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->