### PR TITLE
fix: project unannotated @for headers through the type lane

### DIFF
--- a/crates/tsrx_syntax/src/projection/builder.rs
+++ b/crates/tsrx_syntax/src/projection/builder.rs
@@ -453,6 +453,13 @@ impl<'a> Builder<'a> {
             return Err(ProjectionError::StructuralMismatch);
         }
         let header = clause.for_header;
+        // Only an annotated header carries `left`/`right`, because only an annotated header has a
+        // grammar the type lane has to rewrite. An unannotated `@for (const {cell} of rows)` is
+        // already the TypeScript it projects to, so it is copied the way every other lane copies
+        // it rather than demanding fields the scanner never fills in.
+        if !header.annotated {
+            return self.unannotated_type_header(clause.header);
+        }
         if header.left.is_empty() || header.right.is_empty() {
             return Err(ProjectionError::StructuralMismatch);
         }
@@ -481,6 +488,44 @@ impl<'a> Builder<'a> {
         self.output.push(')');
         self.cursor = clause.header.end as usize;
         Ok(())
+    }
+
+    /// Copies an unannotated `@for` header verbatim, spending the lazy sigils on the way through.
+    ///
+    /// The sigils have to be spent here for the same reason the annotated header spends them:
+    /// rewriting the header moves the cursor past the whole clause, and `PendingActions::next`
+    /// then skips every lazy pattern behind that cursor.
+    fn unannotated_type_header(&mut self, header: ByteSpan) -> Result<(), ProjectionError> {
+        let open = header.start as usize;
+        if self.source.as_bytes().get(open) != Some(&b'(') || header.end <= header.start {
+            return Err(ProjectionError::StructuralMismatch);
+        }
+        let inner = ByteSpan::new(to_u32(open.saturating_add(1))?, header.end);
+        self.copy_to(inner.start as usize)?;
+        // A bare lazy loop target — `@for (&{cell} of rows)` — is the one unannotated shape that is
+        // not already TypeScript: the sigil stands in for the declaration keyword, so the type lane
+        // writes the keyword the annotated lane writes for the very same target.
+        if self.has_bare_lazy_loop_target(inner) {
+            self.output.push_str("const ");
+        }
+        self.copy_original_with_lazy_markers(inner)?;
+        self.cursor = header.end as usize;
+        Ok(())
+    }
+
+    /// Reports whether the header's iteration target is a lazy pattern with no declaration keyword
+    /// of its own, which is the shape `Scanner::register_lazy_loop_target` records.
+    fn has_bare_lazy_loop_target(&self, inner: ByteSpan) -> bool {
+        let Some(text) = self.source.get(inner.start as usize..inner.end as usize) else {
+            return false;
+        };
+        let Some(offset) = text.find(|byte: char| !byte.is_ascii_whitespace()) else {
+            return false;
+        };
+        let Ok(target) = u32::try_from(inner.start as usize + offset) else {
+            return false;
+        };
+        self.overlay.parser_lazy_patterns.iter().any(|pattern| pattern.ampersand == target)
     }
 
     fn for_body(&mut self, clause_index: u32) -> Result<(), ProjectionError> {

--- a/crates/tsrx_syntax/tests/public_api.rs
+++ b/crates/tsrx_syntax/tests/public_api.rs
@@ -173,6 +173,92 @@ fn type_projection_rewrites_lazy_sigils_in_annotated_for_headers() {
 }
 
 #[test]
+fn type_projection_keeps_unannotated_for_headers_verbatim() {
+    let source = concat!(
+        "type Row={cell:string};",
+        "declare const rows:Row[];",
+        "declare const pairs:[string,string][];",
+        "function View() @{<main>",
+        "@for (const {cell} of rows) {<span>{cell}</span>}",
+        "@for (const [first,second] of pairs) {<b>{first}{second}</b>}",
+        "@for (const row of rows) {<i>{row.cell}</i>}",
+        "</main>}"
+    );
+    let overlay = scan(source).unwrap();
+    let projection = project_for_types(source, &overlay).unwrap();
+    assert!(projection.source().contains("for (const {cell} of rows)"));
+    assert!(projection.source().contains("for (const [first,second] of pairs)"));
+    assert!(projection.source().contains("for (const row of rows)"));
+    // An unannotated header carries no scaffold, so no header helper is declared for it.
+    assert!(!projection.source().contains("H0_"));
+
+    for needle in ["cell", "second", "row.cell"] {
+        let projected_start = u32::try_from(projection.source().rfind(needle).unwrap()).unwrap();
+        let authored_start = u32::try_from(source.rfind(needle).unwrap()).unwrap();
+        let width = u32::try_from(needle.len()).unwrap();
+        assert_eq!(
+            projection.map_range(projected_start..projected_start + width),
+            Some(authored_start..authored_start + width),
+            "{needle} maps back to its authored bytes"
+        );
+    }
+}
+
+#[test]
+fn type_projection_declares_bare_lazy_targets_but_leaves_assignment_targets_alone() {
+    let source = concat!(
+        "declare const items:{id:string;label:string}[];",
+        "declare let cell:string;",
+        "declare const rows:string[];",
+        "function View() @{<ol>",
+        "@for (&{id, label} of items) {<li>{label}</li>}",
+        "@for ([cell] of rows.map(row=>[row])) {<li>{cell}</li>}",
+        "</ol>}"
+    );
+    let overlay = scan_for_parser(source).unwrap();
+    let projection = project_for_types(source, &overlay).unwrap();
+    let projected = projection.source();
+    assert!(!projected.contains('&'), "{projected}");
+
+    // The sigil stands in for the declaration keyword, so the type lane has to write one.
+    let lazy = header_target(projected, " of items)");
+    assert!(lazy.starts_with("const "), "{lazy}");
+    assert!(lazy.contains("{id, label}"), "{lazy}");
+
+    // A plain assignment target already declares nothing, and declaring it would change what the
+    // authored loop means.
+    let assignment = header_target(projected, " of rows.map(");
+    assert!(!assignment.contains("const"), "{assignment}");
+    assert!(assignment.contains("[cell]"), "{assignment}");
+}
+
+/// Returns the projected `@for` target between its `for (` and the given ` of ...` tail.
+fn header_target<'a>(projected: &'a str, tail: &str) -> &'a str {
+    let end = projected.find(tail).expect("projected loop tail");
+    let start = projected[..end].rfind("for (").expect("projected loop head") + "for (".len();
+    &projected[start..end]
+}
+
+#[test]
+fn type_projection_mixes_annotated_and_unannotated_for_headers() {
+    let source = concat!(
+        "type Row={cell:string};",
+        "declare const rows:Row[];",
+        "function View() @{<main>",
+        "@for (const {cell} of rows) {<span>{cell}</span>}",
+        "@for(const row of rows;index i;key row.cell){<i>{i}{row.cell}</i>}",
+        "</main>}"
+    );
+    let overlay = scan(source).unwrap();
+    let projection = project_for_types(source, &overlay).unwrap();
+    assert!(projection.source().contains("for (const {cell} of rows)"));
+    // The annotated header keeps today's rewrite: bindings hoisted into the body.
+    assert!(projection.source().contains("for(const row of rows)"));
+    assert!(projection.source().contains("let i = 0;"));
+    assert!(projection.source().contains("void (row.cell);"));
+}
+
+#[test]
 fn dynamic_tag_expression_is_affine_but_style_payload_is_synthetic() {
     let source = "function View({tag}:{tag:string}) @{<{tag}><style>.x{color:red}</style></{tag}>}";
     let overlay = scan(source).unwrap();


### PR DESCRIPTION
Fixes #50. `type_header` demanded the `left`/`right` spans only annotated headers carry, so every unannotated `@for` returned `StructuralMismatch` — and because the lint pipeline propagates that error, type-aware mode failed the whole file, not just its type coverage.

Unannotated headers now copy verbatim (they are already the TypeScript they project to), spending lazy sigils the same way the annotated lane does so `PendingActions::next` stays consistent; a bare lazy loop target (`@for (&{cell} of rows)`) additionally gets the `const` the annotated lane writes. Annotated behavior unchanged.

Regression tests: unannotated object/array destructuring and plain-identifier headers through `project_for_types` with mapping checks, an annotated+unannotated mix, and lazy-vs-assignment-target cases. The two new `project_for_types` tests fail with `StructuralMismatch` before the fix. fmt, clippy `-D warnings`, and the full workspace suite pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core type projection for `@for` headers; incorrect lazy-target or sigil handling could emit invalid TypeScript or break source mapping, though annotated paths are unchanged and tests are thorough.
> 
> **Overview**
> **Fixes type projection failing on unannotated `@for` loops**, which previously returned `StructuralMismatch` because `type_header` always required annotated `left`/`right` spans—breaking type-aware lint for entire files when such loops appeared.
> 
> The type lane now **branches on `for_header.annotated`**: unannotated headers are copied verbatim (they already match target TypeScript), with lazy `&` sigils consumed during the copy so `PendingActions` stays aligned with the annotated path. The exception is **bare lazy targets** (`@for (&{…} of …)`): the lane inserts `const` and rewrites sigils, matching annotated behavior, while **assignment-style targets** (e.g. `[cell] of …`) are left without an injected keyword.
> 
> Regression tests cover verbatim unannotated destructuring/identifiers with **byte mapping**, lazy vs assignment targets, and **mixed annotated + unannotated** headers in one view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec8c5e0b570db46d9a7979e74ec03a00218ac8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->