### PR TITLE
fix: line-leading controls open statements (issue #8, defect 2)

### DIFF
--- a/crates/tsrx_syntax/src/parser_scanner/control.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/control.rs
@@ -374,7 +374,10 @@ impl Scanner<'_> {
             }
             break;
         }
-        if index == 0 || matches!(self.bytes[index - 1], b'{' | b'}' | b';') {
+        if index == 0
+            || matches!(self.bytes[index - 1], b'{' | b'}' | b';')
+            || self.line_leading_control_starts_a_statement(start, index)
+        {
             ControlContext::Statement
         } else {
             ControlContext::Expression

--- a/crates/tsrx_syntax/src/parser_scanner/jsx.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/jsx.rs
@@ -487,7 +487,7 @@ impl Scanner<'_> {
     /// True when only non-terminator whitespace separates `index` from the preceding line
     /// terminator. A comment before the cursor on the same line is not whitespace, so it keeps the
     /// cursor inside the line it was written on.
-    fn at_line_start(&self, index: usize) -> bool {
+    pub(super) fn at_line_start(&self, index: usize) -> bool {
         let mut cursor = index;
         while cursor > 0 {
             match self.bytes[cursor - 1] {

--- a/crates/tsrx_syntax/src/parser_scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/lexical.rs
@@ -743,7 +743,64 @@ impl Scanner<'_> {
         }
         index
     }
+
+    /// Octane starts a new statement when a line begins with a TSRX control, even though the
+    /// previous line left its statement unterminated — the same boundary
+    /// `line_leading_markup_starts_a_statement` gives a line-leading markup opening. `start` is the
+    /// control's `@`; `previous` is one past the last non-trivia byte before it, as `code_context`
+    /// computed it. The control only continues the preceding expression when the token before it
+    /// demands an operand, so everything else on a fresh line opens a statement.
+    pub(super) fn line_leading_control_starts_a_statement(
+        &self,
+        start: usize,
+        previous: usize,
+    ) -> bool {
+        self.at_line_start(start) && !self.token_demands_an_operand(previous)
+    }
+
+    /// True when the token ending at `index` cannot end an expression, so whatever follows it has
+    /// to continue that expression rather than start a statement. Deliberately a deny-list: an
+    /// unrecognised token leaves the control where a line break already put it.
+    fn token_demands_an_operand(&self, index: usize) -> bool {
+        let Some(&last) = index.checked_sub(1).and_then(|last| self.bytes.get(last)) else {
+            return false;
+        };
+        if OPERAND_BYTES.contains(&last) {
+            return true;
+        }
+        let mut word_start = index;
+        while word_start > 0 && self.bytes[word_start - 1].is_ascii_alphabetic() {
+            word_start -= 1;
+        }
+        word_start < index
+            && !identifier_continue_before(self.bytes, word_start)
+            && OPERAND_KEYWORDS.contains(&&self.bytes[word_start..index])
+    }
 }
+
+/// Last bytes of the tokens that cannot end an expression, so a TSRX control written after one is
+/// continuing that expression however the source is laid out. `>` covers both `=>` and the close of
+/// a markup element, and `/` covers both division and the close of a regular expression, which is
+/// why neither of those shapes changes context under the line-leading rule.
+const OPERAND_BYTES: &[u8] = b"=([,?:.+-*/%&|^!~<>";
+
+/// Keywords that demand an operand. A line-leading control after one of these is still part of the
+/// expression the keyword opened, even though ASI would end some of them.
+const OPERAND_KEYWORDS: &[&[u8]] = &[
+    b"await",
+    b"case",
+    b"default",
+    b"delete",
+    b"extends",
+    b"in",
+    b"instanceof",
+    b"new",
+    b"of",
+    b"return",
+    b"typeof",
+    b"void",
+    b"yield",
+];
 
 /// One balanced group consumed in type position.
 struct TypeGroup {

--- a/crates/tsrx_syntax/src/scanner/lexical.rs
+++ b/crates/tsrx_syntax/src/scanner/lexical.rs
@@ -5,6 +5,30 @@ use crate::{
 
 use super::Scanner;
 
+/// Last bytes of the tokens that cannot end an expression, so a TSRX control written after one is
+/// continuing that expression however the source is laid out. `>` covers both `=>` and the close of
+/// a markup element, and `/` covers both division and the close of a regular expression, which is
+/// why neither of those shapes changes context under the line-leading rule.
+const OPERAND_BYTES: &[u8] = b"=([,?:.+-*/%&|^!~<>";
+
+/// Keywords that demand an operand. A line-leading control after one of these is still part of the
+/// expression the keyword opened, even though ASI would end some of them.
+const OPERAND_KEYWORDS: &[&[u8]] = &[
+    b"await",
+    b"case",
+    b"default",
+    b"delete",
+    b"extends",
+    b"in",
+    b"instanceof",
+    b"new",
+    b"of",
+    b"return",
+    b"typeof",
+    b"void",
+    b"yield",
+];
+
 impl Scanner<'_> {
     pub(super) fn scan_template(&mut self, start: usize) -> Result<usize, ProjectionError> {
         let mut index = start + 1;
@@ -104,11 +128,43 @@ impl Scanner<'_> {
             }
             break;
         }
-        if index == 0 || matches!(self.bytes[index - 1], b'{' | b'}' | b';') {
+        if index == 0
+            || matches!(self.bytes[index - 1], b'{' | b'}' | b';')
+            || self.line_leading_control_starts_a_statement(start, index)
+        {
             ControlContext::Statement
         } else {
             ControlContext::Expression
         }
+    }
+
+    /// Octane starts a new statement when a line begins with a TSRX control, even though the
+    /// previous line left its statement unterminated — the same boundary
+    /// `line_leading_markup_starts_a_statement` gives a line-leading markup opening. `start` is the
+    /// control's `@`; `previous` is one past the last non-trivia byte before it, as `code_context`
+    /// computed it. The control only continues the preceding expression when the token before it
+    /// demands an operand, so everything else on a fresh line opens a statement.
+    fn line_leading_control_starts_a_statement(&self, start: usize, previous: usize) -> bool {
+        self.at_line_start(start) && !self.token_demands_an_operand(previous)
+    }
+
+    /// True when the token ending at `index` cannot end an expression, so whatever follows it has
+    /// to continue that expression rather than start a statement. Deliberately a deny-list: an
+    /// unrecognised token leaves the control where a line break already put it.
+    fn token_demands_an_operand(&self, index: usize) -> bool {
+        let Some(&last) = index.checked_sub(1).and_then(|last| self.bytes.get(last)) else {
+            return false;
+        };
+        if OPERAND_BYTES.contains(&last) {
+            return true;
+        }
+        let mut word_start = index;
+        while word_start > 0 && self.bytes[word_start - 1].is_ascii_alphabetic() {
+            word_start -= 1;
+        }
+        word_start < index
+            && !identifier_continue_before(self.bytes, word_start)
+            && OPERAND_KEYWORDS.contains(&&self.bytes[word_start..index])
     }
 
     /// Octane starts a new statement when a line begins with a committed markup opening, even

--- a/crates/tsrx_syntax/tests/format_round_trip.rs
+++ b/crates/tsrx_syntax/tests/format_round_trip.rs
@@ -149,3 +149,108 @@ fn breaking_a_scaffold_call_does_not_make_the_lift_accept_a_changed_scaffold() {
         );
     }
 }
+
+/// The four trailing controls, each written after a sibling statement on its own line, with and
+/// without the sibling's authored semicolon. Issue #8 defect 2: the semicolon-less sibling left the
+/// control in expression context, which gave it the wrapper-call scaffold, which made the sibling's
+/// semicolon load-bearing scaffold structure — so Oxfmt's `semi` normalisation refused the lift.
+const TRAILING_CONTROL_BODIES: [&str; 4] = [
+    "@if (d) {\n    <main>a</main>\n  }",
+    "@for (const x of d) {\n    <main>a</main>\n  }",
+    "@switch (d) {\n    @case (1): {\n      <main>a</main>\n    }\n  }",
+    "@try {\n    <main>a</main>\n  } @catch (e) {\n    <b>{e}</b>\n  }",
+];
+
+fn trailing_control_source(body: &str, semicolon: bool) -> String {
+    let semicolon = if semicolon { ";" } else { "" };
+    format!("function D() @{{\n  const d = get(){semicolon}\n  {body}\n}}\n")
+}
+
+/// Rewrites the sibling statement's semicolon inside the already-built projection exactly the way
+/// Oxfmt's `semi` option does, leaving every scaffold and marker byte alone.
+fn flip_sibling_semicolon(projected: &str) -> String {
+    if projected.contains("get();") {
+        projected.replacen("get();", "get()", 1)
+    } else {
+        projected.replacen("get()", "get();", 1)
+    }
+}
+
+#[test]
+fn a_trailing_control_lifts_when_oxfmt_flips_its_sibling_semicolon() {
+    for body in TRAILING_CONTROL_BODIES {
+        for authored_semicolon in [false, true] {
+            let source = trailing_control_source(body, authored_semicolon);
+            let overlay = scan(&source).unwrap_or_else(|error| panic!("scan `{source}`: {error}"));
+            let controls = overlay.control_count();
+            let projection = project_for_format(&source, &overlay)
+                .unwrap_or_else(|error| panic!("project `{source}`: {error}"));
+
+            let flipped = flip_sibling_semicolon(projection.source());
+            assert_ne!(
+                flipped,
+                projection.source(),
+                "the semicolon flip did not change anything to test in `{source}`"
+            );
+
+            let lifted = lift_formatted(&flipped, &source, &projection).unwrap_or_else(|error| {
+                panic!("flipped-semicolon lift failed for `{source}`: {error}\n{flipped}")
+            });
+            assert!(!lifted.contains("_t"), "a scaffold identifier survived the lift: {lifted}");
+            let relifted =
+                scan(&lifted).unwrap_or_else(|error| panic!("rescan `{lifted}`: {error}"));
+            assert_eq!(relifted.control_count(), controls, "control count changed: {lifted}");
+        }
+    }
+}
+
+#[test]
+fn a_trailing_control_takes_no_wrapper_scaffold_whichever_way_its_sibling_ends() {
+    // The scaffold is what coupled the control to its sibling's semicolon. A control that leads its
+    // line is a statement, so the projection must spell it as one — with a plain marker comment and
+    // no generator wrapper — exactly as it does after an authored `;`.
+    for body in TRAILING_CONTROL_BODIES {
+        let with = trailing_control_source(body, true);
+        let without = trailing_control_source(body, false);
+        let projected_with =
+            project_for_format(&with, &scan(&with).unwrap()).unwrap().source().to_owned();
+        let projected_without =
+            project_for_format(&without, &scan(&without).unwrap()).unwrap().source().to_owned();
+
+        assert_eq!(
+            projected_with.replacen("get();", "get()", 1),
+            projected_without,
+            "dropping the sibling semicolon changed the projected structure of `{body}`"
+        );
+    }
+}
+
+#[test]
+fn a_control_that_really_continues_an_expression_keeps_its_wrapper_scaffold() {
+    // The line-leading rule is a deny-list, so the tokens that demand an operand must still hold
+    // the control in expression context. Each of these would otherwise be reclassified by the
+    // newline alone.
+    for source in [
+        "function D() @{\n  const d = get()\n  const e =\n    @if (d) {\n      <main>a</main>\n    }\n  <b>{e}</b>\n}\n",
+        "function D() @{\n  const d = get()\n  const e = [\n    @if (d) {\n      <main>a</main>\n    }\n  ]\n  <b>{e}</b>\n}\n",
+        "function D() @{\n  const d = get()\n  const e = () =>\n    @if (d) {\n      <main>a</main>\n    }\n  <b>{e()}</b>\n}\n",
+        "function D() @{\n  const d = get()\n  const e = d ?\n    @if (d) {\n      <main>a</main>\n    } : null\n  <b>{e}</b>\n}\n",
+    ] {
+        let overlay = scan(source).unwrap_or_else(|error| panic!("scan `{source}`: {error}"));
+        let projection = project_for_format(source, &overlay)
+            .unwrap_or_else(|error| panic!("project `{source}`: {error}"));
+        assert!(
+            projection.source().contains("_W0_("),
+            "the expression-position control lost its wrapper scaffold: {}",
+            projection.source()
+        );
+        let lifted = lift_formatted(projection.source(), source, &projection)
+            .unwrap_or_else(|error| panic!("lift `{source}`: {error}"));
+        assert!(!lifted.contains("_t"), "a scaffold identifier survived the lift: {lifted}");
+        assert_eq!(
+            scan(&lifted).unwrap().control_count(),
+            overlay.control_count(),
+            "control count changed: {lifted}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes the second defect in #8 (the first was fixed by 343ae86 in v0.3.0): Oxfmt refused `formatted TSRX structure differs from the input` at default options for a trailing `@if` — and on current main also `@for`/`@switch`/`@try` — whenever formatting had to flip a sibling statement's semicolon.

Root cause: `code_context` classified a control as Statement only after `{`/`}`/`;`, so after an unterminated sibling (`const d = get()`) a line-leading control read as Expression and took the wrapper-call scaffold, making the sibling's semicolon load-bearing scaffold structure that Oxfmt's `semi` normalization then broke in lift.

Fix, mirroring 343ae86's line-leading markup rule in both scanner lanes: a line-leading `@`-control opens a statement unless the previous non-trivia token demands an operand (deny-list of trailing bytes plus operand keywords — `return`, `typeof`, `case`, …). No projected `;` action was needed: statement-context controls project to `if`/`for`/`switch` keywords that JS ASI already terminates.

Evidence:
- Issue repros: `b-if`/`c-for`/`d-switch`/`e-try` go exit 2 → exit 1 at defaults; the `semi:false` variants likewise; no-sibling shapes unchanged; write-then-check idempotent throughout.
- Octane corpus replay (667 unique files, 2137 path entries), baseline vs fixed: fmt, lint, and plugin-projection outputs identical — 0 regressions.
- Two new round-trip tests reproduce the exact issue diagnostic when the fix is reverted.
- fmt / clippy `-D warnings` / crate tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core statement-vs-expression classification for all TSRX controls in both scanners; wrong operand heuristics could mis-project controls in edge layouts, though deny-list design and new tests narrow exposure.
> 
> **Overview**
> Fixes **issue #8 defect 2**: when a `@if` / `@for` / `@switch` / `@try` sits on its own line after an unterminated sibling (`const d = get()`), `code_context` used to keep it in **expression** context unless the prior token was `{`, `}`, or `;`. That forced the **wrapper-call** projection scaffold and made the sibling’s semicolon part of scaffold structure, so Oxfmt `semi` flips broke **lift**.
> 
> **`code_context`** in both scanner lanes now also treats a control as **statement** when **`line_leading_control_starts_a_statement`** applies: the `@` is at a line start (reusing **`at_line_start`**, now `pub(super)` in the parser JSX module) and the preceding non-trivia token does **not** **`token_demands_an_operand`**. Operand detection is a deny-list of trailing punctuation bytes plus keywords like `return`, `new`, `typeof`, etc., so controls after `=`, `(`, `=>`, etc. still continue an expression.
> 
> Round-trip tests cover trailing controls with/without sibling semicolons, semicolon-flip lift, matching projection with or without `;`, and expression-position controls that must keep **`_W0_(`** wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6532feb292006c0f3ed8992897a94ed2b4d9c777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->