### PR TITLE
site: pin wasm demo engine 4575dc4

### DIFF
--- a/website-oxc/wasm-pin.json
+++ b/website-oxc/wasm-pin.json
@@ -1,10 +1,10 @@
 {
   "tag": "wasm-demo-latest",
-  "inputsHash": "e6318cf8c254477386fdb06c1772172cd2224d75821579c5db370e621fa3b468",
-  "sourceCommit": "9e24fe099ec255471f5be6bfbd764519b5b0ca1d",
+  "inputsHash": "769527024e3314e4894e60ecefdb14f1052255a707368a642f5054bf711f5dd9",
+  "sourceCommit": "4575dc4f20ea6a88347596be81f68a38c6df4f2d",
   "wasm": {
-    "sha256": "28e3bef4b602d3808ee97adcfb070624f56935ca6244e492d1ecad9bbc381472",
-    "bytes": 9555006
+    "sha256": "e1dfc03ead03fe426cc18c6e9ede6630231de3adee03ed7c7f79f935b11d5e54",
+    "bytes": 9556443
   },
   "worker": {
     "sha256": "9e8064c5af1619769984b28fe66e5400cdf8b46ab4678f45cdb4f1b5a2441f47",


### PR DESCRIPTION
Third re-pin (crate merges #54/#56 invalidated the pin; live site degraded to static). Assets from run 33266857514 at 4575dc4 (current main head): wasm e1dfc03e…5e54 (9,556,443 B), worker unchanged. inputsHash 769527…5dd9 computed twice on independent pristine git-archive trees. Positive control: fetch-docs-wasm reports 'demo engine in place, built from 4575dc4'; negative control: the stale pin is refused. A follow-up PR makes stale pins serve the last verified engine instead of degrading, ending this class of outage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates pinned demo WASM metadata and hashes; no application logic or security-sensitive code changes.
> 
> **Overview**
> **Re-pins the live wasm demo** after prior crate merges (#54/#56) invalidated the old pin and the site fell back to a static/degraded experience.
> 
> `wasm-pin.json` now points at **`sourceCommit` `4575dc4`** with a new **`inputsHash`** and updated **`wasm` artifact** (`sha256` `e1dfc03e…`, **9,556,443 B**). The **worker bundle is unchanged** (same `sha256` and size).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 859f715e298176bf806794b9c0d1fa3e7a70c8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->