### PR TITLE
fix: the bare lazy loop-target scan steps over comments

### DIFF
--- a/crates/tsrx_syntax/src/projection/builder.rs
+++ b/crates/tsrx_syntax/src/projection/builder.rs
@@ -515,14 +515,39 @@ impl<'a> Builder<'a> {
 
     /// Reports whether the header's iteration target is a lazy pattern with no declaration keyword
     /// of its own, which is the shape `Scanner::register_lazy_loop_target` records.
+    ///
+    /// The scan has to step over full trivia rather than whitespace alone, because the scanner
+    /// reaches the sigil through `Scanner::skip_trivia`: in `@for (/* note */ &{cell} of rows)` the
+    /// `&` is registered behind a comment, and a whitespace-only scan stops at the `/` and never
+    /// matches the recorded position — so the type lane would omit the `const` the sigil stands in
+    /// for. That scanner helper is private to the scanner, so its comment handling is mirrored
+    /// here, bounded by the header span the scanner already balanced.
     fn has_bare_lazy_loop_target(&self, inner: ByteSpan) -> bool {
-        let Some(text) = self.source.get(inner.start as usize..inner.end as usize) else {
-            return false;
+        let bytes = self.source.as_bytes();
+        let end = (inner.end as usize).min(bytes.len());
+        let mut index = (inner.start as usize).min(end);
+        let target = loop {
+            while index < end && bytes[index].is_ascii_whitespace() {
+                index += 1;
+            }
+            let rest = &bytes[index..end];
+            if rest.starts_with(b"//") {
+                index += 2;
+                while index < end && !matches!(bytes[index], b'\n' | b'\r') {
+                    index += 1;
+                }
+            } else if rest.starts_with(b"/*") {
+                // An unterminated block comment never reaches projection — the scanner rejects it
+                // before an overlay exists — so a missing `*/` only means there is no target here.
+                let Some(close) = rest[2..].windows(2).position(|pair| pair == b"*/") else {
+                    return false;
+                };
+                index += 2 + close + 2;
+            } else {
+                break index;
+            }
         };
-        let Some(offset) = text.find(|byte: char| !byte.is_ascii_whitespace()) else {
-            return false;
-        };
-        let Ok(target) = u32::try_from(inner.start as usize + offset) else {
+        let Ok(target) = u32::try_from(target) else {
             return false;
         };
         self.overlay.parser_lazy_patterns.iter().any(|pattern| pattern.ampersand == target)

--- a/crates/tsrx_syntax/tests/public_api.rs
+++ b/crates/tsrx_syntax/tests/public_api.rs
@@ -232,6 +232,35 @@ fn type_projection_declares_bare_lazy_targets_but_leaves_assignment_targets_alon
     assert!(assignment.contains("[cell]"), "{assignment}");
 }
 
+#[test]
+fn type_projection_declares_bare_lazy_targets_behind_header_comments() {
+    // The scanner walks full trivia to find the sigil, so a comment between `(` and `&` still
+    // registers a bare lazy loop target. The type lane has to agree, or the `const` the sigil
+    // stands in for goes unwritten and the projected loop assigns to undeclared bindings.
+    let source = concat!(
+        "declare const items:{id:string;label:string}[];",
+        "declare const rows:{cell:string}[];",
+        "function View() @{<ol>",
+        "@for (/* note */ &{id, label} of items) {<li>{label}</li>}",
+        "@for (// note\n&{cell} of rows) {<li>{cell}</li>}",
+        "</ol>}"
+    );
+    let overlay = scan_for_parser(source).unwrap();
+    let projection = project_for_types(source, &overlay).unwrap();
+    let projected = projection.source();
+    assert!(!projected.contains('&'), "{projected}");
+
+    let block = header_target(projected, " of items)");
+    assert!(block.starts_with("const "), "{block}");
+    assert!(block.contains("/* note */"), "{block}");
+    assert!(block.contains("{id, label}"), "{block}");
+
+    let line = header_target(projected, " of rows)");
+    assert!(line.starts_with("const "), "{line}");
+    assert!(line.contains("// note"), "{line}");
+    assert!(line.contains("{cell}"), "{line}");
+}
+
 /// Returns the projected `@for` target between its `for (` and the given ` of ...` tail.
 fn header_target<'a>(projected: &'a str, tail: &str) -> &'a str {
     let end = projected.find(tail).expect("projected loop tail");


### PR DESCRIPTION
Addresses the Bugbot Medium on #54: `has_bare_lazy_loop_target` advanced only over ASCII whitespace while the scanner registers the sigil through `skip_trivia`, so `@for (/* note */ &{cell} of rows)` missed its recorded position and the type lane omitted the `const`. The projection-side scan now mirrors the scanner's comment handling (line and block), bounded by the already-balanced header span; an unterminated block comment can't reach projection and simply means no target. Scanner untouched.

Regression test covers both comment forms through `project_for_types`; reverting only the source fix reproduces the missed-const projection. fmt, clippy `-D warnings`, tsrx_syntax + tsrx_lint tests green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized projection logic for `@for` type headers plus a regression test; scanner unchanged.
> 
> **Overview**
> Fixes type projection for unannotated `@for` loops whose lazy `&` binding sits after trivia in the header (e.g. `@for (/* note */ &{id, label} of items)`).
> 
> **`has_bare_lazy_loop_target`** used to find the first non-whitespace byte only, so it stopped at `/` in a comment and never matched the scanner-recorded `&` position (the scanner reaches the sigil via **`skip_trivia`**). The helper now skips line and block comments within the header inner span, same as the scanner, so the type lane still inserts **`const`** when the sigil stands in for a declaration keyword. Comments are preserved in the projected header.
> 
> Adds **`type_projection_declares_bare_lazy_targets_behind_header_comments`** for block and line-comment cases through **`project_for_types`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812c638ca483df110a165e3c85a938068cecffb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->