### PR TITLE
site: a stale wasm pin serves the last verified engine instead of degrading

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "docs:serve": "node docs/serve.mjs",
     "docs:verify": "node docs/verify.mjs",
     "docs:check": "node scripts/check-docs-fresh.ts",
-    "test:site:unit": "node --test tests/site/benchmark-sections.test.mjs tests/site/benchmark-chart-parity.test.mjs tests/site/launch-build.test.mjs tests/site/fragment-links.test.mjs tests/site/documented-version-pin.test.mjs tests/site/platform-support-matrix.test.mjs",
+    "test:site:unit": "node --test tests/site/benchmark-sections.test.mjs tests/site/benchmark-chart-parity.test.mjs tests/site/launch-build.test.mjs tests/site/fragment-links.test.mjs tests/site/documented-version-pin.test.mjs tests/site/platform-support-matrix.test.mjs tests/site/stale-pin-fallback.test.mjs",
     "test:site:static": "node tests/site/verify-static.mjs",
     "test:site:wasm": "pnpm run docs:wasm && node tests/site/verify-static.mjs --require-wasm",
     "test:site": "pnpm run test:site:unit && pnpm run test:site:static",

--- a/scripts/fetch-docs-wasm.ts
+++ b/scripts/fetch-docs-wasm.ts
@@ -14,22 +14,42 @@
 //   website-oxc/wasm-pin.json             tag + inputs hash + sha256 of each byte
 //   this script                           downloads and verifies against the pin
 //
-// Two rules shape everything below.
+// Three rules shape everything below.
 //
-// It never fails the site build. A missing pin, a pin describing a different
-// source tree, a download that will not come, bytes that do not match their
-// hash: each one prints one line and exits 0. docs/build.mjs detects the engine
-// by the presence of docs/tools/demo-wasm/dist/demo-wasm.wasm and renders the
-// static preview contract without it (docs/build.mjs, `wasmDemo`), so the
-// correct degradation is a site that builds and says the demo is unavailable --
-// never a red deploy.
+// It never fails the site build. A missing pin, a download that will not come,
+// bytes that do not match their hash: each one prints one line and exits 0.
+// docs/build.mjs detects the engine by the presence of
+// docs/tools/demo-wasm/dist/demo-wasm.wasm and renders the static preview
+// contract without it (docs/build.mjs, `wasmDemo`), so the correct degradation
+// is a site that builds and says the demo is unavailable -- never a red deploy.
+// The exit code matters: website-oxc/package.json runs this script and the site
+// build in one `&&` chain, so a non-zero exit here is a failed deploy.
 //
-// It refuses bytes that do not belong to this source tree. The pin carries a
-// hash of the sources the engine is compiled from; if this checkout hashes
-// differently, the released engine is from other source and is not downloaded.
-// That check is why the hash lives here rather than in the workflow: the
-// workflow authors the pin by calling this same file with --print-inputs-hash,
-// so the two definitions cannot drift.
+// It refuses bytes that do not match the pin, and only those. sha256 and byte
+// length are checked on every download and a mismatch installs nothing --
+// integrity is fail-closed and this file must keep it that way.
+//
+// A stale pin is NOT an integrity failure, and does not take the demo down.
+// Owner directive, 2026-08-29, after this cost the live site the demo more than
+// once. The pin also carries a hash of the sources the engine was compiled
+// from, and that hash disagrees with the checkout on every merge that touches
+// crates/tsrx_* or docs/tools/demo-wasm, because the workflow's pin-refresh
+// push is rejected by branch protection and lands late or not at all. Refusing
+// on that mismatch turned an ordinary merge into a silent outage:
+// oxc.tsrx.dev fell back to mode:"static" with nothing red anywhere. So a
+// mismatch now prints a loud warning and installs the pinned engine anyway.
+// The bytes are still exactly the bytes CI proved; they are merely older than
+// the checkout, which is strictly better than no engine at all. The known cost
+// is skew -- demo-panel JS newer than the engine it drives -- and there is no
+// version handshake between the two to catch it (docs/demo-wasm-engine-entry.mjs
+// re-exports lint/format/project straight off the module), so skew shows up as
+// a panel-side error rather than a clean fallback. That risk was weighed and
+// accepted against a certain outage.
+//
+// The inputs hash therefore has exactly one remaining job: telling a reader
+// which engine they are looking at. It still lives here rather than in the
+// workflow because the workflow authors the pin by calling this same file with
+// --print-inputs-hash, so the two definitions cannot drift.
 //
 // Deliberately repo-only: the hash covers tracked source, not the rustc that
 // compiled it. Vercel's builder cannot know which compiler CI used, and it does
@@ -43,7 +63,12 @@ import { join, resolve } from "node:path";
 const root = resolve(import.meta.dirname, "..");
 const pinPath = "website-oxc/wasm-pin.json";
 const outputDir = "docs/tools/demo-wasm/dist";
-const releaseBase = "https://github.com/tsrx-org/oxc/releases/download";
+// Overridable so the download can be pointed at a local server: the fallback
+// policy above is only believable if it is tested, and tests/site/
+// stale-pin-fallback.test.mjs cannot reach a GitHub release. Unset in every
+// real build, where the bytes come from the release named by the pin.
+const releaseBase =
+  process.env.OXC_TSRX_WASM_RELEASE_BASE || "https://github.com/tsrx-org/oxc/releases/download";
 
 // Both files land in docs/tools/demo-wasm/dist/ and neither is optional: the
 // engine bundle reaches the worker through a relative URL that the worker entry
@@ -163,17 +188,31 @@ async function download(url, expected, name) {
 
 async function fetchPinnedEngine() {
   const pin = await readPin();
+  const sourceCommit =
+    typeof pin.sourceCommit === "string" && pin.sourceCommit !== ""
+      ? pin.sourceCommit.slice(0, 7)
+      : "an unrecorded commit";
 
+  // Advisory from here on. Neither a mismatch nor a failure to compute it stops
+  // the install; both only decide what gets printed. See the staleness note at
+  // the top of this file -- the only thing that can stop an install is a byte
+  // that does not match the pin.
   let inputsHash;
   try {
     inputsHash = await computeInputsHash();
   } catch (error) {
-    throw new Skip(`the engine sources could not be hashed: ${describe(error)}`);
+    console.warn(
+      `fetch-docs-wasm: WARNING -- freshness unknown: the engine sources could not be hashed ` +
+        `(${describe(error)}). Installing the pinned engine built from ${sourceCommit} anyway; ` +
+        `its sha256s are still checked below.`,
+    );
   }
-  if (inputsHash !== pin.inputsHash) {
-    throw new Skip(
-      `${pinPath} pins an engine built from other source ` +
-        `(pinned ${pin.inputsHash.slice(0, 12)}, this checkout ${inputsHash.slice(0, 12)})`,
+  if (inputsHash !== undefined && inputsHash !== pin.inputsHash) {
+    console.warn(
+      `fetch-docs-wasm: WARNING -- stale pin: engine built from ${sourceCommit} ` +
+        `(inputs ${pin.inputsHash.slice(0, 12)}), checkout is ${inputsHash.slice(0, 12)}. ` +
+        `Installing the last engine CI proved, so the playground stays live on older ` +
+        `engine code; a fresh pin from site-artifact.yml clears this.`,
     );
   }
 
@@ -194,9 +233,8 @@ async function fetchPinnedEngine() {
   }
 
   const sizes = downloaded.map((asset) => `${asset.name} ${asset.bytes.length} bytes`).join(", ");
-  const commit = typeof pin.sourceCommit === "string" ? pin.sourceCommit.slice(0, 7) : "unknown";
   console.log(
-    `fetch-docs-wasm: demo engine in place from ${pin.tag} (${sizes}), built from ${commit}`,
+    `fetch-docs-wasm: demo engine in place from ${pin.tag} (${sizes}), built from ${sourceCommit}`,
   );
 }
 
@@ -207,13 +245,18 @@ if (options.length > 0 && !printInputsHash) {
 }
 
 if (printInputsHash) {
-  // The workflow's half of the contract. Failure here must be loud: a pin
-  // written with a wrong hash is a pin no site build will ever accept.
+  // The workflow's half of the contract, and the one caller that must fail
+  // hard: site-artifact.yml runs this under `set -e` to author the pin, and a
+  // hash silently defaulted to nothing would write a pin that reports every
+  // later build as stale. Nothing about the fallback below applies here.
   process.stdout.write(`${await computeInputsHash()}\n`);
 } else {
   try {
     await fetchPinnedEngine();
   } catch (error) {
+    // Reaching here now means the pin is unusable or its bytes did not verify,
+    // never that the pin is merely old. Exit 0 all the same: the site must
+    // build and say the demo is unavailable rather than fail the deploy.
     const reason = error instanceof Skip ? error.message : `unexpected failure: ${describe(error)}`;
     console.log(`fetch-docs-wasm: no demo engine, ${reason}`);
     console.log("fetch-docs-wasm: the playground will render its static preview instead.");

--- a/tests/site/stale-pin-fallback.test.mjs
+++ b/tests/site/stale-pin-fallback.test.mjs
@@ -1,0 +1,270 @@
+// scripts/fetch-docs-wasm.ts installs the demo engine for the one build that
+// cannot compile it (oxc.tsrx.dev, built on Vercel's image with no cargo). This
+// file pins the single decision that build gets wrong most expensively: what to
+// do when website-oxc/wasm-pin.json describes an engine older than the checkout.
+//
+// It used to install nothing. That is not a rare case -- the pin goes stale on
+// every merge touching crates/tsrx_* or docs/tools/demo-wasm, because the
+// workflow's pin-refresh push is rejected by branch protection -- and it took
+// the live playground down to mode:"static" with nothing red anywhere to say
+// so. The policy now is: a stale pin still installs, loudly; only bytes that
+// fail their sha256 or byte length are refused.
+//
+// The script is exercised as the process the site build actually runs, not by
+// importing pieces of it, because the behaviour under test is exactly its exit
+// code and what it leaves on disk. To keep that honest without touching this
+// repository's real pin or dist directory, each case builds a throwaway root:
+//
+//   <tmp>/package.json                 type: module, so node reads the script as ESM
+//   <tmp>/scripts/fetch-docs-wasm.ts   a copy -- the script derives its root from here
+//   <tmp>/node_modules/tinyglobby      symlink, the one dependency it imports
+//   <tmp>/rust-toolchain.toml + docs/tools/demo-wasm/...   stand-in engine sources
+//   <tmp>/website-oxc/wasm-pin.json    doctored per case
+//
+// and serves the release bytes from a loopback HTTP server through
+// OXC_TSRX_WASM_RELEASE_BASE, so no case reaches the network.
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+
+const repoRoot = resolve(import.meta.dirname, "../..");
+const scriptSource = join(repoRoot, "scripts", "fetch-docs-wasm.ts");
+
+// Stand-ins for the two published files. Their content is irrelevant -- the
+// script only ever compares bytes to the pin -- but they must differ from each
+// other so a swap could not pass.
+const engineBytes = {
+  "demo-wasm.wasm": Buffer.from("\0asm\0\0\0 not a real engine, just bytes to pin"),
+  "wasi-worker-browser.mjs": Buffer.from("// stand-in worker\nexport {}\n"),
+};
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+// The script imports tinyglobby to hash the engine sources. Resolving it here
+// rather than assuming a layout keeps this test working under pnpm's symlinked
+// node_modules and under a flat one.
+function tinyglobbyPackageDir() {
+  const require = createRequire(import.meta.url);
+  let dir = dirname(require.resolve("tinyglobby"));
+  while (!existsSync(join(dir, "package.json"))) {
+    const parent = dirname(dir);
+    assert.notEqual(parent, dir, "tinyglobby resolved outside any package");
+    dir = parent;
+  }
+  return dir;
+}
+
+async function makeFixtureRoot(t) {
+  const root = await mkdtemp(join(tmpdir(), "stale-pin-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+
+  await mkdir(join(root, "scripts"), { recursive: true });
+  await cp(scriptSource, join(root, "scripts", "fetch-docs-wasm.ts"));
+  await writeFile(join(root, "package.json"), '{ "type": "module" }\n');
+
+  await mkdir(join(root, "node_modules"), { recursive: true });
+  await symlink(tinyglobbyPackageDir(), join(root, "node_modules", "tinyglobby"), "dir");
+
+  // Enough of the hashed input set to give computeInputsHash something real to
+  // hash; the patterns it globs are crates/tsrx_*, docs/tools/demo-wasm and the
+  // toolchain file.
+  await mkdir(join(root, "docs", "tools", "demo-wasm", "src"), { recursive: true });
+  await writeFile(join(root, "rust-toolchain.toml"), '[toolchain]\nchannel = "stable"\n');
+  await writeFile(join(root, "docs", "tools", "demo-wasm", "src", "lib.rs"), "// engine source\n");
+
+  return root;
+}
+
+async function writePin(root, overrides = {}) {
+  const pin = {
+    tag: "wasm-demo-latest",
+    inputsHash: "0".repeat(64),
+    sourceCommit: "4575dc4f20ea6a88347596be81f68a38c6df4f2d",
+    wasm: {
+      sha256: sha256(engineBytes["demo-wasm.wasm"]),
+      bytes: engineBytes["demo-wasm.wasm"].length,
+    },
+    worker: {
+      sha256: sha256(engineBytes["wasi-worker-browser.mjs"]),
+      bytes: engineBytes["wasi-worker-browser.mjs"].length,
+    },
+    ...overrides,
+  };
+  await mkdir(join(root, "website-oxc"), { recursive: true });
+  await writeFile(join(root, "website-oxc", "wasm-pin.json"), `${JSON.stringify(pin, null, 2)}\n`);
+  return pin;
+}
+
+// One release, served from loopback. Anything the script asks for that is not
+// <tag>/<asset name> is a 404, which is also what the real release gives.
+async function serveRelease(t, { tag = "wasm-demo-latest" } = {}) {
+  const requested = [];
+  const server = createServer((request, response) => {
+    requested.push(request.url);
+    const bytes = engineBytes[request.url.replace(`/${tag}/`, "")];
+    if (!request.url.startsWith(`/${tag}/`) || !bytes) {
+      response.writeHead(404, { "content-type": "text/plain" });
+      response.end("Not Found");
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/octet-stream" });
+    response.end(bytes);
+  });
+  await new Promise((done) => server.listen(0, "127.0.0.1", done));
+  t.after(() => new Promise((done) => server.close(done)));
+  return { base: `http://127.0.0.1:${server.address().port}`, requested };
+}
+
+function runScript(root, { args = [], base } = {}) {
+  return new Promise((done) => {
+    execFile(
+      process.execPath,
+      [join(root, "scripts", "fetch-docs-wasm.ts"), ...args],
+      {
+        cwd: root,
+        env: { ...process.env, OXC_TSRX_WASM_RELEASE_BASE: base ?? "http://127.0.0.1:1/nowhere" },
+      },
+      (error, stdout, stderr) => {
+        done({ code: error?.code ?? 0, stdout, stderr, output: `${stdout}${stderr}` });
+      },
+    );
+  });
+}
+
+function installedPath(root, name) {
+  return join(root, "docs", "tools", "demo-wasm", "dist", name);
+}
+
+async function assertEngineInstalled(root) {
+  for (const [name, bytes] of Object.entries(engineBytes)) {
+    const onDisk = await readFile(installedPath(root, name));
+    assert.deepEqual(onDisk, bytes, `${name} was not installed byte for byte`);
+  }
+}
+
+function assertNothingInstalled(root) {
+  for (const name of Object.keys(engineBytes)) {
+    assert.equal(existsSync(installedPath(root, name)), false, `${name} must not be installed`);
+  }
+}
+
+test("a stale pin installs the pinned engine and says so loudly", async (t) => {
+  const root = await makeFixtureRoot(t);
+  // The default fixture hash is deliberately wrong for this tree, which is the
+  // shape of every post-merge checkout before the pin refresh lands.
+  await writePin(root);
+  const release = await serveRelease(t);
+
+  const run = await runScript(root, { base: release.base });
+
+  assert.equal(run.code, 0, `exit 0 or the Vercel build's && chain fails: ${run.output}`);
+  await assertEngineInstalled(root);
+  assert.match(run.output, /WARNING -- stale pin/);
+  // Named precisely enough that a reader knows which engine is live and how
+  // far behind it is, per the owner's report of the silent outage.
+  assert.match(run.output, /engine built from 4575dc4/);
+  assert.match(run.output, /checkout is [0-9a-f]{12}/);
+  assert.match(run.output, /demo engine in place from wasm-demo-latest/);
+  assert.doesNotMatch(run.output, /no demo engine/);
+  assert.doesNotMatch(run.output, /static preview/);
+});
+
+test("a stale pin whose bytes do not match their sha256 installs nothing", async (t) => {
+  const root = await makeFixtureRoot(t);
+  await writePin(root, { wasm: { sha256: "b".repeat(64), bytes: 41 } });
+  const release = await serveRelease(t);
+
+  const run = await runScript(root, { base: release.base });
+
+  assert.equal(run.code, 0, `a refusal is still a green build: ${run.output}`);
+  assertNothingInstalled(root);
+  assert.match(run.output, /no demo engine/);
+  assert.match(run.output, /static preview/);
+  assert.doesNotMatch(run.output, /demo engine in place/);
+});
+
+test("a fresh pin whose bytes are the wrong length installs nothing", async (t) => {
+  const root = await makeFixtureRoot(t);
+  const inputsHash = (await runScript(root, { args: ["--print-inputs-hash"] })).stdout.trim();
+  await writePin(root, {
+    inputsHash,
+    wasm: { sha256: sha256(engineBytes["demo-wasm.wasm"]), bytes: 999_999 },
+  });
+  const release = await serveRelease(t);
+
+  const run = await runScript(root, { base: release.base });
+
+  assert.equal(run.code, 0);
+  assertNothingInstalled(root);
+  assert.match(run.output, /bytes, the pin says 999999/);
+});
+
+test("a pin whose release will not serve the bytes installs nothing", async (t) => {
+  const root = await makeFixtureRoot(t);
+  await writePin(root, { tag: "wasm-demo-missing" });
+  const release = await serveRelease(t);
+
+  const run = await runScript(root, { base: release.base });
+
+  assert.equal(run.code, 0);
+  assertNothingInstalled(root);
+  assert.match(run.output, /responded 404/);
+});
+
+test("a matching pin installs with no staleness warning at all", async (t) => {
+  const root = await makeFixtureRoot(t);
+  const printed = await runScript(root, { args: ["--print-inputs-hash"] });
+  // --print-inputs-hash is the workflow's half of the contract: one hash on
+  // stdout, nothing else, exit 0.
+  assert.equal(printed.code, 0, printed.output);
+  assert.match(printed.stdout, /^[0-9a-f]{64}\n$/);
+
+  await writePin(root, { inputsHash: printed.stdout.trim() });
+  const release = await serveRelease(t);
+
+  const run = await runScript(root, { base: release.base });
+
+  assert.equal(run.code, 0, run.output);
+  await assertEngineInstalled(root);
+  assert.doesNotMatch(run.output, /WARNING/);
+  assert.match(run.output, /demo engine in place from wasm-demo-latest/);
+});
+
+test("an engine whose sources cannot be hashed still installs, flagged as unverified", async (t) => {
+  const root = await makeFixtureRoot(t);
+  await writePin(root);
+  // No files match the hash patterns any more, so computeInputsHash throws.
+  // Before the fallback that was a refusal too, which meant a hashing accident
+  // could take the demo down as surely as a stale pin.
+  await rm(join(root, "rust-toolchain.toml"));
+  await rm(join(root, "docs", "tools", "demo-wasm"), { recursive: true });
+  const release = await serveRelease(t);
+
+  const run = await runScript(root, { base: release.base });
+
+  assert.equal(run.code, 0, run.output);
+  await assertEngineInstalled(root);
+  assert.match(run.output, /WARNING -- freshness unknown/);
+});
+
+test("the release URL is built from the pinned tag and asset names", async (t) => {
+  const root = await makeFixtureRoot(t);
+  await writePin(root);
+  const release = await serveRelease(t);
+
+  await runScript(root, { base: release.base });
+
+  assert.deepEqual(release.requested, [
+    "/wasm-demo-latest/demo-wasm.wasm",
+    "/wasm-demo-latest/wasi-worker-browser.mjs",
+  ]);
+});


### PR DESCRIPTION
Owner directive after the demo degraded to static on three ordinary crate merges: never again. The pin's `inputsHash` disagrees with the checkout on every merge touching crates/tsrx_* or docs/tools/demo-wasm (the workflow's pin-refresh push is rejected by branch protection), and `fetch-docs-wasm.ts` treated that mismatch as a refusal — turning routine merges into silent outages.

A stale pin is not an integrity failure. On mismatch the script now prints a loud warning naming the pinned sourceCommit and the checkout hash, then still downloads, sha256+length-verifies (unchanged rigor), and installs the pinned engine — bytes CI already proved, merely older than the checkout. Only bad digests/sizes, an unusable pin, or a failed download refuse (still exit 0 for the Vercel `&&` chain). `--print-inputs-hash` untouched.

Known, accepted residual (documented in the header): no panel/engine API handshake exists, so stale-engine skew would surface as a panel-side error; weighed against a certain outage.

Tests: `tests/site/stale-pin-fallback.test.mjs` — 7 cases running the real script against a loopback release server (stale hash + good digests installs with warning; bad digest refuses; etc.), added to `test:site:unit`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters production docs-site WASM install policy on oxc.tsrx.dev; integrity checks stay fail-closed but an older engine may run against newer demo JS until the pin refreshes.
> 
> **Overview**
> **Changes how `fetch-docs-wasm.ts` treats a stale `wasm-pin.json`.** When the pin’s `inputsHash` no longer matches the checkout (common after crate merges before CI refreshes the pin), the script **warns and still installs** the last CI-verified engine instead of skipping install and leaving the playground in static mode.
> 
> **Integrity behavior is unchanged:** wrong sha256, wrong byte length, bad pin, or failed download still install nothing and exit **0** so Vercel’s `&&` site build does not fail. `--print-inputs-hash` remains strict for the workflow that authors pins. Downloads can be aimed at a test server via **`OXC_TSRX_WASM_RELEASE_BASE`**.
> 
> Adds **`tests/site/stale-pin-fallback.test.mjs`** (seven process-level cases with a loopback release server) and wires it into **`test:site:unit`**. Documented tradeoff: possible panel/engine skew without a version handshake vs. silent demo outages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2c3ade688809bf6f1bfbf70bfb6f1f5137955b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->