### PR TITLE
feat(parser): recover incomplete editor snapshots

### DIFF
--- a/crates/oxc_adapter/src/parser/mod.rs
+++ b/crates/oxc_adapter/src/parser/mod.rs
@@ -45,6 +45,13 @@ impl RejectionMetadata {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ProjectedParseRecovery {
+    #[default]
+    None,
+    Editor,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ProjectedParseRequest<'a> {
     pub filename: &'a str,
@@ -54,6 +61,8 @@ pub struct ProjectedParseRequest<'a> {
     pub ranges: bool,
     pub preserve_parens: Option<bool>,
     pub show_semantic_errors: bool,
+    /// Retain OXC's partial Program when syntax diagnostics are present.
+    pub recovery: ProjectedParseRecovery,
     /// Private metadata retained solely for rare UTF-16 rejection arbitration.
     pub rejection_metadata: RejectionMetadata,
     pub dynamic_tags: Option<DynamicTagContract<'a>>,
@@ -219,7 +228,7 @@ impl From<TapeBuildError> for ProjectedParseError {
 /// Parses one legal projected TSX source into an owned revision-neutral flat tape.
 ///
 /// The OXC allocator, AST, parser return, and serializer borrow all die before this function
-/// returns. Syntax diagnostics fail closed and never return a partial tape.
+/// returns. Syntax diagnostics fail closed unless the request explicitly enables recovery.
 ///
 /// # Errors
 ///
@@ -271,7 +280,7 @@ fn parse_to_projected_tape_with_retention(
     let (has_retained_diagnostics, suppressed_diagnostics) =
         append_tsrx_grammar_diagnostics(&mut errors, request.source, &parsed.diagnostics)?;
     let syntax_failed = parsed.panicked || has_retained_diagnostics;
-    if syntax_failed {
+    if syntax_failed && (request.recovery != ProjectedParseRecovery::Editor || parsed.panicked) {
         let rejection_module_names = match request.rejection_metadata {
             RejectionMetadata::None => RejectionModuleNames::default(),
             RejectionMetadata::ModuleNames => {
@@ -325,7 +334,7 @@ fn parse_to_projected_tape_with_retention(
             _ => Err(ProjectedParseError::Invariant(error.to_string())),
         };
     }
-    if request.show_semantic_errors {
+    if request.show_semantic_errors && !syntax_failed {
         let semantic = SemanticBuilder::new_compiler().build(&parsed.program);
         append_diagnostics(&mut errors, semantic.diagnostics.iter(), DiagnosticPhase::Semantic)?;
     }
@@ -344,8 +353,8 @@ fn parse_to_projected_tape_with_retention(
         errors,
         suppressed_diagnostics,
         authored_grammar: None,
-        syntax_failed: false,
-        panicked: false,
+        syntax_failed,
+        panicked: parsed.panicked,
     })
 }
 

--- a/crates/oxc_adapter/tests/parser_results.rs
+++ b/crates/oxc_adapter/tests/parser_results.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use oxc_adapter::parser::{
-    OrdinaryParseRequest, ProjectedParseRequest, RejectionMetadata, parse_failed_tsrx_metadata,
-    parse_ordinary, parse_to_projected_tape, render_diagnostic_codeframes,
+    OrdinaryParseRequest, ProjectedParseRecovery, ProjectedParseRequest, RejectionMetadata,
+    parse_failed_tsrx_metadata, parse_ordinary, parse_to_projected_tape,
+    render_diagnostic_codeframes,
 };
 use oxc_allocator::Allocator;
 use oxc_diagnostics::NamedSource;
@@ -24,6 +25,7 @@ fn request(source: &str, show_semantic_errors: bool) -> ProjectedParseRequest<'_
         ranges: false,
         preserve_parens: None,
         show_semantic_errors,
+        recovery: ProjectedParseRecovery::None,
         rejection_metadata: RejectionMetadata::None,
         dynamic_tags: None,
         synthetic_callee_spans: &[],
@@ -158,6 +160,29 @@ fn grammar_diagnostics_are_structured_and_remove_partial_program_and_module() {
     assert_eq!(labels[0].span.end, 23);
     assert!(!labels[0].primary);
     assert!(result.errors.optional_string(labels[0].message).is_none());
+}
+
+#[test]
+fn explicit_recovery_serializes_only_usable_oxc_partial_programs() {
+    let mut recoverable = request("const value; const after = 1;", false);
+    recoverable.recovery = ProjectedParseRecovery::Editor;
+    let recovered = parse_to_projected_tape(recoverable).expect("recoverable grammar result");
+    assert_eq!(recovered.parse_count, 1);
+    assert!(recovered.syntax_failed);
+    assert!(!recovered.panicked);
+    assert!(recovered.program.is_some());
+    assert!(recovered.module.is_some());
+    assert_eq!(recovered.errors.len(), 1);
+
+    let mut panicked = request("export const broken = ;", false);
+    panicked.recovery = ProjectedParseRecovery::Editor;
+    let failed = parse_to_projected_tape(panicked).expect("unrecoverable grammar result");
+    assert_eq!(failed.parse_count, 1);
+    assert!(failed.syntax_failed);
+    assert!(failed.panicked);
+    assert!(failed.program.is_none());
+    assert!(failed.module.is_none());
+    assert_eq!(failed.errors.len(), 1);
 }
 
 #[test]

--- a/crates/oxc_adapter/tests/parser_tape.rs
+++ b/crates/oxc_adapter/tests/parser_tape.rs
@@ -1,8 +1,8 @@
 use oxc_adapter::{
     DynamicTagContract,
     parser::{
-        OrdinaryParseRequest, ProjectedParseRequest, RejectionMetadata, parse_ordinary,
-        parse_to_projected_tape,
+        OrdinaryParseRequest, ProjectedParseRecovery, ProjectedParseRequest, RejectionMetadata,
+        parse_ordinary, parse_to_projected_tape,
     },
 };
 use tsrx_tape_schema::{FlatTape, ValueKind, ValueRef};
@@ -56,6 +56,7 @@ fn projected_dynamic_scaffold_is_validated_and_serialized_in_one_parse() {
         ranges: false,
         preserve_parens: None,
         show_semantic_errors: false,
+        recovery: ProjectedParseRecovery::None,
         rejection_metadata: RejectionMetadata::None,
         dynamic_tags: Some(DynamicTagContract {
             prefix: "_t0_",
@@ -98,6 +99,7 @@ fn flat_serializer_matches_public_oxc_estree_serialization() {
         ranges: false,
         preserve_parens: None,
         show_semantic_errors: false,
+        recovery: ProjectedParseRecovery::None,
         rejection_metadata: RejectionMetadata::None,
         dynamic_tags: None,
         synthetic_callee_spans: &[],

--- a/crates/parser_napi_binding/src/lib.rs
+++ b/crates/parser_napi_binding/src/lib.rs
@@ -26,7 +26,8 @@ use tsrx_parser_engine::{
     parse_tsrx_with_options_for_transfer_observed,
 };
 use tsrx_parser_engine::{
-    TsrxParseError, TsrxParseOptions, TsrxParseRequest, TsrxParseResult, TsrxUtf16ParseRequest,
+    TsrxParseError, TsrxParseOptions, TsrxParseRecovery, TsrxParseRequest, TsrxParseResult,
+    TsrxUtf16ParseRequest,
 };
 #[cfg(not(feature = "stage4-observer"))]
 use tsrx_parser_engine::{
@@ -286,16 +287,19 @@ fn validate_tsrx_options(options: &NativeParserOptions) -> napi::Result<()> {
     }
     if let Some(value) = options.recovery.as_deref() {
         match value {
-            "none" => {}
-            "editor" => {
-                return Err(napi::Error::from_reason(
-                    "ERR_TSRX_CAPABILITY_RECOVERY: editor recovery is not available".to_string(),
-                ));
-            }
+            "none" | "editor" => {}
             _ => return Err(invalid(format!("unsupported recovery `{value}`"))),
         }
     }
     Ok(())
+}
+
+fn tsrx_recovery(options: &NativeParserOptions) -> TsrxParseRecovery {
+    if options.recovery.as_deref() == Some("editor") {
+        TsrxParseRecovery::Editor
+    } else {
+        TsrxParseRecovery::None
+    }
 }
 
 fn owned_source(
@@ -358,6 +362,7 @@ fn parse_owned(
                 preserve_parens: if eager_compat { Some(false) } else { options.preserve_parens },
                 show_semantic_errors: !eager_compat
                     && options.show_semantic_errors.unwrap_or(false),
+                recovery: tsrx_recovery(options),
             };
             #[cfg(feature = "stage4-observer")]
             let parsed = if eager_compat {
@@ -393,6 +398,7 @@ fn parse_owned(
                 preserve_parens: if eager_compat { Some(false) } else { options.preserve_parens },
                 show_semantic_errors: !eager_compat
                     && options.show_semantic_errors.unwrap_or(false),
+                recovery: tsrx_recovery(options),
             };
             #[cfg(feature = "stage4-observer")]
             let parsed = if eager_compat {

--- a/crates/tsrx_parser_engine/src/entry.rs
+++ b/crates/tsrx_parser_engine/src/entry.rs
@@ -28,8 +28,11 @@ pub fn parse_tsrx(request: &TsrxParseRequest<'_>) -> Result<TsrxParseResult, Tsr
 ///
 /// # Errors
 ///
-/// Malformed, unsupported, or OXC-rejected authored grammar is returned as a structured
-/// [`ParseCompleteness::Failed`](tsrx_tape_schema::ParseCompleteness::Failed) result with null `program` and `module` records. Requested
+/// With default options, malformed, unsupported, or OXC-rejected authored grammar is returned as
+/// a structured [`ParseCompleteness::Failed`](tsrx_tape_schema::ParseCompleteness::Failed) result
+/// with null `program` and `module` records. Editor recovery may instead retain a usable OXC
+/// partial tree and mark it
+/// [`ParseCompleteness::Recovered`](tsrx_tape_schema::ParseCompleteness::Recovered). Requested
 /// semantic diagnostics are likewise returned as structured result data. Returns an error only
 /// for operational failures such as unsupported coordinate domains, capacity exhaustion, or an
 /// internal projection/reconstruction invariant.

--- a/crates/tsrx_parser_engine/src/lib.rs
+++ b/crates/tsrx_parser_engine/src/lib.rs
@@ -10,6 +10,7 @@ mod parse_result;
 mod pipeline;
 mod projection;
 mod reconstruct;
+mod recovery;
 mod request;
 mod results;
 mod source_bridge;
@@ -32,4 +33,4 @@ pub use error::TsrxParseError;
 #[cfg(feature = "stage4-observer")]
 pub use observer::Stage4WorkCounters;
 pub use parse_result::TsrxParseResult;
-pub use request::{TsrxParseOptions, TsrxParseRequest, TsrxUtf16ParseRequest};
+pub use request::{TsrxParseOptions, TsrxParseRecovery, TsrxParseRequest, TsrxUtf16ParseRequest};

--- a/crates/tsrx_parser_engine/src/parse_result.rs
+++ b/crates/tsrx_parser_engine/src/parse_result.rs
@@ -24,11 +24,11 @@ pub struct TsrxParseResult {
 }
 
 impl TsrxParseResult {
-    /// Returns the complete Program for production callers that already require parse success.
+    /// Returns the Program for callers that already require a populated result.
     ///
     /// # Panics
     ///
-    /// Panics when called on a failed or future recovered result without a Program.
+    /// Panics when called on a failed result.
     #[must_use]
     pub fn program(&self) -> &FlatTape {
         self.program.as_ref().expect("complete TSRX result must contain a Program")
@@ -43,7 +43,58 @@ impl TsrxParseResult {
         needs_compaction: bool,
         rejection_module_names: RejectionModuleNames,
     ) -> Self {
-        let mut completeness = Completeness::COMPLETE.with(Completeness::HAS_PROGRAM);
+        Self::populated(
+            ParseCompleteness::Complete,
+            Completeness::COMPLETE,
+            program,
+            module,
+            comments,
+            errors,
+            suppressed_diagnostics,
+            needs_compaction,
+            rejection_module_names,
+        )
+    }
+
+    pub(super) fn recovered(
+        program: FlatTape,
+        module: Option<ModuleTable>,
+        comments: CommentTable,
+        errors: DiagnosticTable,
+        suppressed_diagnostics: u32,
+        needs_compaction: bool,
+        rejection_module_names: RejectionModuleNames,
+    ) -> Self {
+        debug_assert!(!errors.is_empty());
+        Self::populated(
+            ParseCompleteness::Recovered,
+            Completeness::EMPTY,
+            program,
+            module,
+            comments,
+            errors,
+            suppressed_diagnostics,
+            needs_compaction,
+            rejection_module_names,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the constructor owns each independent result table and status field"
+    )]
+    fn populated(
+        status: ParseCompleteness,
+        initial_completeness: Completeness,
+        program: FlatTape,
+        module: Option<ModuleTable>,
+        comments: CommentTable,
+        errors: DiagnosticTable,
+        suppressed_diagnostics: u32,
+        needs_compaction: bool,
+        rejection_module_names: RejectionModuleNames,
+    ) -> Self {
+        let mut completeness = initial_completeness.with(Completeness::HAS_PROGRAM);
         if module.is_some() {
             completeness = completeness.with(Completeness::HAS_MODULE);
         }
@@ -54,7 +105,7 @@ impl TsrxParseResult {
             completeness = completeness.with(Completeness::HAS_ERRORS);
         }
         Self {
-            status: ParseCompleteness::Complete,
+            status,
             coordinate_domain: CoordinateDomain::AuthoredUtf8Bytes,
             completeness,
             program: Some(program),

--- a/crates/tsrx_parser_engine/src/pipeline.rs
+++ b/crates/tsrx_parser_engine/src/pipeline.rs
@@ -9,10 +9,11 @@ use oxc_adapter::{
         parse_to_projected_tape_program_only, render_diagnostic_codeframes,
     },
 };
-use tsrx_syntax::{Overlay, OverlayView, ProjectionView, project_for_parser, scan_for_parser};
-use tsrx_tape_schema::{
-    CommentTable, DiagnosticTable, FlatTape, ModuleTable, ParseCompleteness, TapeSpan,
+use tsrx_syntax::{
+    Overlay, OverlayView, PARSER_RECOVERY_DIAGNOSTIC, ProjectionView, project_for_parser,
+    recover_for_parser, scan_for_parser,
 };
+use tsrx_tape_schema::{CommentTable, DiagnosticTable, FlatTape, ModuleTable, TapeSpan};
 
 use crate::{
     TsrxParseError, TsrxParseOptions, TsrxParseRecovery, TsrxParseResult,
@@ -36,53 +37,43 @@ pub(super) fn parse_tsrx_utf8_source<W: Utf16WorkObserver>(
     observer: &mut W,
 ) -> Result<TsrxParseResult, TsrxParseError> {
     let recovery_source = (options.recovery == TsrxParseRecovery::Editor)
-        .then(|| recovery::prepare(source))
+        .then(|| recover_for_parser(source).map_err(TsrxParseError::from))
         .transpose()?
         .flatten();
-    let initial = match parse_tsrx_utf8_source_once(
-        source,
-        options,
-        defer_compaction,
-        retain_rejection_module_names,
-        retain_module,
-        observer,
-    ) {
-        Ok(result) if result.status != ParseCompleteness::Failed || recovery_source.is_none() => {
-            return Ok(result);
-        }
-        Ok(result) => result,
-        Err(error) if recovery_source.is_some() => {
-            let recovery_source = recovery_source
-                .as_ref()
-                .ok_or(TsrxParseError::Unsupported("missing prepared editor recovery"))?;
-            let message = error.to_string();
-            grammar_result(
-                source,
-                options.filename,
-                CommentTable::default(),
-                &message,
-                Some(TapeSpan::new(
-                    recovery_source.diagnostic_offset(),
-                    recovery_source.diagnostic_offset(),
-                )),
-            )?
-        }
-        Err(error) => return Err(error),
+    let Some(recovery_source) = recovery_source else {
+        return parse_tsrx_utf8_source_once(
+            source,
+            options,
+            defer_compaction,
+            retain_rejection_module_names,
+            retain_module,
+            observer,
+        );
     };
-    let recovery_source =
-        recovery_source.ok_or(TsrxParseError::Unsupported("missing prepared editor recovery"))?;
+    let failure = grammar_result(
+        source,
+        options.filename,
+        CommentTable::default(),
+        PARSER_RECOVERY_DIAGNOSTIC,
+        Some(TapeSpan::new(
+            recovery_source.diagnostic_offset(),
+            recovery_source.diagnostic_offset(),
+        )),
+    )?;
     let mut recovery_options = options;
     recovery_options.recovery = TsrxParseRecovery::None;
     recovery_options.show_semantic_errors = false;
-    let recovered = parse_tsrx_utf8_source_once(
+    let Ok(recovered) = parse_tsrx_utf8_source_once(
         recovery_source.source(),
         recovery_options,
         defer_compaction,
         retain_rejection_module_names,
         retain_module,
         observer,
-    )?;
-    recovery::finish(recovered, initial, &recovery_source)
+    ) else {
+        return Ok(failure);
+    };
+    recovery::finish(recovered, failure, &recovery_source)
 }
 
 fn parse_tsrx_utf8_source_once<W: Utf16WorkObserver>(

--- a/crates/tsrx_parser_engine/src/pipeline.rs
+++ b/crates/tsrx_parser_engine/src/pipeline.rs
@@ -4,27 +4,88 @@
 use oxc_adapter::{
     DynamicTagContract,
     parser::{
-        ProjectedParseRequest, ProjectedParseResult, RejectionMetadata, RejectionModuleNames,
-        parse_failed_tsrx_metadata, parse_to_projected_tape, parse_to_projected_tape_program_only,
-        render_diagnostic_codeframes,
+        ProjectedParseRecovery, ProjectedParseRequest, ProjectedParseResult, RejectionMetadata,
+        RejectionModuleNames, parse_failed_tsrx_metadata, parse_to_projected_tape,
+        parse_to_projected_tape_program_only, render_diagnostic_codeframes,
     },
 };
 use tsrx_syntax::{Overlay, OverlayView, ProjectionView, project_for_parser, scan_for_parser};
-use tsrx_tape_schema::{CommentTable, DiagnosticTable, FlatTape, ModuleTable};
+use tsrx_tape_schema::{
+    CommentTable, DiagnosticTable, FlatTape, ModuleTable, ParseCompleteness, TapeSpan,
+};
 
 use crate::{
-    TsrxParseError, TsrxParseOptions, TsrxParseResult,
+    TsrxParseError, TsrxParseOptions, TsrxParseRecovery, TsrxParseResult,
     grammar_result::{
-        adapter_grammar_result, authored_grammar_result,
+        adapter_grammar_result, authored_grammar_result, grammar_result,
         grammar_result_with_rejection_module_names, projection_grammar_result,
     },
     lexical, projection,
     reconstruct::{finalize_reachable_spans, reconstruct_projected},
+    recovery,
     results::{reconstruct_diagnostics, reconstruct_module},
     utf16_result::Utf16WorkObserver,
 };
 
 pub(super) fn parse_tsrx_utf8_source<W: Utf16WorkObserver>(
+    source: &str,
+    options: TsrxParseOptions<'_>,
+    defer_compaction: bool,
+    retain_rejection_module_names: bool,
+    retain_module: bool,
+    observer: &mut W,
+) -> Result<TsrxParseResult, TsrxParseError> {
+    let recovery_source = (options.recovery == TsrxParseRecovery::Editor)
+        .then(|| recovery::prepare(source))
+        .transpose()?
+        .flatten();
+    let initial = match parse_tsrx_utf8_source_once(
+        source,
+        options,
+        defer_compaction,
+        retain_rejection_module_names,
+        retain_module,
+        observer,
+    ) {
+        Ok(result) if result.status != ParseCompleteness::Failed || recovery_source.is_none() => {
+            return Ok(result);
+        }
+        Ok(result) => result,
+        Err(error) if recovery_source.is_some() => {
+            let recovery_source = recovery_source
+                .as_ref()
+                .ok_or(TsrxParseError::Unsupported("missing prepared editor recovery"))?;
+            let message = error.to_string();
+            grammar_result(
+                source,
+                options.filename,
+                CommentTable::default(),
+                &message,
+                Some(TapeSpan::new(
+                    recovery_source.diagnostic_offset(),
+                    recovery_source.diagnostic_offset(),
+                )),
+            )?
+        }
+        Err(error) => return Err(error),
+    };
+    let recovery_source =
+        recovery_source.ok_or(TsrxParseError::Unsupported("missing prepared editor recovery"))?;
+    let mut recovery_options = options;
+    recovery_options.recovery = TsrxParseRecovery::None;
+    recovery_options.show_semantic_errors = false;
+    let recovered = parse_tsrx_utf8_source_once(
+        recovery_source.source(),
+        recovery_options,
+        defer_compaction,
+        retain_rejection_module_names,
+        retain_module,
+        observer,
+    )?;
+    recovery::finish(recovered, initial, &recovery_source)
+}
+
+fn parse_tsrx_utf8_source_once<W: Utf16WorkObserver>(
     source: &str,
     options: TsrxParseOptions<'_>,
     defer_compaction: bool,
@@ -85,6 +146,11 @@ fn parse_direct<W: Utf16WorkObserver>(
         ranges: options.ranges,
         preserve_parens: options.preserve_parens,
         show_semantic_errors: options.show_semantic_errors,
+        recovery: if options.recovery == TsrxParseRecovery::Editor {
+            ProjectedParseRecovery::Editor
+        } else {
+            ProjectedParseRecovery::None
+        },
         rejection_metadata: rejection_metadata(retain_rejection_module_names),
         dynamic_tags: None,
         synthetic_callee_spans: &[],
@@ -103,7 +169,7 @@ fn parse_direct<W: Utf16WorkObserver>(
     let suppressed_diagnostics = parsed.suppressed_diagnostics;
     render_diagnostic_codeframes(options.filename, source, &mut errors)
         .map_err(TsrxParseError::from)?;
-    if parsed.syntax_failed {
+    if parsed.syntax_failed && parsed.program.is_none() {
         return TsrxParseResult::failed_with_rejection_module_names(
             parsed.comments,
             errors,
@@ -117,7 +183,9 @@ fn parse_direct<W: Utf16WorkObserver>(
     } else {
         None
     };
-    Ok(TsrxParseResult::complete(
+    let build_result =
+        if parsed.syntax_failed { TsrxParseResult::recovered } else { TsrxParseResult::complete };
+    Ok(build_result(
         program,
         module,
         parsed.comments,
@@ -172,6 +240,11 @@ fn parse_projected<W: Utf16WorkObserver>(
         ranges: options.ranges,
         preserve_parens: options.preserve_parens,
         show_semantic_errors: options.show_semantic_errors,
+        recovery: if options.recovery == TsrxParseRecovery::Editor {
+            ProjectedParseRecovery::Editor
+        } else {
+            ProjectedParseRecovery::None
+        },
         rejection_metadata: rejection_metadata(retain_rejection_module_names),
         dynamic_tags: dynamic_contract,
         synthetic_callee_spans: projected.synthetic_callee_spans(),
@@ -223,14 +296,17 @@ fn parse_projected<W: Utf16WorkObserver>(
             rejection_module_names,
         );
     }
-    let (mut errors, projection_suppressed_diagnostics) =
-        reconstruct_diagnostics(projected_errors, projection_view.segments)?;
+    let (mut errors, projection_suppressed_diagnostics) = reconstruct_diagnostics(
+        projected_errors,
+        projection_view.segments,
+        options.recovery == TsrxParseRecovery::Editor,
+    )?;
     let suppressed_diagnostics = parser_suppressed_diagnostics
         .checked_add(projection_suppressed_diagnostics)
         .ok_or(TsrxParseError::Unsupported("suppressed diagnostic count exceeds 4 GiB"))?;
     render_diagnostic_codeframes(options.filename, source, &mut errors)
         .map_err(TsrxParseError::from)?;
-    if syntax_failed {
+    if syntax_failed && program.is_none() {
         return TsrxParseResult::failed_with_rejection_module_names(
             comments,
             errors,
@@ -256,6 +332,7 @@ fn parse_projected<W: Utf16WorkObserver>(
         comments,
         errors,
         suppressed_diagnostics,
+        recovered: syntax_failed,
         defer_compaction,
         rejection_module_names,
     }
@@ -303,6 +380,7 @@ struct ProjectedCompletion<'source, 'filename, 'overlay, 'projection> {
     comments: CommentTable,
     errors: DiagnosticTable,
     suppressed_diagnostics: u32,
+    recovered: bool,
     defer_compaction: bool,
     rejection_module_names: RejectionModuleNames,
 }
@@ -353,7 +431,9 @@ impl ProjectedCompletion<'_, '_, '_, '_> {
         if !self.defer_compaction {
             self.tape.compact_reachable()?;
         }
-        Ok(TsrxParseResult::complete(
+        let build_result =
+            if self.recovered { TsrxParseResult::recovered } else { TsrxParseResult::complete };
+        Ok(build_result(
             self.tape,
             module,
             self.comments,

--- a/crates/tsrx_parser_engine/src/recovery.rs
+++ b/crates/tsrx_parser_engine/src/recovery.rs
@@ -1,0 +1,321 @@
+//! Bounded source repair for editor snapshots that cannot produce an OXC partial Program.
+//!
+//! The repair is deliberately outside the strict parser. It edits only incomplete syntax, keeps
+//! an endpoint map for every inserted byte, and accepts a candidate only after the ordinary
+//! fail-closed pipeline produces a complete authored TSRX tree.
+
+use tsrx_syntax::{ProjectionError, scan_for_parser};
+use tsrx_tape_schema::{ParseCompleteness, TapeSpan};
+
+use crate::{
+    TsrxParseError, TsrxParseResult,
+    utf16_result::{program_reachable_objects, try_map_program_spans},
+};
+
+pub(super) struct RecoverySource {
+    text: String,
+    boundaries: Vec<u32>,
+    diagnostic_offset: u32,
+}
+
+impl RecoverySource {
+    fn new(source: &str) -> Result<Self, TsrxParseError> {
+        let source_len = u32::try_from(source.len()).map_err(|_| {
+            TsrxParseError::ResourceExhausted("TSRX source exceeds the 4 GiB span limit")
+        })?;
+        Ok(Self {
+            text: source.to_string(),
+            boundaries: (0..=source_len).collect(),
+            diagnostic_offset: source_len,
+        })
+    }
+
+    pub(super) fn source(&self) -> &str {
+        &self.text
+    }
+
+    pub(super) const fn diagnostic_offset(&self) -> u32 {
+        self.diagnostic_offset
+    }
+
+    fn replace(
+        &mut self,
+        start: usize,
+        end: usize,
+        replacement: &str,
+    ) -> Result<(), TsrxParseError> {
+        if start > end
+            || !self.text.is_char_boundary(start)
+            || !self.text.is_char_boundary(end)
+            || end > self.text.len()
+        {
+            return Err(TsrxParseError::Unsupported(
+                "editor recovery edit is outside authored source boundaries",
+            ));
+        }
+        let original_start = *self
+            .boundaries
+            .get(start)
+            .ok_or(TsrxParseError::Unsupported("editor recovery start has no authored boundary"))?;
+        let original_end = *self
+            .boundaries
+            .get(end)
+            .ok_or(TsrxParseError::Unsupported("editor recovery end has no authored boundary"))?;
+        let old_length = end - start;
+        let replacement_boundaries = if replacement.len() == old_length {
+            self.boundaries[start..=end].to_vec()
+        } else {
+            let mut boundaries = vec![original_start; replacement.len() + 1];
+            if let Some(last) = boundaries.last_mut() {
+                *last = original_end;
+            }
+            boundaries
+        };
+        self.text.replace_range(start..end, replacement);
+        self.boundaries.splice(start..=end, replacement_boundaries);
+        self.diagnostic_offset = self.diagnostic_offset.min(original_start);
+        Ok(())
+    }
+
+    fn insert(&mut self, at: usize, text: &str) -> Result<(), TsrxParseError> {
+        self.replace(at, at, text)
+    }
+
+    fn map_endpoint(&self, offset: u32) -> Result<u32, TsrxParseError> {
+        let index = usize::try_from(offset)
+            .map_err(|_| TsrxParseError::Unsupported("recovered offset exceeds usize"))?;
+        self.boundaries
+            .get(index)
+            .copied()
+            .ok_or(TsrxParseError::Unsupported("recovered offset has no authored boundary"))
+    }
+}
+
+pub(super) fn prepare(source: &str) -> Result<Option<RecoverySource>, TsrxParseError> {
+    let mut recovered = RecoverySource::new(source)?;
+    let mut changed = blank_bare_at_tokens(&mut recovered)?;
+
+    for _ in 0..16 {
+        match scan_for_parser(recovered.source()) {
+            Ok(_) => break,
+            Err(ProjectionError::UnterminatedSyntax { offset, construct: "JSX element" }) => {
+                if !close_unterminated_jsx(&mut recovered, offset)? {
+                    return Ok(None);
+                }
+                changed = true;
+            }
+            Err(
+                ProjectionError::UnterminatedSyntax { offset, .. }
+                | ProjectionError::MalformedSyntax { offset, .. },
+            ) => {
+                if !blank_incomplete_control(&mut recovered, offset)? {
+                    return Ok(None);
+                }
+                changed = true;
+            }
+            Err(_) => return Ok(None),
+        }
+    }
+    if scan_for_parser(recovered.source()).is_err() {
+        return Ok(None);
+    }
+    changed |= complete_tail(&mut recovered)?;
+    Ok(changed.then_some(recovered))
+}
+
+pub(super) fn finish(
+    mut recovered: TsrxParseResult,
+    failure: TsrxParseResult,
+    source: &RecoverySource,
+) -> Result<TsrxParseResult, TsrxParseError> {
+    if recovered.status != ParseCompleteness::Complete {
+        return Ok(failure);
+    }
+    let mut program = recovered
+        .program
+        .take()
+        .ok_or(TsrxParseError::Unsupported("recovery candidate has no Program"))?;
+    let reachable = program_reachable_objects(&program)?;
+    try_map_program_spans(&mut program, &reachable, |offset| source.map_endpoint(offset))?;
+    if let Some(module) = recovered.module.as_mut() {
+        module.try_map_spans(|span| map_span(source, span))?;
+    }
+    recovered.comments.try_map_spans(|span| map_span(source, span))?;
+    recovered.rejection_module_names.try_map_spans(|span| map_span(source, span))?;
+
+    Ok(TsrxParseResult::recovered(
+        program,
+        recovered.module,
+        recovered.comments,
+        failure.errors,
+        failure.suppressed_diagnostics.saturating_add(recovered.suppressed_diagnostics),
+        recovered.needs_compaction,
+        std::mem::take(&mut recovered.rejection_module_names),
+    ))
+}
+
+fn map_span(source: &RecoverySource, span: TapeSpan) -> Result<TapeSpan, TsrxParseError> {
+    Ok(TapeSpan::new(source.map_endpoint(span.start)?, source.map_endpoint(span.end)?))
+}
+
+fn blank_bare_at_tokens(source: &mut RecoverySource) -> Result<bool, TsrxParseError> {
+    let mut offsets = Vec::new();
+    let bytes = source.text.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' | b'`' => index = skip_quoted(bytes, index, bytes[index]),
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(bytes, index + 2);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index + 2);
+            }
+            b'@' => {
+                let next = bytes.get(index + 1).copied();
+                if !matches!(next, Some(b'{' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_')) {
+                    offsets.push(index);
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    for offset in offsets.into_iter().rev() {
+        source.replace(offset, offset + 1, " ")?;
+    }
+    Ok(source.diagnostic_offset != u32::try_from(source.text.len()).unwrap_or(u32::MAX))
+}
+
+fn blank_incomplete_control(
+    source: &mut RecoverySource,
+    failure_offset: u32,
+) -> Result<bool, TsrxParseError> {
+    let limit = usize::try_from(failure_offset).unwrap_or(usize::MAX).min(source.text.len());
+    let Some(start) = last_control_start(&source.text, limit) else {
+        return Ok(false);
+    };
+    let replacement = " ".repeat(source.text.len() - start);
+    source.replace(start, source.text.len(), &replacement)?;
+    Ok(true)
+}
+
+fn close_unterminated_jsx(
+    source: &mut RecoverySource,
+    opening_offset: u32,
+) -> Result<bool, TsrxParseError> {
+    let start = usize::try_from(opening_offset)
+        .map_err(|_| TsrxParseError::Unsupported("JSX recovery offset exceeds usize"))?;
+    let bytes = source.text.as_bytes();
+    if bytes.get(start) != Some(&b'<') {
+        return Ok(false);
+    }
+    let mut end = start + 1;
+    while bytes.get(end).is_some_and(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'$')
+    }) {
+        end += 1;
+    }
+    if end == start + 1 {
+        return Ok(false);
+    }
+    let name = source.text[start + 1..end].to_string();
+    let insertion =
+        source.text[start..].rfind('}').map_or(source.text.len(), |relative| start + relative);
+    source.insert(insertion, &format!("</{name}>"))?;
+    Ok(true)
+}
+
+fn complete_tail(source: &mut RecoverySource) -> Result<bool, TsrxParseError> {
+    let bytes = source.text.as_bytes();
+    let mut stack = Vec::new();
+    let mut index = 0;
+    let mut last_significant = None;
+    while index < bytes.len() {
+        match bytes[index] {
+            byte @ (b'\'' | b'"' | b'`') => {
+                index = skip_quoted(bytes, index, byte);
+                last_significant = Some(byte);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(bytes, index + 2);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index + 2);
+            }
+            byte @ (b'(' | b'[' | b'{') => {
+                stack.push(match byte {
+                    b'(' => b')',
+                    b'[' => b']',
+                    b'{' => b'}',
+                    _ => unreachable!(),
+                });
+                last_significant = Some(byte);
+                index += 1;
+            }
+            byte @ (b')' | b']' | b'}') => {
+                if stack.last() == Some(&byte) {
+                    stack.pop();
+                }
+                last_significant = Some(byte);
+                index += 1;
+            }
+            byte if byte.is_ascii_whitespace() => index += 1,
+            byte => {
+                last_significant = Some(byte);
+                index += 1;
+            }
+        }
+    }
+    let mut suffix = String::new();
+    if matches!(
+        last_significant,
+        Some(b'=' | b'.' | b'+' | b'-' | b'*' | b'/' | b'%' | b'?' | b':' | b',')
+    ) {
+        suffix.push_str(" undefined");
+    }
+    suffix.extend(stack.into_iter().rev().map(char::from));
+    if suffix.is_empty() {
+        return Ok(false);
+    }
+    source.insert(source.text.len(), &suffix)?;
+    Ok(true)
+}
+
+fn last_control_start(source: &str, limit: usize) -> Option<usize> {
+    ["@if", "@for", "@switch", "@try"]
+        .into_iter()
+        .filter_map(|keyword| source[..limit].rfind(keyword))
+        .max()
+}
+
+fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut index = start + 1;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+        } else if bytes[index] == quote {
+            return index + 1;
+        } else {
+            index += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() && !matches!(bytes[index], b'\r' | b'\n') {
+        index += 1;
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index + 1 < bytes.len() {
+        if bytes[index..index + 2] == *b"*/" {
+            return index + 2;
+        }
+        index += 1;
+    }
+    bytes.len()
+}

--- a/crates/tsrx_parser_engine/src/recovery.rs
+++ b/crates/tsrx_parser_engine/src/recovery.rs
@@ -1,10 +1,6 @@
-//! Bounded source repair for editor snapshots that cannot produce an OXC partial Program.
-//!
-//! The repair is deliberately outside the strict parser. It edits only incomplete syntax, keeps
-//! an endpoint map for every inserted byte, and accepts a candidate only after the ordinary
-//! fail-closed pipeline produces a complete authored TSRX tree.
+//! Mapping a parser-owned editor recovery candidate back to authored result coordinates.
 
-use tsrx_syntax::{ProjectionError, scan_for_parser};
+use tsrx_syntax::ParserRecovery;
 use tsrx_tape_schema::{ParseCompleteness, TapeSpan};
 
 use crate::{
@@ -12,121 +8,10 @@ use crate::{
     utf16_result::{program_reachable_objects, try_map_program_spans},
 };
 
-pub(super) struct RecoverySource {
-    text: String,
-    boundaries: Vec<u32>,
-    diagnostic_offset: u32,
-}
-
-impl RecoverySource {
-    fn new(source: &str) -> Result<Self, TsrxParseError> {
-        let source_len = u32::try_from(source.len()).map_err(|_| {
-            TsrxParseError::ResourceExhausted("TSRX source exceeds the 4 GiB span limit")
-        })?;
-        Ok(Self {
-            text: source.to_string(),
-            boundaries: (0..=source_len).collect(),
-            diagnostic_offset: source_len,
-        })
-    }
-
-    pub(super) fn source(&self) -> &str {
-        &self.text
-    }
-
-    pub(super) const fn diagnostic_offset(&self) -> u32 {
-        self.diagnostic_offset
-    }
-
-    fn replace(
-        &mut self,
-        start: usize,
-        end: usize,
-        replacement: &str,
-    ) -> Result<(), TsrxParseError> {
-        if start > end
-            || !self.text.is_char_boundary(start)
-            || !self.text.is_char_boundary(end)
-            || end > self.text.len()
-        {
-            return Err(TsrxParseError::Unsupported(
-                "editor recovery edit is outside authored source boundaries",
-            ));
-        }
-        let original_start = *self
-            .boundaries
-            .get(start)
-            .ok_or(TsrxParseError::Unsupported("editor recovery start has no authored boundary"))?;
-        let original_end = *self
-            .boundaries
-            .get(end)
-            .ok_or(TsrxParseError::Unsupported("editor recovery end has no authored boundary"))?;
-        let old_length = end - start;
-        let replacement_boundaries = if replacement.len() == old_length {
-            self.boundaries[start..=end].to_vec()
-        } else {
-            let mut boundaries = vec![original_start; replacement.len() + 1];
-            if let Some(last) = boundaries.last_mut() {
-                *last = original_end;
-            }
-            boundaries
-        };
-        self.text.replace_range(start..end, replacement);
-        self.boundaries.splice(start..=end, replacement_boundaries);
-        self.diagnostic_offset = self.diagnostic_offset.min(original_start);
-        Ok(())
-    }
-
-    fn insert(&mut self, at: usize, text: &str) -> Result<(), TsrxParseError> {
-        self.replace(at, at, text)
-    }
-
-    fn map_endpoint(&self, offset: u32) -> Result<u32, TsrxParseError> {
-        let index = usize::try_from(offset)
-            .map_err(|_| TsrxParseError::Unsupported("recovered offset exceeds usize"))?;
-        self.boundaries
-            .get(index)
-            .copied()
-            .ok_or(TsrxParseError::Unsupported("recovered offset has no authored boundary"))
-    }
-}
-
-pub(super) fn prepare(source: &str) -> Result<Option<RecoverySource>, TsrxParseError> {
-    let mut recovered = RecoverySource::new(source)?;
-    let mut changed = blank_bare_at_tokens(&mut recovered)?;
-
-    for _ in 0..16 {
-        match scan_for_parser(recovered.source()) {
-            Ok(_) => break,
-            Err(ProjectionError::UnterminatedSyntax { offset, construct: "JSX element" }) => {
-                if !close_unterminated_jsx(&mut recovered, offset)? {
-                    return Ok(None);
-                }
-                changed = true;
-            }
-            Err(
-                ProjectionError::UnterminatedSyntax { offset, .. }
-                | ProjectionError::MalformedSyntax { offset, .. },
-            ) => {
-                if !blank_incomplete_control(&mut recovered, offset)? {
-                    return Ok(None);
-                }
-                changed = true;
-            }
-            Err(_) => return Ok(None),
-        }
-    }
-    if scan_for_parser(recovered.source()).is_err() {
-        return Ok(None);
-    }
-    changed |= complete_tail(&mut recovered)?;
-    Ok(changed.then_some(recovered))
-}
-
 pub(super) fn finish(
     mut recovered: TsrxParseResult,
     failure: TsrxParseResult,
-    source: &RecoverySource,
+    source: &ParserRecovery,
 ) -> Result<TsrxParseResult, TsrxParseError> {
     if recovered.status != ParseCompleteness::Complete {
         return Ok(failure);
@@ -136,7 +21,11 @@ pub(super) fn finish(
         .take()
         .ok_or(TsrxParseError::Unsupported("recovery candidate has no Program"))?;
     let reachable = program_reachable_objects(&program)?;
-    try_map_program_spans(&mut program, &reachable, |offset| source.map_endpoint(offset))?;
+    try_map_program_spans(&mut program, &reachable, |offset| {
+        source
+            .map_endpoint(offset)
+            .ok_or(TsrxParseError::Unsupported("recovered offset has no authored boundary"))
+    })?;
     if let Some(module) = recovered.module.as_mut() {
         module.try_map_spans(|span| map_span(source, span))?;
     }
@@ -154,168 +43,12 @@ pub(super) fn finish(
     ))
 }
 
-fn map_span(source: &RecoverySource, span: TapeSpan) -> Result<TapeSpan, TsrxParseError> {
-    Ok(TapeSpan::new(source.map_endpoint(span.start)?, source.map_endpoint(span.end)?))
-}
-
-fn blank_bare_at_tokens(source: &mut RecoverySource) -> Result<bool, TsrxParseError> {
-    let mut offsets = Vec::new();
-    let bytes = source.text.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' | b'"' | b'`' => index = skip_quoted(bytes, index, bytes[index]),
-            b'/' if bytes.get(index + 1) == Some(&b'/') => {
-                index = skip_line_comment(bytes, index + 2);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                index = skip_block_comment(bytes, index + 2);
-            }
-            b'@' => {
-                let next = bytes.get(index + 1).copied();
-                if !matches!(next, Some(b'{' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_')) {
-                    offsets.push(index);
-                }
-                index += 1;
-            }
-            _ => index += 1,
-        }
-    }
-    for offset in offsets.into_iter().rev() {
-        source.replace(offset, offset + 1, " ")?;
-    }
-    Ok(source.diagnostic_offset != u32::try_from(source.text.len()).unwrap_or(u32::MAX))
-}
-
-fn blank_incomplete_control(
-    source: &mut RecoverySource,
-    failure_offset: u32,
-) -> Result<bool, TsrxParseError> {
-    let limit = usize::try_from(failure_offset).unwrap_or(usize::MAX).min(source.text.len());
-    let Some(start) = last_control_start(&source.text, limit) else {
-        return Ok(false);
-    };
-    let replacement = " ".repeat(source.text.len() - start);
-    source.replace(start, source.text.len(), &replacement)?;
-    Ok(true)
-}
-
-fn close_unterminated_jsx(
-    source: &mut RecoverySource,
-    opening_offset: u32,
-) -> Result<bool, TsrxParseError> {
-    let start = usize::try_from(opening_offset)
-        .map_err(|_| TsrxParseError::Unsupported("JSX recovery offset exceeds usize"))?;
-    let bytes = source.text.as_bytes();
-    if bytes.get(start) != Some(&b'<') {
-        return Ok(false);
-    }
-    let mut end = start + 1;
-    while bytes.get(end).is_some_and(|byte| {
-        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'$')
-    }) {
-        end += 1;
-    }
-    if end == start + 1 {
-        return Ok(false);
-    }
-    let name = source.text[start + 1..end].to_string();
-    let insertion =
-        source.text[start..].rfind('}').map_or(source.text.len(), |relative| start + relative);
-    source.insert(insertion, &format!("</{name}>"))?;
-    Ok(true)
-}
-
-fn complete_tail(source: &mut RecoverySource) -> Result<bool, TsrxParseError> {
-    let bytes = source.text.as_bytes();
-    let mut stack = Vec::new();
-    let mut index = 0;
-    let mut last_significant = None;
-    while index < bytes.len() {
-        match bytes[index] {
-            byte @ (b'\'' | b'"' | b'`') => {
-                index = skip_quoted(bytes, index, byte);
-                last_significant = Some(byte);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'/') => {
-                index = skip_line_comment(bytes, index + 2);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                index = skip_block_comment(bytes, index + 2);
-            }
-            byte @ (b'(' | b'[' | b'{') => {
-                stack.push(match byte {
-                    b'(' => b')',
-                    b'[' => b']',
-                    b'{' => b'}',
-                    _ => unreachable!(),
-                });
-                last_significant = Some(byte);
-                index += 1;
-            }
-            byte @ (b')' | b']' | b'}') => {
-                if stack.last() == Some(&byte) {
-                    stack.pop();
-                }
-                last_significant = Some(byte);
-                index += 1;
-            }
-            byte if byte.is_ascii_whitespace() => index += 1,
-            byte => {
-                last_significant = Some(byte);
-                index += 1;
-            }
-        }
-    }
-    let mut suffix = String::new();
-    if matches!(
-        last_significant,
-        Some(b'=' | b'.' | b'+' | b'-' | b'*' | b'/' | b'%' | b'?' | b':' | b',')
-    ) {
-        suffix.push_str(" undefined");
-    }
-    suffix.extend(stack.into_iter().rev().map(char::from));
-    if suffix.is_empty() {
-        return Ok(false);
-    }
-    source.insert(source.text.len(), &suffix)?;
-    Ok(true)
-}
-
-fn last_control_start(source: &str, limit: usize) -> Option<usize> {
-    ["@if", "@for", "@switch", "@try"]
-        .into_iter()
-        .filter_map(|keyword| source[..limit].rfind(keyword))
-        .max()
-}
-
-fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
-    let mut index = start + 1;
-    while index < bytes.len() {
-        if bytes[index] == b'\\' {
-            index = (index + 2).min(bytes.len());
-        } else if bytes[index] == quote {
-            return index + 1;
-        } else {
-            index += 1;
-        }
-    }
-    bytes.len()
-}
-
-fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
-    while index < bytes.len() && !matches!(bytes[index], b'\r' | b'\n') {
-        index += 1;
-    }
-    index
-}
-
-fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
-    while index + 1 < bytes.len() {
-        if bytes[index..index + 2] == *b"*/" {
-            return index + 2;
-        }
-        index += 1;
-    }
-    bytes.len()
+fn map_span(source: &ParserRecovery, span: TapeSpan) -> Result<TapeSpan, TsrxParseError> {
+    let start = source
+        .map_endpoint(span.start)
+        .ok_or(TsrxParseError::Unsupported("recovered span start has no authored boundary"))?;
+    let end = source
+        .map_endpoint(span.end)
+        .ok_or(TsrxParseError::Unsupported("recovered span end has no authored boundary"))?;
+    Ok(TapeSpan::new(start, end))
 }

--- a/crates/tsrx_parser_engine/src/request.rs
+++ b/crates/tsrx_parser_engine/src/request.rs
@@ -14,6 +14,16 @@ pub struct TsrxUtf16ParseRequest<'a> {
     pub source: &'a [u16],
 }
 
+/// Whether authored syntax errors may return OXC's partial editor tree.
+///
+/// Recovery is opt-in and never changes the fail-closed compiler path.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TsrxParseRecovery {
+    #[default]
+    None,
+    Editor,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct TsrxParseOptions<'a> {
     pub filename: &'a str,
@@ -22,6 +32,7 @@ pub struct TsrxParseOptions<'a> {
     pub ranges: bool,
     pub preserve_parens: Option<bool>,
     pub show_semantic_errors: bool,
+    pub recovery: TsrxParseRecovery,
 }
 
 impl Default for TsrxParseOptions<'static> {
@@ -33,6 +44,7 @@ impl Default for TsrxParseOptions<'static> {
             ranges: false,
             preserve_parens: None,
             show_semantic_errors: false,
+            recovery: TsrxParseRecovery::None,
         }
     }
 }

--- a/crates/tsrx_parser_engine/src/results.rs
+++ b/crates/tsrx_parser_engine/src/results.rs
@@ -248,6 +248,7 @@ fn reconstruct_import_metas(
 pub(super) fn reconstruct_diagnostics(
     mut projected: DiagnosticTable,
     segments: &[ProjectionSegment],
+    recover_mixed_labels: bool,
 ) -> Result<(DiagnosticTable, u32), TsrxParseError> {
     let mut authored = DiagnosticTable::default();
     let mut suppressed = 0_usize;
@@ -268,22 +269,34 @@ pub(super) fn reconstruct_diagnostics(
         for label in labels {
             let _ = mapped_span(segments, label.span, &mut state);
         }
-        if !state.retain("mixed authored and synthetic diagnostic labels")? {
+        let retain = match state.retain("mixed authored and synthetic diagnostic labels") {
+            Ok(retain) => retain,
+            Err(_) if recover_mixed_labels && state.mapped > 0 => true,
+            Err(error) => return Err(error),
+        };
+        if !retain {
             suppressed += 1;
             continue;
         }
         let label_start = authored.begin_labels()?;
+        let mut mapped_labels = 0;
         for label in labels {
-            let span = map_affine_span(segments, label.span).ok_or(TsrxParseError::Unsupported(
-                "authored diagnostic mapping changed between validation and emission",
-            ))?;
+            let Some(span) = map_affine_span(segments, label.span) else {
+                if recover_mixed_labels {
+                    continue;
+                }
+                return Err(TsrxParseError::Unsupported(
+                    "authored diagnostic mapping changed between validation and emission",
+                ));
+            };
             authored.push_labeled(
                 span,
                 optional_string(&projected_strings, label.message)?,
                 label.primary,
             )?;
+            mapped_labels += 1;
         }
-        let labels = authored.finish_labels(label_start, record.labels.length)?;
+        let labels = authored.finish_labels(label_start, mapped_labels)?;
         copy_diagnostic(&projected_strings, &mut authored, record, labels)?;
     }
     drop(labels);
@@ -614,7 +627,7 @@ mod tests {
                 None,
             )
             .expect("coordinate-free diagnostic");
-        let (authored, suppressed) = reconstruct_diagnostics(coordinate_free, &segments)
+        let (authored, suppressed) = reconstruct_diagnostics(coordinate_free, &segments, false)
             .expect("coordinate-free diagnostic survives");
         assert_eq!(suppressed, 0);
         let record = &authored.records()[0];
@@ -644,7 +657,7 @@ mod tests {
             )
             .expect("synthetic diagnostic");
         let (authored, suppressed) =
-            reconstruct_diagnostics(synthetic, &segments).expect("synthetic suppression");
+            reconstruct_diagnostics(synthetic, &segments, false).expect("synthetic suppression");
         assert!(authored.is_empty());
         assert_eq!(suppressed, 1);
 
@@ -669,7 +682,7 @@ mod tests {
                 None,
             )
             .expect("mixed diagnostic");
-        assert!(reconstruct_diagnostics(mixed, &segments).is_err());
+        assert!(reconstruct_diagnostics(mixed, &segments, false).is_err());
     }
 
     #[test]
@@ -703,7 +716,7 @@ mod tests {
                     None,
                 )
                 .expect("projected diagnostic");
-            let (authored, suppressed) = reconstruct_diagnostics(projected, &segments)
+            let (authored, suppressed) = reconstruct_diagnostics(projected, &segments, false)
                 .expect("non-affine diagnostics are suppressed exactly");
             assert!(authored.is_empty());
             assert_eq!(suppressed, 1);

--- a/crates/tsrx_parser_engine/src/utf16_result/ledger.rs
+++ b/crates/tsrx_parser_engine/src/utf16_result/ledger.rs
@@ -63,11 +63,12 @@ impl<'source, 'original> FixupLedger<'source, 'original> {
     }
 
     pub(super) fn finish(mut self, status: ParseCompleteness) -> Result<(), TsrxParseError> {
-        if status == ParseCompleteness::Failed {
+        if status != ParseCompleteness::Complete {
             for state in &mut self.states {
                 if *state == 0 {
-                    // No Program/module value is public on failure; classify the remaining source
-                    // substitutions as deliberately discarded rather than semantic owners.
+                    // Failed results expose no Program, while recovered Programs may omit the
+                    // malformed tail. Classify every unowned substitution as deliberately
+                    // discarded rather than requiring a semantic owner.
                     *state = 3;
                 }
             }

--- a/crates/tsrx_parser_engine/src/utf16_result/mod.rs
+++ b/crates/tsrx_parser_engine/src/utf16_result/mod.rs
@@ -19,3 +19,4 @@ pub(super) use observer::RepairCopyLane;
 #[cfg(test)]
 pub(super) use observer::Utf16Work;
 pub(super) use observer::{NoopUtf16WorkObserver, Utf16WorkObserver};
+pub(crate) use reachability::{program_reachable_objects, try_map_program_spans};

--- a/crates/tsrx_parser_engine/src/utf16_result/reachability.rs
+++ b/crates/tsrx_parser_engine/src/utf16_result/reachability.rs
@@ -7,7 +7,7 @@ use crate::{TsrxParseError, source_bridge::PreparedSource};
 
 use super::tape_fields::{object_type, record_index};
 
-pub(super) fn program_reachable_objects(tape: &FlatTape) -> Result<Vec<bool>, TsrxParseError> {
+pub(crate) fn program_reachable_objects(tape: &FlatTape) -> Result<Vec<bool>, TsrxParseError> {
     let mut objects = vec![false; tape.object_count()];
     let mut lists = vec![false; tape.list_count()];
     let mut pending = vec![tape.root()];
@@ -54,6 +54,20 @@ pub(super) fn map_program_spans(
     source: &PreparedSource<'_>,
     reachable_objects: &[bool],
 ) -> Result<(), TsrxParseError> {
+    try_map_program_spans(tape, reachable_objects, |byte_offset| {
+        source.map_endpoint(byte_offset).ok_or_else(|| {
+            TsrxParseError::Adapter(format!(
+                "coordinate {byte_offset} is not an exact UTF-8 boundary"
+            ))
+        })
+    })
+}
+
+pub(crate) fn try_map_program_spans(
+    tape: &mut FlatTape,
+    reachable_objects: &[bool],
+    mut map_endpoint: impl FnMut(u32) -> Result<u32, TsrxParseError>,
+) -> Result<(), TsrxParseError> {
     // CSS parser coordinates are relative to the `<style>` payload, not the authored module.
     // Keep the complete StyleSheet-owned graph out of source-global UTF-16 remapping, matching
     // @tsrx/core's coordinate contract while every surrounding JS/TSRX node is still mapped.
@@ -73,12 +87,7 @@ pub(super) fn map_program_spans(
                     let byte_offset = tape.scalar_u32(field.value).ok_or_else(|| {
                         TsrxParseError::Adapter("coordinate field is not u32".to_string())
                     })?;
-                    let utf16_offset = source.map_endpoint(byte_offset).ok_or_else(|| {
-                        TsrxParseError::Adapter(format!(
-                            "coordinate {byte_offset} is not an exact UTF-8 boundary"
-                        ))
-                    })?;
-                    field_updates.push((field_index, utf16_offset));
+                    field_updates.push((field_index, map_endpoint(byte_offset)?));
                 }
                 "range" => {
                     let list = field.value.as_list().ok_or_else(|| {
@@ -88,12 +97,7 @@ pub(super) fn map_program_spans(
                         let byte_offset = tape.scalar_u32(value).ok_or_else(|| {
                             TsrxParseError::Adapter("range endpoint is not u32".to_string())
                         })?;
-                        let utf16_offset = source.map_endpoint(byte_offset).ok_or_else(|| {
-                            TsrxParseError::Adapter(format!(
-                                "range endpoint {byte_offset} is not an exact UTF-8 boundary"
-                            ))
-                        })?;
-                        list_updates.push((entry, utf16_offset));
+                        list_updates.push((entry, map_endpoint(byte_offset)?));
                     }
                 }
                 _ => {}

--- a/crates/tsrx_parser_engine/src/utf16_route.rs
+++ b/crates/tsrx_parser_engine/src/utf16_route.rs
@@ -55,7 +55,7 @@ pub(super) fn parse_tsrx_utf16_with_options_and_observer<W: Utf16WorkObserver>(
             prepared.source(),
             Some(&prepared),
         )? {
-            if result.status != ParseCompleteness::Failed {
+            if result.status == ParseCompleteness::Complete {
                 return Err(TsrxParseError::Adapter(
                     "complete parse retained an earlier grammar diagnostic".to_string(),
                 ));

--- a/crates/tsrx_parser_engine/tests/recovery.rs
+++ b/crates/tsrx_parser_engine/tests/recovery.rs
@@ -79,6 +79,16 @@ fn editor_recovery_reconstructs_tsrx_nodes_in_partial_programs() {
 }
 
 #[test]
+fn editor_recovery_does_not_rewrite_at_signs_inside_regex_literals() {
+    let source = "const pattern = /@/;";
+    let result = recover(source);
+
+    assert_eq!(result.status, ParseCompleteness::Complete);
+    assert!(result.completeness.contains(Completeness::COMPLETE));
+    assert!(result.errors.is_empty());
+}
+
+#[test]
 fn editor_recovery_still_fails_when_oxc_cannot_return_a_usable_program() {
     let source = "function View() @{ const value = ; <main /> }";
     let result = recover(source);
@@ -97,6 +107,7 @@ fn editor_recovery_completes_common_in_progress_tsrx_snapshots() {
         "export function View() @{ @if (",
         "export function View() @{ @ }",
         "export function View() @{\n  <div>\n}",
+        "export function View() @{\n  <div>",
     ] {
         if let Ok(strict) = parse_tsrx(&TsrxParseRequest { source }) {
             assert_eq!(strict.status, ParseCompleteness::Failed, "{source}");

--- a/crates/tsrx_parser_engine/tests/recovery.rs
+++ b/crates/tsrx_parser_engine/tests/recovery.rs
@@ -1,0 +1,138 @@
+#[expect(
+    dead_code,
+    reason = "the shared test-support module is compiled into every integration binary and each one uses a different part of it"
+)]
+mod support;
+
+use support::{object_field, program_body, require_type, span};
+use tsrx_parser_engine::{
+    TsrxParseOptions, TsrxParseRecovery, TsrxParseRequest, TsrxParseResult, TsrxUtf16ParseRequest,
+    parse_tsrx, parse_tsrx_utf16_with_options, parse_tsrx_with_options,
+};
+use tsrx_tape_schema::{Completeness, ParseCompleteness};
+
+fn recover(source: &str) -> TsrxParseResult {
+    parse_tsrx_with_options(
+        &TsrxParseRequest { source },
+        TsrxParseOptions { recovery: TsrxParseRecovery::Editor, ..TsrxParseOptions::default() },
+    )
+    .expect("editor recovery should remain result-oriented")
+}
+
+fn assert_recovered(result: &TsrxParseResult, source: &str) {
+    let source_len = u32::try_from(source.len()).expect("fixture length");
+    assert_eq!(result.status, ParseCompleteness::Recovered, "{source}");
+    assert!(!result.completeness.contains(Completeness::COMPLETE), "{source}");
+    assert!(result.completeness.contains(Completeness::HAS_PROGRAM), "{source}");
+    assert!(result.completeness.contains(Completeness::HAS_MODULE), "{source}");
+    assert!(result.completeness.contains(Completeness::HAS_ERRORS), "{source}");
+    assert!(result.module.is_some(), "{source}");
+    assert!(!result.errors.is_empty(), "{source}");
+    let tape = result.program.as_ref().expect("recovered Program");
+    let root = tape.root().as_object().expect("Program root");
+    assert_eq!(span(tape, root), (0, source_len), "{source}");
+    for diagnostic in result.errors.records() {
+        for label in result.errors.labels(diagnostic.labels).expect("diagnostic labels") {
+            assert!(label.span.end <= source_len, "{source}");
+        }
+    }
+}
+
+#[test]
+fn strict_parsing_remains_fail_closed_when_editor_recovery_is_available() {
+    let source = "function View() @{ const value = ; <main /> }";
+    let result = parse_tsrx(&TsrxParseRequest { source }).expect("syntax failures are result data");
+
+    assert_eq!(result.status, ParseCompleteness::Failed);
+    assert!(result.program.is_none());
+    assert!(result.module.is_none());
+    assert!(!result.errors.is_empty());
+}
+
+#[test]
+fn editor_recovery_returns_oxc_partial_programs_for_direct_sources() {
+    let source = "const value; const after = 1;";
+    let result = recover(source);
+    assert_recovered(&result, source);
+
+    let tape = result.program.as_ref().expect("recovered Program");
+    let body = program_body(tape);
+    assert_eq!(body.len(), 2);
+    for statement in body {
+        require_type(tape, statement.as_object().expect("declaration"), "VariableDeclaration");
+    }
+}
+
+#[test]
+fn editor_recovery_reconstructs_tsrx_nodes_in_partial_programs() {
+    let source = "function View() @{ const value; <main /> }";
+    let result = recover(source);
+    assert_recovered(&result, source);
+
+    let tape = result.program.as_ref().expect("recovered Program");
+    let function = program_body(tape)[0].as_object().expect("function");
+    require_type(tape, function, "FunctionDeclaration");
+    let block = object_field(tape, function, "body");
+    require_type(tape, block, "JSXCodeBlock");
+    let render = object_field(tape, block, "render");
+    require_type(tape, render, "JSXElement");
+}
+
+#[test]
+fn editor_recovery_still_fails_when_oxc_cannot_return_a_usable_program() {
+    let source = "function View() @{ const value = ; <main /> }";
+    let result = recover(source);
+
+    assert_eq!(result.status, ParseCompleteness::Failed);
+    assert!(result.program.is_none());
+    assert!(result.module.is_none());
+    assert!(!result.errors.is_empty());
+}
+
+#[test]
+fn editor_recovery_completes_common_in_progress_tsrx_snapshots() {
+    for source in [
+        "export function View() @{",
+        "export function View() @{ const value = ",
+        "export function View() @{ @if (",
+        "export function View() @{ @ }",
+        "export function View() @{\n  <div>\n}",
+    ] {
+        if let Ok(strict) = parse_tsrx(&TsrxParseRequest { source }) {
+            assert_eq!(strict.status, ParseCompleteness::Failed, "{source}");
+        }
+
+        let recovered = recover(source);
+        assert_recovered(&recovered, source);
+        assert!(!program_body(recovered.program.as_ref().expect("recovered Program")).is_empty());
+        assert!(recovered.errors.records().iter().all(|diagnostic| {
+            recovered
+                .errors
+                .string(diagnostic.message)
+                .is_some_and(|message| !message.contains("synthetic diagnostic labels"))
+        }));
+    }
+}
+
+#[test]
+fn editor_recovery_composes_repair_offsets_with_the_utf16_bridge() {
+    let source = "export function View() @{ const \u{3c0} = 1;";
+    let units = source.encode_utf16().collect::<Vec<_>>();
+    let unit_len = u32::try_from(units.len()).expect("fixture length");
+    let recovered = parse_tsrx_utf16_with_options(
+        &TsrxUtf16ParseRequest { source: &units },
+        TsrxParseOptions { recovery: TsrxParseRecovery::Editor, ..TsrxParseOptions::default() },
+    )
+    .expect("UTF-16 editor recovery");
+
+    assert_eq!(recovered.status, ParseCompleteness::Recovered);
+    let tape = recovered.program.as_ref().expect("recovered Program");
+    let root = tape.root().as_object().expect("Program root");
+    assert_eq!(span(tape, root), (0, unit_len));
+    assert!(recovered.errors.records().iter().all(|diagnostic| {
+        recovered
+            .errors
+            .labels(diagnostic.labels)
+            .is_some_and(|labels| labels.iter().all(|label| label.span.end <= unit_len))
+    }));
+}

--- a/crates/tsrx_syntax/src/lib.rs
+++ b/crates/tsrx_syntax/src/lib.rs
@@ -3,6 +3,7 @@
 mod diagnostics;
 mod model;
 mod parser_projection;
+mod parser_recovery;
 mod parser_scanner;
 mod projection;
 mod projection_view;
@@ -17,6 +18,7 @@ pub use model::{
     ParserShorthandAttribute, ScriptBlock, StructuralKind, StructuralToken,
 };
 pub use parser_projection::{MappedProjection as ParserProjection, project_for_parser};
+pub use parser_recovery::{PARSER_RECOVERY_DIAGNOSTIC, ParserRecovery, recover_for_parser};
 pub use parser_scanner::OpaqueSurrogateContext;
 pub use projection::{
     FormatProjection, MappedProjection, TypeProjection, lift_formatted, project,

--- a/crates/tsrx_syntax/src/parser_recovery.rs
+++ b/crates/tsrx_syntax/src/parser_recovery.rs
@@ -73,15 +73,39 @@ impl ParserRecovery {
 #[doc(hidden)]
 pub fn recover_for_parser(source: &str) -> Result<Option<ParserRecovery>, ProjectionError> {
     let mut recovered = ParserRecovery::new(source)?;
-    let Some(mut changed) = blank_bare_at_tokens(&mut recovered) else {
+    let Some(mut changed) = blank_active_bare_at_tokens(&mut recovered) else {
         return Ok(None);
     };
 
     for _ in 0..16 {
         match scan_for_parser(recovered.source()) {
-            Ok(_) => break,
+            Ok(_) => {
+                let Some(blanked_at) = blank_active_bare_at_tokens(&mut recovered) else {
+                    return Ok(None);
+                };
+                if blanked_at {
+                    changed = true;
+                    continue;
+                }
+                let Some(completed_tail) = complete_delimited_tail(&mut recovered) else {
+                    return Ok(None);
+                };
+                changed |= completed_tail;
+                break;
+            }
             Err(ProjectionError::UnterminatedSyntax { offset, construct: "JSX element" }) => {
                 if !close_unterminated_jsx(&mut recovered, offset) {
+                    return Ok(None);
+                }
+                changed = true;
+            }
+            Err(ProjectionError::UnterminatedSyntax {
+                construct: "delimited expression", ..
+            }) => {
+                let Some(completed_tail) = complete_delimited_tail(&mut recovered) else {
+                    return Ok(None);
+                };
+                if !completed_tail {
                     return Ok(None);
                 }
                 changed = true;
@@ -101,40 +125,37 @@ pub fn recover_for_parser(source: &str) -> Result<Option<ParserRecovery>, Projec
     if scan_for_parser(recovered.source()).is_err() {
         return Ok(None);
     }
-    let Some(completed_tail) = complete_tail(&mut recovered) else {
-        return Ok(None);
-    };
-    changed |= completed_tail;
     Ok(changed.then_some(recovered))
 }
 
-fn blank_bare_at_tokens(source: &mut ParserRecovery) -> Option<bool> {
-    let mut offsets = Vec::new();
+fn blank_active_bare_at_tokens(source: &mut ParserRecovery) -> Option<bool> {
     let bytes = source.text.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' | b'"' | b'`' => index = skip_quoted(bytes, index, bytes[index]),
-            b'/' if bytes.get(index + 1) == Some(&b'/') => {
-                index = skip_line_comment(bytes, index + 2);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                index = skip_block_comment(bytes, index + 2);
-            }
-            b'@' => {
-                let next = bytes.get(index + 1).copied();
-                if !matches!(next, Some(b'{' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_')) {
-                    offsets.push(index);
-                }
-                index += 1;
-            }
-            _ => index += 1,
-        }
+    let offsets = bytes
+        .iter()
+        .enumerate()
+        .filter_map(|(index, byte)| {
+            let next = bytes.get(index + 1).copied();
+            (*byte == b'@'
+                && !matches!(next, Some(b'{' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_')))
+            .then(|| u32::try_from(index).ok())
+            .flatten()
+        })
+        .collect::<Vec<_>>();
+    let classification = crate::classify_wtf8_surrogates_detailed(source.text.as_bytes(), &offsets);
+    if classification.earlier_error.is_some() {
+        return Some(false);
     }
-    for offset in offsets.into_iter().rev() {
+    let active = offsets
+        .into_iter()
+        .zip(classification.contexts)
+        .filter_map(|(offset, context)| context.is_none().then_some(offset))
+        .collect::<Vec<_>>();
+    let changed = !active.is_empty();
+    for offset in active.into_iter().rev() {
+        let offset = usize::try_from(offset).ok()?;
         source.replace(offset, offset + 1, " ")?;
     }
-    Some(source.diagnostic_offset != u32::try_from(source.text.len()).unwrap_or(u32::MAX))
+    Some(changed)
 }
 
 fn blank_incomplete_control(source: &mut ParserRecovery, failure_offset: u32) -> bool {
@@ -169,60 +190,58 @@ fn close_unterminated_jsx(source: &mut ParserRecovery, opening_offset: u32) -> b
     source.insert(insertion, &format!("</{name}>")).is_some()
 }
 
-fn complete_tail(source: &mut ParserRecovery) -> Option<bool> {
-    let bytes = source.text.as_bytes();
+fn complete_expression_tail(source: &mut ParserRecovery) -> Option<bool> {
+    if !source.text.trim_end().ends_with('=') {
+        return Some(false);
+    }
+    source.insert(source.text.len(), " undefined")?;
+    Some(true)
+}
+
+fn complete_delimited_tail(source: &mut ParserRecovery) -> Option<bool> {
+    let mut changed = complete_expression_tail(source)?;
+    let delimiters = source
+        .text
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, byte)| {
+            matches!(*byte, b'(' | b'[' | b'{' | b')' | b']' | b'}')
+                .then(|| u32::try_from(index).ok().map(|offset| (offset, *byte)))
+                .flatten()
+        })
+        .collect::<Vec<_>>();
+    let offsets = delimiters.iter().map(|(offset, _)| *offset).collect::<Vec<_>>();
+    let classification = crate::classify_wtf8_surrogates_detailed(source.text.as_bytes(), &offsets);
     let mut stack = Vec::new();
-    let mut index = 0;
-    let mut last_significant = None;
-    while index < bytes.len() {
-        match bytes[index] {
-            byte @ (b'\'' | b'"' | b'`') => {
-                index = skip_quoted(bytes, index, byte);
-                last_significant = Some(byte);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'/') => {
-                index = skip_line_comment(bytes, index + 2);
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                index = skip_block_comment(bytes, index + 2);
-            }
-            byte @ (b'(' | b'[' | b'{') => {
+    for ((_, byte), context) in delimiters.into_iter().zip(classification.contexts) {
+        if context.is_some() {
+            continue;
+        }
+        match byte {
+            b'(' | b'[' | b'{' => {
                 stack.push(match byte {
                     b'(' => b')',
                     b'[' => b']',
                     b'{' => b'}',
                     _ => unreachable!(),
                 });
-                last_significant = Some(byte);
-                index += 1;
             }
-            byte @ (b')' | b']' | b'}') => {
+            b')' | b']' | b'}' => {
                 if stack.last() == Some(&byte) {
                     stack.pop();
                 }
-                last_significant = Some(byte);
-                index += 1;
             }
-            byte if byte.is_ascii_whitespace() => index += 1,
-            byte => {
-                last_significant = Some(byte);
-                index += 1;
-            }
+            _ => unreachable!(),
         }
     }
-    let mut suffix = String::new();
-    if matches!(
-        last_significant,
-        Some(b'=' | b'.' | b'+' | b'-' | b'*' | b'/' | b'%' | b'?' | b':' | b',')
-    ) {
-        suffix.push_str(" undefined");
-    }
-    suffix.extend(stack.into_iter().rev().map(char::from));
+    let suffix = stack.into_iter().rev().map(char::from).collect::<String>();
     if suffix.is_empty() {
-        return Some(false);
+        return Some(changed);
     }
     source.insert(source.text.len(), &suffix)?;
-    Some(true)
+    changed = true;
+    Some(changed)
 }
 
 fn last_control_start(source: &str, limit: usize) -> Option<usize> {
@@ -230,37 +249,6 @@ fn last_control_start(source: &str, limit: usize) -> Option<usize> {
         .into_iter()
         .filter_map(|keyword| source[..limit].rfind(keyword))
         .max()
-}
-
-fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
-    let mut index = start + 1;
-    while index < bytes.len() {
-        if bytes[index] == b'\\' {
-            index = (index + 2).min(bytes.len());
-        } else if bytes[index] == quote {
-            return index + 1;
-        } else {
-            index += 1;
-        }
-    }
-    bytes.len()
-}
-
-fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
-    while index < bytes.len() && !matches!(bytes[index], b'\r' | b'\n') {
-        index += 1;
-    }
-    index
-}
-
-fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
-    while index + 1 < bytes.len() {
-        if bytes[index..index + 2] == *b"*/" {
-            return index + 2;
-        }
-        index += 1;
-    }
-    bytes.len()
 }
 
 #[cfg(test)]
@@ -275,6 +263,7 @@ mod tests {
             "export function View() @{ @if (",
             "export function View() @{ @ }",
             "export function View() @{\n  <div>\n}",
+            "export function View() @{\n  <div>",
         ] {
             let recovered = recover_for_parser(source)
                 .expect("bounded recovery")
@@ -285,5 +274,24 @@ mod tests {
             assert_eq!(recovered.map_endpoint(recovered_len), Some(source_len));
             assert!(crate::scan_for_parser(recovered.source()).is_ok());
         }
+    }
+
+    #[test]
+    fn parser_recovery_blanks_only_lexically_active_bare_at_tokens() {
+        for source in [
+            "const value = /@/;",
+            "const value = /[{}()]/;",
+            "const value = '@';",
+            "const value = `@`;",
+            "const value = 1; // @",
+        ] {
+            assert!(recover_for_parser(source).expect("bounded recovery").is_none(), "{source}");
+        }
+
+        let source = "export function View() @{ const value = /@/; @ }";
+        let recovered =
+            recover_for_parser(source).expect("bounded recovery").expect("recoverable active `@`");
+        assert!(recovered.source().contains("/@/"));
+        assert!(recovered.source().contains(";   }"));
     }
 }

--- a/crates/tsrx_syntax/src/parser_recovery.rs
+++ b/crates/tsrx_syntax/src/parser_recovery.rs
@@ -1,0 +1,289 @@
+//! Bounded, authored-coordinate source repair for the parser's opt-in editor lane.
+
+use crate::{ProjectionError, scan_for_parser};
+
+pub const PARSER_RECOVERY_DIAGNOSTIC: &str = "incomplete TSRX editor snapshot";
+
+#[derive(Debug)]
+pub struct ParserRecovery {
+    text: String,
+    boundaries: Vec<u32>,
+    diagnostic_offset: u32,
+}
+
+impl ParserRecovery {
+    fn new(source: &str) -> Result<Self, ProjectionError> {
+        let source_len =
+            u32::try_from(source.len()).map_err(|_| ProjectionError::SourceTooLarge)?;
+        Ok(Self {
+            text: source.to_string(),
+            boundaries: (0..=source_len).collect(),
+            diagnostic_offset: source_len,
+        })
+    }
+
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.text
+    }
+
+    #[must_use]
+    pub const fn diagnostic_offset(&self) -> u32 {
+        self.diagnostic_offset
+    }
+
+    #[must_use]
+    pub fn map_endpoint(&self, offset: u32) -> Option<u32> {
+        self.boundaries.get(usize::try_from(offset).ok()?).copied()
+    }
+
+    fn replace(&mut self, start: usize, end: usize, replacement: &str) -> Option<()> {
+        if start > end
+            || !self.text.is_char_boundary(start)
+            || !self.text.is_char_boundary(end)
+            || end > self.text.len()
+        {
+            return None;
+        }
+        let original_start = *self.boundaries.get(start)?;
+        let original_end = *self.boundaries.get(end)?;
+        let old_length = end - start;
+        let replacement_boundaries = if replacement.len() == old_length {
+            self.boundaries[start..=end].to_vec()
+        } else {
+            let mut boundaries = vec![original_start; replacement.len() + 1];
+            *boundaries.last_mut()? = original_end;
+            boundaries
+        };
+        self.text.replace_range(start..end, replacement);
+        self.boundaries.splice(start..=end, replacement_boundaries);
+        self.diagnostic_offset = self.diagnostic_offset.min(original_start);
+        Some(())
+    }
+
+    fn insert(&mut self, at: usize, text: &str) -> Option<()> {
+        self.replace(at, at, text)
+    }
+}
+
+/// Builds one legal parser candidate for an incomplete editor snapshot.
+///
+/// The strict scanner remains unchanged. Unsupported constructs return `None`; accepted repairs
+/// preserve an exact endpoint map back to the source handed to this function.
+#[doc(hidden)]
+pub fn recover_for_parser(source: &str) -> Result<Option<ParserRecovery>, ProjectionError> {
+    let mut recovered = ParserRecovery::new(source)?;
+    let Some(mut changed) = blank_bare_at_tokens(&mut recovered) else {
+        return Ok(None);
+    };
+
+    for _ in 0..16 {
+        match scan_for_parser(recovered.source()) {
+            Ok(_) => break,
+            Err(ProjectionError::UnterminatedSyntax { offset, construct: "JSX element" }) => {
+                if !close_unterminated_jsx(&mut recovered, offset) {
+                    return Ok(None);
+                }
+                changed = true;
+            }
+            Err(
+                ProjectionError::UnterminatedSyntax { offset, .. }
+                | ProjectionError::MalformedSyntax { offset, .. },
+            ) => {
+                if !blank_incomplete_control(&mut recovered, offset) {
+                    return Ok(None);
+                }
+                changed = true;
+            }
+            Err(_) => return Ok(None),
+        }
+    }
+    if scan_for_parser(recovered.source()).is_err() {
+        return Ok(None);
+    }
+    let Some(completed_tail) = complete_tail(&mut recovered) else {
+        return Ok(None);
+    };
+    changed |= completed_tail;
+    Ok(changed.then_some(recovered))
+}
+
+fn blank_bare_at_tokens(source: &mut ParserRecovery) -> Option<bool> {
+    let mut offsets = Vec::new();
+    let bytes = source.text.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' | b'"' | b'`' => index = skip_quoted(bytes, index, bytes[index]),
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(bytes, index + 2);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index + 2);
+            }
+            b'@' => {
+                let next = bytes.get(index + 1).copied();
+                if !matches!(next, Some(b'{' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_')) {
+                    offsets.push(index);
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+    for offset in offsets.into_iter().rev() {
+        source.replace(offset, offset + 1, " ")?;
+    }
+    Some(source.diagnostic_offset != u32::try_from(source.text.len()).unwrap_or(u32::MAX))
+}
+
+fn blank_incomplete_control(source: &mut ParserRecovery, failure_offset: u32) -> bool {
+    let limit = usize::try_from(failure_offset).unwrap_or(usize::MAX).min(source.text.len());
+    let Some(start) = last_control_start(&source.text, limit) else {
+        return false;
+    };
+    let replacement = " ".repeat(source.text.len() - start);
+    source.replace(start, source.text.len(), &replacement).is_some()
+}
+
+fn close_unterminated_jsx(source: &mut ParserRecovery, opening_offset: u32) -> bool {
+    let Ok(start) = usize::try_from(opening_offset) else {
+        return false;
+    };
+    let bytes = source.text.as_bytes();
+    if bytes.get(start) != Some(&b'<') {
+        return false;
+    }
+    let mut end = start + 1;
+    while bytes.get(end).is_some_and(|byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b':' | b'$')
+    }) {
+        end += 1;
+    }
+    if end == start + 1 {
+        return false;
+    }
+    let name = source.text[start + 1..end].to_string();
+    let insertion =
+        source.text[start..].rfind('}').map_or(source.text.len(), |relative| start + relative);
+    source.insert(insertion, &format!("</{name}>")).is_some()
+}
+
+fn complete_tail(source: &mut ParserRecovery) -> Option<bool> {
+    let bytes = source.text.as_bytes();
+    let mut stack = Vec::new();
+    let mut index = 0;
+    let mut last_significant = None;
+    while index < bytes.len() {
+        match bytes[index] {
+            byte @ (b'\'' | b'"' | b'`') => {
+                index = skip_quoted(bytes, index, byte);
+                last_significant = Some(byte);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                index = skip_line_comment(bytes, index + 2);
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                index = skip_block_comment(bytes, index + 2);
+            }
+            byte @ (b'(' | b'[' | b'{') => {
+                stack.push(match byte {
+                    b'(' => b')',
+                    b'[' => b']',
+                    b'{' => b'}',
+                    _ => unreachable!(),
+                });
+                last_significant = Some(byte);
+                index += 1;
+            }
+            byte @ (b')' | b']' | b'}') => {
+                if stack.last() == Some(&byte) {
+                    stack.pop();
+                }
+                last_significant = Some(byte);
+                index += 1;
+            }
+            byte if byte.is_ascii_whitespace() => index += 1,
+            byte => {
+                last_significant = Some(byte);
+                index += 1;
+            }
+        }
+    }
+    let mut suffix = String::new();
+    if matches!(
+        last_significant,
+        Some(b'=' | b'.' | b'+' | b'-' | b'*' | b'/' | b'%' | b'?' | b':' | b',')
+    ) {
+        suffix.push_str(" undefined");
+    }
+    suffix.extend(stack.into_iter().rev().map(char::from));
+    if suffix.is_empty() {
+        return Some(false);
+    }
+    source.insert(source.text.len(), &suffix)?;
+    Some(true)
+}
+
+fn last_control_start(source: &str, limit: usize) -> Option<usize> {
+    ["@if", "@for", "@switch", "@try"]
+        .into_iter()
+        .filter_map(|keyword| source[..limit].rfind(keyword))
+        .max()
+}
+
+fn skip_quoted(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut index = start + 1;
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+        } else if bytes[index] == quote {
+            return index + 1;
+        } else {
+            index += 1;
+        }
+    }
+    bytes.len()
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() && !matches!(bytes[index], b'\r' | b'\n') {
+        index += 1;
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index + 1 < bytes.len() {
+        if bytes[index..index + 2] == *b"*/" {
+            return index + 2;
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recover_for_parser;
+
+    #[test]
+    fn parser_recovery_returns_one_mapped_candidate_without_changing_strict_scanning() {
+        for source in [
+            "export function View() @{",
+            "export function View() @{ const value = ",
+            "export function View() @{ @if (",
+            "export function View() @{ @ }",
+            "export function View() @{\n  <div>\n}",
+        ] {
+            let recovered = recover_for_parser(source)
+                .expect("bounded recovery")
+                .expect("recoverable snapshot");
+            let recovered_len = u32::try_from(recovered.source().len()).expect("fixture length");
+            let source_len = u32::try_from(source.len()).expect("fixture length");
+            assert_ne!(recovered.source(), source);
+            assert_eq!(recovered.map_endpoint(recovered_len), Some(source_len));
+            assert!(crate::scan_for_parser(recovered.source()).is_ok());
+        }
+    }
+}

--- a/packages/toolchain/dist/parser.js
+++ b/packages/toolchain/dist/parser.js
@@ -107,7 +107,7 @@ const capabilities = Object.freeze({
 	oxcRevision: OXC_REVISION,
 	lazy: true,
 	async: true,
-	editorRecovery: false,
+	editorRecovery: true,
 	cssMaterialization: false,
 	rawTransfer: false
 });
@@ -239,7 +239,7 @@ function expectedCapabilities() {
 	return {
 		lazy: true,
 		async: true,
-		editorRecovery: false,
+		editorRecovery: true,
 		cssMaterialization: false,
 		rawTransfer: false
 	};

--- a/packages/toolchain/src/parser.ts
+++ b/packages/toolchain/src/parser.ts
@@ -117,7 +117,7 @@ export const capabilities = Object.freeze({
   oxcRevision: OXC_REVISION,
   lazy: true,
   async: true,
-  editorRecovery: false,
+  editorRecovery: true,
   cssMaterialization: false,
   rawTransfer: false,
 });
@@ -292,7 +292,7 @@ function expectedCapabilities() {
   return {
     lazy: true,
     async: true,
-    editorRecovery: false,
+    editorRecovery: true,
     cssMaterialization: false,
     rawTransfer: false,
   };

--- a/scripts/build-parser-native.ts
+++ b/scripts/build-parser-native.ts
@@ -148,7 +148,7 @@ const record = {
   capabilities: {
     lazy: true,
     async: true,
-    editorRecovery: false,
+    editorRecovery: true,
     cssMaterialization: false,
     rawTransfer: false,
   },

--- a/scripts/package-native.ts
+++ b/scripts/package-native.ts
@@ -359,7 +359,7 @@ try {
     const capabilities = {
       lazy: true,
       async: true,
-      editorRecovery: false,
+      editorRecovery: true,
       cssMaterialization: false,
       rawTransfer: false,
     };

--- a/tests/packaging/native-package.test.mjs
+++ b/tests/packaging/native-package.test.mjs
@@ -413,7 +413,7 @@ test("canonical parser packaging adds one verified schema-2 addon without changi
   assert.deepEqual(record.capabilities, {
     lazy: true,
     async: true,
-    editorRecovery: false,
+    editorRecovery: true,
     cssMaterialization: false,
     rawTransfer: false,
   });

--- a/tests/parser-api/host-product.test.mjs
+++ b/tests/parser-api/host-product.test.mjs
@@ -231,7 +231,7 @@ test("untouched packed parser and host-native tarballs load, parse, and preserve
     oxcRevision: "8e0ed2ebb96137fb1611cdbd5742d5cb46037d40",
     lazy: true,
     async: true,
-    editorRecovery: false,
+    editorRecovery: true,
     cssMaterialization: false,
     rawTransfer: false,
     });

--- a/tests/parser-api/utf16-lazy.test.mjs
+++ b/tests/parser-api/utf16-lazy.test.mjs
@@ -176,25 +176,26 @@ test("active lone surrogates fail closed at their exact UTF-16 unit and null is 
   });
 });
 
-test("unavailable transports and recovery fail before parsing with stable operational codes", async () => {
-  await withParser(async ({ ParserOperationalError, parse, parseSync }) => {
+test("unavailable raw transport fails before parsing with a stable operational code", async () => {
+  await withParser(async ({ ParserOperationalError, parseSync }) => {
     assert.throws(
       () => parseSync("x.js", "let x", { experimentalRawTransfer: true }),
       (error) =>
         error instanceof ParserOperationalError &&
         error.code === "ERR_TSRX_CAPABILITY_RAW_TRANSFER",
     );
-    assert.throws(
-      () => parseSync("x.tsrx", "const x=1", { recovery: "editor" }),
-      (error) =>
-        error instanceof ParserOperationalError &&
-        error.code === "ERR_TSRX_CAPABILITY_RECOVERY",
-    );
-    await assert.rejects(
-      parse("x.tsrx", "const x=1", { recovery: "editor" }),
-      (error) =>
-        error instanceof ParserOperationalError &&
-        error.code === "ERR_TSRX_CAPABILITY_RECOVERY",
-    );
+  });
+});
+
+test("editor recovery returns authored partial programs through sync and async APIs", async () => {
+  await withParser(async ({ parse, parseSync }) => {
+    const source = "export function View() @{";
+    const sync = parseSync("View.tsrx", source, { recovery: "editor" });
+    assert.notEqual(sync.program, null);
+    assert.equal(sync.program.end, source.length);
+    assert.ok(sync.errors.length > 0);
+
+    const asyncResult = await parse("View.tsrx", source, { recovery: "editor" });
+    assert.deepEqual(asyncResult, sync);
   });
 });


### PR DESCRIPTION
## Summary
- add opt-in, framework-neutral editor recovery while preserving strict fail-closed parsing
- plan bounded incomplete-snapshot repairs in `tsrx_syntax` before invoking OXC, preserving the one-OXC-parse contract
- retain usable OXC partial programs and map recovered AST, module, comment, diagnostic, and UTF-16 coordinates back to authored source
- expose the existing `recovery: \"editor\"` parser capability through native and packaged APIs

## Test plan
- [x] `cargo test -p tsrx_syntax -p tsrx_parser_engine`
- [x] `cargo test -p oxc_adapter --features parser`
- [x] `cargo clippy -p tsrx_syntax -p tsrx_parser_engine -p oxc_adapter --features oxc_adapter/parser --all-targets -- -D warnings`
- [x] `pnpm build:packages`
- [x] `node --test tests/packaging/dist-freshness.test.mjs`
- [ ] Native-addon and full packaging suites require CMake and release artifacts unavailable in the local environment; CI should run them.

Made with [Cursor](https://cursor.com)