### PR TITLE
site: pin wasm demo engine 5382c0d

### DIFF
--- a/website-oxc/wasm-pin.json
+++ b/website-oxc/wasm-pin.json
@@ -1,10 +1,10 @@
 {
   "tag": "wasm-demo-latest",
-  "inputsHash": "769527024e3314e4894e60ecefdb14f1052255a707368a642f5054bf711f5dd9",
-  "sourceCommit": "4575dc4f20ea6a88347596be81f68a38c6df4f2d",
+  "inputsHash": "2ff905c37706dda422ee64c299960e197da4f2625faa076182acef46b460d0f0",
+  "sourceCommit": "5382c0dd64927245ee434280eff0a816092b3753",
   "wasm": {
-    "sha256": "e1dfc03ead03fe426cc18c6e9ede6630231de3adee03ed7c7f79f935b11d5e54",
-    "bytes": 9556443
+    "sha256": "0c90bdddbb6f930b1aa30c11018a7148817a8362b57bceec93aa587fb3ab60af",
+    "bytes": 9556179
   },
   "worker": {
     "sha256": "9e8064c5af1619769984b28fe66e5400cdf8b46ab4678f45cdb4f1b5a2441f47",


### PR DESCRIPTION
Re-lands the pin commit that run 33524750890 built and could not push (GH006, protected main; the continue-on-error swallow). The engine at wasm-demo-latest was rebuilt for the v0.9.0 tree (inputs hash 2ff905c3, wasm sha256 0c90bddd, 9556179 bytes; worker unchanged). Verified locally: inputs hash recomputed in a pristine checkout matches the runner's, asset sha256s match the release API digests, and scripts/fetch-docs-wasm.ts fetches and validates the engine against this pin end to end. Same recovery as #52 after v0.8.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only pin update for the docs WASM demo; no application logic changes.
> 
> **Overview**
> Updates **`wasm-pin.json`** so the site’s **`wasm-demo-latest`** bundle points at source commit **`5382c0d`** (v0.9.0 tree) instead of the previous pin.
> 
> The **`inputsHash`** and **wasm** **`sha256` / byte size** change to match the rebuilt engine; the **worker** digest and size are unchanged. Site builds that run **`fetch-docs-wasm.ts`** will pull and validate against this new pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1924accc66157cfe04dfe76831dde1c2fcca34da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->