### PR TITLE
site: make every branch of the hero snippet reachable

### DIFF
--- a/docs/demo-sources.mjs
+++ b/docs/demo-sources.mjs
@@ -6,11 +6,16 @@
 
 // Real TSRX hero snippet, highlighted with the actual TSRX grammar. This is
 // oxc-tsrx-fmt's converged output, so the default demo state is format-clean.
-export const heroCode = `export function TaskList({ tasks }: Props) @{
+//
+// The outer @if guards on `user`, not on `pending.length`: the @for already
+// owns the empty case through @empty, and guarding the loop on the list's
+// length made that clause unreachable (issue #65). Every branch shown here
+// must be one the runtime can actually take.
+export const heroCode = `export function TaskList({ user, tasks }: Props) @{
   const pending = tasks.filter((task) => !task.done);
 
   <section class="tasks">
-    @if (pending.length > 0) {
+    @if (user) {
       @for (const task of pending; key task.id) {
         <TaskRow task={task} />;
       } @empty {

--- a/docs/verify.mjs
+++ b/docs/verify.mjs
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { chromium } from 'playwright-core'
+import { heroCode, playgroundCode } from './demo-sources.mjs'
 
 const positional = process.argv.slice(2).filter((argument) => !argument.startsWith('--'))
 const mode =
@@ -68,46 +69,12 @@ if (mode !== 'static') {
   ])
   const clientHighlighter = createDemoHighlighter()
   const serverHighlighter = await getDocsHighlighter()
+  // The TSRX parity samples are the snippets the site actually renders, so a
+  // change to the hero or playground cannot leave this check exercising a
+  // stale copy.
   const paritySamples = [
-    `export function TaskList({ tasks }: Props) @{
-  const pending = tasks.filter((task) => !task.done);
-
-  <section class="tasks">
-    @if (pending.length > 0) {
-      @for (const task of pending; key task.id) {
-        <TaskRow task={task} />;
-      } @empty {
-        <AllDone />;
-      }
-    } @else {
-      <SignIn />;
-    }
-    <style>
-      .tasks { display: grid; gap: 0.5rem; }
-    </style>
-  </section>;
-}`,
-    `type Task = { id: string; label: string; done: boolean };
-
-function TaskRow({ task }: { task: Task }) @{
-  <li>{task.label}</li>;
-}
-
-export function TaskList({ tasks }: { tasks: Task[] }) @{
-  const pending = tasks.filter((task) => !task.done);
-
-  <section class="tasks">
-    @if (pending.length > 0) {
-      <ul>
-        @for (const task of pending; key task.id) {
-          <TaskRow task={task} />;
-        }
-      </ul>;
-    } @else {
-      <p>All done!</p>;
-    }
-  </section>;
-}`,
+    heroCode,
+    playgroundCode,
     `export const Card = ({ name }: { name: string }) => (
   <section className="card">{\`Hello \${name}!\`}</section>
 )`,


### PR DESCRIPTION
## Summary
- The landing-page \`TaskList\` example guarded its \`@for\` on \`pending.length > 0\`, which made the loop's \`@empty\` clause (\`<AllDone />\`) unreachable and sent an empty list to \`<SignIn />\` (#65, reported by @joel-s).
- Guard the outer \`@if\` on a \`user\` prop instead. The loop owns the empty case through \`@empty\`, sign-in becomes a branch that means something, and the example still shows \`@if\`/\`@else\`, \`@for\`/\`@empty\`, and a scoped \`<style>\`.
- \`docs/verify.mjs\` now imports \`heroCode\` and \`playgroundCode\` for its highlighter parity check instead of carrying copies that could drift.

The playground default snippet has no \`@empty\` and its \`@if\`/\`@else\` is sound, so it is unchanged. The other \`@empty\` samples in the guides were audited and none has this shape.

## Verification
- New hero is \`oxc-tsrx-fmt\` converged (stdin round-trip is byte-identical), so the default demo state stays format-clean.
- \`pnpm run docs:build\`: 19 pages built; landing HTML carries \`@if (user)\` and no \`pending.length\` in the hero.
- \`pnpm run test:site\`: 207 passed, 0 failed.

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only demo snippet and verification wiring; no runtime product or auth behavior changes.
> 
> **Overview**
> Fixes **#65** by changing the landing-page **hero** `TaskList` snippet so every control-flow branch the demo shows can actually run.
> 
> The outer `@if` now checks **`user`** instead of **`pending.length > 0`**. When the list is empty but the user is signed in, **`@empty`** can render `<AllDone />`; **`@else`** shows `<SignIn />` for unauthenticated visitors. Comments in `demo-sources.mjs` document why guarding on list length made `@empty` unreachable.
> 
> **`docs/verify.mjs`** imports **`heroCode`** and **`playgroundCode`** from `demo-sources.mjs` for client/server highlighter parity checks, replacing duplicated inline strings that could drift from what the site renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac902bcd2f5a773ea4c8ea9e5c9c46ec8696d15d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->