### PR TITLE
site: permanently redirect compiled.run/oxc-tsrx to oxc.tsrx.dev

### DIFF
--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -204,8 +204,9 @@ jobs:
       # and never fail this job -- see the continue-on-error note below.
       # -----------------------------------------------------------------------
       - name: Publish the proven demo engine and pin it for oxc.tsrx.dev
-        # This whole path is additive: production at compiled.run/oxc-tsrx is
-        # deployed from the artifact this job uploads and does not depend on any
+        # This whole path is additive: the compiled.run deploy (now a redirect
+        # to oxc.tsrx.dev plus /guessless) ships the artifact this job uploads
+        # and does not depend on any
         # of it. A release API hiccup or a protected branch must therefore leave
         # a warning, not a red build that blocks that deploy. The cost of a miss
         # is bounded and self-correcting: oxc.tsrx.dev keeps serving its last
@@ -389,7 +390,7 @@ jobs:
     permissions: {}
     environment:
       name: production
-      url: https://compiled.run/oxc-tsrx
+      url: https://compiled.run
     env:
       # The static docs project. Vercel's Git integration is deliberately not
       # connected: the site cannot be built on Vercel's image, so the artifact
@@ -424,30 +425,39 @@ jobs:
           set -euo pipefail
           # The project's stable production alias: verification must not depend
           # on custom-domain DNS, which can change independently of a deploy.
-          # The site lives under the /oxc-tsrx base path (docs/site.config.mjs).
-          origin="https://oxc-tsrx-docs.vercel.app/oxc-tsrx"
-          for attempt in 1 2 3 4 5; do
-            if curl -fsS "${origin}/demo-capabilities.json" -o capabilities.json; then
-              break
+          origin="https://oxc-tsrx-docs.vercel.app"
+          # /oxc-tsrx is a legacy location now. The artifact's vercel.json
+          # permanently redirects it, and everything under it, to the same path
+          # on https://oxc.tsrx.dev (docs/site.config.mjs redirectTo). Prove the
+          # redirect rather than the page: a 200 here would mean the old copy of
+          # the docs is live again.
+          expect_redirect() {
+            local from="$1" to="$2" status location
+            for attempt in 1 2 3 4 5; do
+              status="$(curl -sS -o /dev/null -w '%{http_code}' "${from}" || echo 000)"
+              if [ "${status}" = "308" ] || [ "${status}" = "301" ]; then
+                break
+              fi
+              echo "attempt ${attempt}: ${from} returned ${status}, retrying"
+              sleep 5
+            done
+            location="$(curl -sS -o /dev/null -w '%{redirect_url}' "${from}" || echo "")"
+            if { [ "${status}" != "308" ] && [ "${status}" != "301" ]; } || [ "${location}" != "${to}" ]; then
+              echo "::error::${from} answered ${status} -> '${location}', expected a permanent redirect to ${to}"
+              exit 1
             fi
-            echo "attempt ${attempt} could not read the live capabilities, retrying"
-            sleep 5
-          done
-          node -e '
-            const live = require("./capabilities.json")
-            if (!live.ok || !live.wasm || live.mode !== "wasm") {
-              throw new Error(`production is not serving the WebAssembly engine: ${JSON.stringify(live)}`)
-            }
-          '
-          # demo-capabilities.json is byte-identical across builds, so matching
-          # it would also "pass" against a deploy that never took effect. Hash
-          # the actual page instead: that only matches if production is serving
-          # the artifact this run built.
-          # No trailing slash: the deploy redirects /oxc-tsrx/ to /oxc-tsrx
-          # (trailingSlash: false) and curl is not following redirects.
-          curl -fsS "${origin}" -o live-index.html
+            echo "${from} -> ${to} (${status})"
+          }
+          expect_redirect "${origin}/oxc-tsrx" "https://oxc.tsrx.dev/"
+          expect_redirect "${origin}/oxc-tsrx/guide/getting-started" "https://oxc.tsrx.dev/guide/getting-started"
+          expect_redirect "${origin}/oxc-tsrx/playground?share=abc" "https://oxc.tsrx.dev/playground?share=abc"
+          # The redirect alone would also "pass" against the previous deploy
+          # once it is live, so hash a page that is not redirected: the domain
+          # root landing page only matches if production is serving the
+          # artifact this run built.
+          curl -fsS "${origin}/" -o live-index.html
           live="$(shasum -a 256 < live-index.html | cut -d" " -f1)"
-          built="$(shasum -a 256 < dist/oxc-tsrx/index.html | cut -d" " -f1)"
+          built="$(shasum -a 256 < dist/index.html | cut -d" " -f1)"
           if [ "${live}" != "${built}" ]; then
             echo "::error::production serves index.html ${live}, this run built ${built}"
             exit 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://compiled.run/oxc-tsrx"><img alt="OXC for TSRX" width="600" src="https://raw.githubusercontent.com/tsrx-org/oxc/HEAD/.github/assets/readme-hero.png"></a>
+  <a href="https://oxc.tsrx.dev"><img alt="OXC for TSRX" width="600" src="https://raw.githubusercontent.com/tsrx-org/oxc/HEAD/.github/assets/readme-hero.png"></a>
 </p>
 
 <p align="center">
@@ -24,7 +24,7 @@ written in Rust. This package teaches them to read `.tsrx` too.
 
 _OXC for TSRX is the official OXC integration maintained by the TSRX project._
 
-[**Docs**](https://compiled.run/oxc-tsrx) &nbsp;·&nbsp; [**Getting started**](https://compiled.run/oxc-tsrx/guide/getting-started) &nbsp;·&nbsp; [**Playground**](https://compiled.run/oxc-tsrx/playground)
+[**Docs**](https://oxc.tsrx.dev) &nbsp;·&nbsp; [**Getting started**](https://oxc.tsrx.dev/guide/getting-started) &nbsp;·&nbsp; [**Playground**](https://oxc.tsrx.dev/playground)
 
 ## Install
 
@@ -34,12 +34,12 @@ npm install --save-dev @tsrx/oxc@latest
 
 That is the whole setup, for the command line and for your editor. There is no
 config file to write and no install script to run. [Vite+ needs one more
-command](https://compiled.run/oxc-tsrx/guide/getting-started#try-it-with-vite).
+command](https://oxc.tsrx.dev/guide/getting-started#try-it-with-vite).
 
 You do not need Rust. Installing downloads one ready-built program for your
 computer, one of eight built for macOS, Linux, and Windows. Anything else has
 to build from source. [Platform
-support](https://compiled.run/oxc-tsrx/reference/platform-support) lists all eight
+support](https://oxc.tsrx.dev/reference/platform-support) lists all eight
 targets. You need Node.js 20.19+ (in the 20.x line) or 22.12+.
 
 ## Usage
@@ -74,7 +74,7 @@ npx oxfmt --write src/Cart.tsrx # Tidy it up.
 Give `oxlint` a path. Without one it also checks `node_modules`, the folder your
 installed packages live in, and `--fix` (the flag that lets `oxlint` edit your
 files) will rewrite files in there. The [CLI
-reference](https://compiled.run/oxc-tsrx/reference/cli#npx-oxlint-with-no-path-also-lints-nodemodules)
+reference](https://oxc.tsrx.dev/reference/cli#npx-oxlint-with-no-path-also-lints-nodemodules)
 has every flag.
 
 Your `.js`, `.ts`, `.jsx`, and `.tsx` files are left alone, and go to OXC just
@@ -87,7 +87,7 @@ import { parseSync } from "@tsrx/oxc/parser";
 ```
 
 The parser hands back the structure of your file, so you can build your own
-tools on the same reader the commands use. [Parsing](https://compiled.run/oxc-tsrx/guide/parsing) has the shape it returns.
+tools on the same reader the commands use. [Parsing](https://oxc.tsrx.dev/guide/parsing) has the shape it returns.
 
 ## What works today
 
@@ -107,7 +107,7 @@ build tool reads `.tsrx` as plain TypeScript and stops at the first `@{`.
 Three smaller limits: CSS inside a `<style>` block is left alone rather than
 tidied, your own JavaScript lint rules see a translated copy of the file so each
 one is read once more, and a tag name that itself contains markup is not
-supported yet. [Limitations](https://compiled.run/oxc-tsrx/reference/limitations)
+supported yet. [Limitations](https://oxc.tsrx.dev/reference/limitations)
 explains each one.
 
 ## In your editor
@@ -117,22 +117,22 @@ set up, and your editor underlines the same problems the terminal reports. One
 catch: the TSRX toolchain's own extension owns `.tsrx`, and the OXC extension
 lists no activation event for it, so it does not start on its own. Open any
 JavaScript, TypeScript, or JSON file once, and `.tsrx` works for the rest of the
-session. The [editor guide](https://compiled.run/oxc-tsrx/integrations/editor) has the
+session. The [editor guide](https://oxc.tsrx.dev/integrations/editor) has the
 settings.
 
 ## Documentation
 
-- [Introduction](https://compiled.run/oxc-tsrx/guide/introduction): what this is, in plain terms.
-- [Getting started](https://compiled.run/oxc-tsrx/guide/getting-started): install, first file, first run.
-- [TSRX syntax](https://compiled.run/oxc-tsrx/guide/tsrx-syntax): every supported block.
-- [Configuration](https://compiled.run/oxc-tsrx/integrations/configuration): every supported setting.
+- [Introduction](https://oxc.tsrx.dev/guide/introduction): what this is, in plain terms.
+- [Getting started](https://oxc.tsrx.dev/guide/getting-started): install, first file, first run.
+- [TSRX syntax](https://oxc.tsrx.dev/guide/tsrx-syntax): every supported block.
+- [Configuration](https://oxc.tsrx.dev/integrations/configuration): every supported setting.
 
 ## Contributing
 
 Issues and pull requests are welcome at [the issue
 tracker](https://github.com/tsrx-org/oxc/issues). The source layout and
 the OXC boundary are described in [the Rust and OXC
-core](https://compiled.run/oxc-tsrx/architecture/rust-oxc-core).
+core](https://oxc.tsrx.dev/architecture/rust-oxc-core).
 
 Join the [TSRX Discord community](https://discord.gg/HCYpT5QHQR).
 

--- a/docs/build.mjs
+++ b/docs/build.mjs
@@ -2604,12 +2604,24 @@ async function build() {
     `${JSON.stringify({
       cleanUrls: true,
       trailingSlash: false,
-      // /integrations/vite-plus is a real page again, so the redirect that
-      // stood in for it while the walkthrough lived in the getting-started
-      // guide is gone: a redirect here would shadow the page it points at. The
-      // README published in oxc-tsrx@0.1.5 links that path, and an npm tarball
-      // is immutable, so the path itself has to keep resolving.
-      redirects: [],
+      // A legacy location (compiled.run/oxc-tsrx) sends every path under its
+      // base to the same path on the canonical origin, permanently (308), so
+      // published links, npm READMEs, and search results all land on
+      // oxc.tsrx.dev. Only the base path is claimed: the rest of the domain
+      // (the root landing page, /guessless) is untouched. Vercel applies
+      // redirects before the filesystem, so the pages still shipped under the
+      // base stop being reachable at this origin. The canonical build has no
+      // redirectTo and redirects nothing, so it cannot loop.
+      redirects: config.redirectTo
+        ? [
+            { source: trimmedBase || '/', destination: `${config.redirectTo}/`, permanent: true },
+            {
+              source: `${trimmedBase}/:path*`,
+              destination: `${config.redirectTo}/:path*`,
+              permanent: true,
+            },
+          ]
+        : [],
       // Guessless docs are now embedded as static files under /guessless/ during
       // the site build (see .github/workflows/site-artifact.yml), so no rewrites
       // are needed. Vercel's cleanUrls handles /guessless -> /guessless/index.html.
@@ -2670,7 +2682,7 @@ a:hover { border-color: #888; }
 <body>
 <main>
 <h1>${host}</h1>
-<a href="${trimmedBase}">${escapeHtml(config.title)} &rarr;</a>
+<a href="${config.redirectTo ? `${config.redirectTo}/` : trimmedBase}">${escapeHtml(config.title)} &rarr;</a>
 </main>
 </body>
 </html>

--- a/docs/releasing/site-oxc-tsrx-dev.md
+++ b/docs/releasing/site-oxc-tsrx-dev.md
@@ -1,5 +1,14 @@
 # Publishing the docs site at `oxc.tsrx.dev`
 
+> **Status (2026-09-02):** `oxc.tsrx.dev` is live and canonical. The old
+> `compiled.run/oxc-tsrx` location is kept as a **permanent redirect**: the
+> compiled.run build sets `redirectTo` in `docs/site.config.mjs`, `docs/build.mjs`
+> writes matching `redirects` into that artifact's `vercel.json`, and the
+> `deploy` job in `.github/workflows/site-artifact.yml` proves the 308 instead of
+> the page. Only `/oxc-tsrx` and its subpaths are redirected; the compiled.run
+> root and `/guessless` are unaffected. The rest of this document describes the
+> original hand-off and remains accurate for how the two deploys are wired.
+
 This is a hand-off document. Every step below needs access this repository's
 maintainers do not have: the `tsrx.dev` DNS zone and the TSRX Vercel team.
 Nothing here is automated, nothing here has been run, and nothing here can be

--- a/docs/site.config.mjs
+++ b/docs/site.config.mjs
@@ -4,7 +4,13 @@
 // (a sub-path of a shared domain) and https://oxc.tsrx.dev (its own domain, so
 // the site sits at the root). Only the origin and the base path differ, so both
 // are read from the environment with the compiled.run values as the defaults.
-// With SITE_ORIGIN and SITE_BASE unset the build is byte-identical to before.
+//
+// https://oxc.tsrx.dev is the canonical home. A build for any other origin is
+// a legacy location and gets `redirectTo` set, which docs/build.mjs turns into
+// permanent redirects from its base path to the same paths on the canonical
+// origin (see the vercel.json it writes). The canonical build itself redirects
+// nothing.
+const CANONICAL_ORIGIN = 'https://oxc.tsrx.dev'
 const DEFAULT_ORIGIN = 'https://compiled.run'
 const DEFAULT_BASE = '/oxc-tsrx/'
 
@@ -30,6 +36,9 @@ export default {
   origin,
   // Root-absolute base path the site is served under, with trailing slash.
   base,
+  // Canonical origin every page under `base` should permanently redirect to,
+  // or null when this build is the canonical one.
+  redirectTo: origin === CANONICAL_ORIGIN ? null : CANONICAL_ORIGIN,
   repository: 'https://github.com/tsrx-org/oxc',
   nav: [
     { text: 'Guide', link: '/guide/introduction' },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tsrx",
     "vite"
   ],
-  "homepage": "https://compiled.run/oxc-tsrx",
+  "homepage": "https://oxc.tsrx.dev",
   "bugs": {
     "url": "https://github.com/tsrx-org/oxc/issues"
   },

--- a/packages/toolchain/README.md
+++ b/packages/toolchain/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://compiled.run/oxc-tsrx">
+  <a href="https://oxc.tsrx.dev">
     <img alt="OXC for TSRX" width="600" src="https://raw.githubusercontent.com/tsrx-org/oxc/HEAD/.github/assets/readme-hero.png">
   </a>
 </p>
@@ -26,7 +26,7 @@ written in Rust. This package teaches them to read `.tsrx` too.
 
 _OXC for TSRX is the official OXC integration maintained by the TSRX project._
 
-[**Docs**](https://compiled.run/oxc-tsrx) &nbsp;·&nbsp; [**Getting started**](https://compiled.run/oxc-tsrx/guide/getting-started) &nbsp;·&nbsp; [**Playground**](https://compiled.run/oxc-tsrx/playground)
+[**Docs**](https://oxc.tsrx.dev) &nbsp;·&nbsp; [**Getting started**](https://oxc.tsrx.dev/guide/getting-started) &nbsp;·&nbsp; [**Playground**](https://oxc.tsrx.dev/playground)
 
 ## Install
 
@@ -37,11 +37,11 @@ npm install --save-dev @tsrx/oxc
 That is the whole setup, for the command line and for your editor. You get
 `oxlint` and `oxfmt`, the real [OXC](https://oxc.rs) commands, now able to read
 `.tsrx`, with no config file, no ignore file, and no install script. [Vite+ needs
-one more command](https://compiled.run/oxc-tsrx/guide/getting-started#try-it-with-vite).
+one more command](https://oxc.tsrx.dev/guide/getting-started#try-it-with-vite).
 
 You do not need Rust installed: the install downloads a ready-built program for
 your machine, one of eight published for macOS, Linux, and Windows. See
-[Platform support](https://compiled.run/oxc-tsrx/reference/platform-support).
+[Platform support](https://oxc.tsrx.dev/reference/platform-support).
 
 ## Usage
 
@@ -64,7 +64,7 @@ These are the TSRX blocks the linter and formatter understand: `@{` blocks,
 `@if` / `@else if` / `@else`, `@for` / `@empty`, `@switch` / `@case` /
 `@default`, `@try` / `@pending` / `@catch`, tags whose name is an expression,
 `<{expression}>`, and plain `<style>` blocks
-([TSRX syntax](https://compiled.run/oxc-tsrx/guide/tsrx-syntax) shows each one). Anything
+([TSRX syntax](https://oxc.tsrx.dev/guide/tsrx-syntax) shows each one). Anything
 outside that list **fails closed**: the command stops and says what it found and
 where, rather than guessing and maybe producing wrong output.
 
@@ -82,7 +82,7 @@ underlines the same problems the terminal reports. One catch: the TSRX
 toolchain's own extension owns `.tsrx`, and the OXC extension lists no
 activation event for it, so it does not start on its own. Open any JavaScript,
 TypeScript, or JSON file in the project once, and `.tsrx` works for the rest of
-the session. See the [editor guide](https://compiled.run/oxc-tsrx/integrations/editor).
+the session. See the [editor guide](https://oxc.tsrx.dev/integrations/editor).
 
 ## Using it from your own code
 
@@ -94,7 +94,7 @@ import { format } from "@tsrx/oxc/format";
 
 The parser hands back the structure of your file and the formatter hands back
 tidied text, so you can build your own tools on the same reader the commands
-use. [Parsing](https://compiled.run/oxc-tsrx/guide/parsing) has the shape it returns.
+use. [Parsing](https://oxc.tsrx.dev/guide/parsing) has the shape it returns.
 None of these compiles `.tsrx` either; that stays your framework's TSRX
 plugin's job.
 
@@ -121,16 +121,16 @@ editor both say when they have done that, and
 so it refuses `jsPlugins` and names `oxlint` as the command that can.
 `@tsrx/oxc/lint/plugins-dev` is for *writing* a plugin, since it re-exports the
 `RuleTester` from `oxlint`. See [Custom JavaScript
-plugins](https://compiled.run/oxc-tsrx/integrations/custom-js-plugins).
+plugins](https://oxc.tsrx.dev/integrations/custom-js-plugins).
 
 ## Documentation
 
-- [Getting started](https://compiled.run/oxc-tsrx/guide/getting-started): install, first file, first run.
-- [Configuration](https://compiled.run/oxc-tsrx/integrations/configuration): every supported setting.
-- [CLI reference](https://compiled.run/oxc-tsrx/reference/cli): commands, flags, and exit codes.
-- [Platform support](https://compiled.run/oxc-tsrx/reference/platform-support): which of the eight published platforms are tested on every change.
-- [Limitations](https://compiled.run/oxc-tsrx/reference/limitations): what is not claimed yet.
-- [Provider protocol](https://compiled.run/oxc-tsrx/architecture/provider-protocol): the `oxc.provider` block, what reads it today, and how a plain install reaches released hosts.
+- [Getting started](https://oxc.tsrx.dev/guide/getting-started): install, first file, first run.
+- [Configuration](https://oxc.tsrx.dev/integrations/configuration): every supported setting.
+- [CLI reference](https://oxc.tsrx.dev/reference/cli): commands, flags, and exit codes.
+- [Platform support](https://oxc.tsrx.dev/reference/platform-support): which of the eight published platforms are tested on every change.
+- [Limitations](https://oxc.tsrx.dev/reference/limitations): what is not claimed yet.
+- [Provider protocol](https://oxc.tsrx.dev/architecture/provider-protocol): the `oxc.provider` block, what reads it today, and how a plain install reaches released hosts.
 
 `@tsrx/oxc` is the only package to depend on. The eight `@tsrx/oxc-*`
 packages are platform binaries in `optionalDependencies`, and you never name one

--- a/packages/toolchain/package.json
+++ b/packages/toolchain/package.json
@@ -14,7 +14,7 @@
     "tsrx",
     "typescript"
   ],
-  "homepage": "https://compiled.run/oxc-tsrx",
+  "homepage": "https://oxc.tsrx.dev",
   "bugs": {
     "url": "https://github.com/tsrx-org/oxc/issues"
   },

--- a/packages/tsrx-core-compat/package.json
+++ b/packages/tsrx-core-compat/package.json
@@ -7,7 +7,7 @@
     "parser",
     "tsrx"
   ],
-  "homepage": "https://compiled.run/oxc-tsrx",
+  "homepage": "https://oxc.tsrx.dev",
   "bugs": {
     "url": "https://github.com/tsrx-org/oxc/issues"
   },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "OXC for TSRX",
   "version": "0.9.0",
   "description": "Official OXC editor support for TSRX",
-  "homepage": "https://compiled.run/oxc-tsrx",
+  "homepage": "https://oxc.tsrx.dev",
   "publisher": "thejackshelton",
   "license": "MIT",
   "repository": {

--- a/tests/release/launch-contract.test.mjs
+++ b/tests/release/launch-contract.test.mjs
@@ -10,7 +10,7 @@ import { parseNpmPackResponse } from "../helpers/npm-pack-response.mjs";
 
 const root = resolve(import.meta.dirname, "../..");
 const repository = "https://github.com/tsrx-org/oxc";
-const homepage = "https://compiled.run/oxc-tsrx";
+const homepage = "https://oxc.tsrx.dev";
 // The v0.1.0 launch manifest is a record of the launch as it ran, when the
 // repo lived in its original org and the site at its original domain; it keeps
 // the URL it actually posted.

--- a/tests/site/launch-build.test.mjs
+++ b/tests/site/launch-build.test.mjs
@@ -203,7 +203,10 @@ test("static launch build has a scoped base, crawl metadata, and no internal des
   if (trimmedBase) {
     // The domain root carries the landing page pointing at the docs.
     const landing = await readFile(join(outDir, "index.html"), "utf8");
-    assert.match(landing, new RegExp(`href="${escapedBase}"`, "u"));
+    // A legacy location points visitors straight at the canonical origin so
+    // the click does not have to bounce through the redirect.
+    const landingHref = siteConfig.redirectTo ? `${siteConfig.redirectTo}/` : trimmedBase;
+    assert.match(landing, new RegExp(`href="${landingHref.replace(/[.]/gu, "\\.")}"`, "u"));
     assert.match(landing, /prefers-color-scheme: dark/u);
     assert.match(landing, /color-scheme" content="light dark"/u);
   }
@@ -257,6 +260,22 @@ test("static launch build has a scoped base, crawl metadata, and no internal des
   // external rewrite is needed. Verify the rewrites array is empty.
   assert.ok(Array.isArray(vercel.rewrites), "vercel.json should have rewrites array");
   assert.equal(vercel.rewrites.length, 0, "vercel.json should have no rewrites");
+  // The default build is the legacy compiled.run/oxc-tsrx location: it must
+  // permanently redirect its base path, and only its base path, to the
+  // canonical origin. A canonical (oxc.tsrx.dev) build redirects nothing.
+  if (siteConfig.redirectTo) {
+    assert.deepEqual(vercel.redirects, [
+      { source: trimmedBase || "/", destination: `${siteConfig.redirectTo}/`, permanent: true },
+      {
+        source: `${trimmedBase}/:path*`,
+        destination: `${siteConfig.redirectTo}/:path*`,
+        permanent: true,
+      },
+    ]);
+    assert.ok(trimmedBase, "a legacy redirect must never claim the whole domain");
+  } else {
+    assert.deepEqual(vercel.redirects, []);
+  }
 });
 
 test("launch build fails closed when the browser WebAssembly artifact is required", async () => {


### PR DESCRIPTION
## Summary
- \`compiled.run/oxc-tsrx\` and every path under it now **308-redirect** to the same path on \`https://oxc.tsrx.dev\`. The compiled.run build sets \`redirectTo\` in \`docs/site.config.mjs\`; \`docs/build.mjs\` writes the matching \`redirects\` into that artifact's \`vercel.json\`. Only \`/oxc-tsrx\` is claimed: the compiled.run root and \`/guessless\` are untouched. The canonical oxc.tsrx.dev build has no \`redirectTo\` and writes no redirects, so it cannot loop.
- The compiled.run root landing page links straight to \`https://oxc.tsrx.dev/\`.
- The \`deploy\` job proves the redirect (status + \`Location\` for \`/oxc-tsrx\`, a guide page, and a playground share URL with its query string preserved) and hashes the non-redirected root page so the run still proves its own bytes are live. The Guessless check is unchanged.
- README, package \`homepage\` fields, and \`tests/release/launch-contract.test.mjs\` now point at \`https://oxc.tsrx.dev\`. \`docs/releasing/site-oxc-tsrx-dev.md\` records the new status up top.

## Verification
- Default build (\`compiled.run\`): \`vercel.json\` redirects are \`/oxc-tsrx → https://oxc.tsrx.dev/\` and \`/oxc-tsrx/:path* → https://oxc.tsrx.dev/:path*\`, both permanent; root \`index.html\` links to \`https://oxc.tsrx.dev/\`.
- Canonical build (\`SITE_ORIGIN=https://oxc.tsrx.dev SITE_BASE=/\`): \`redirects: []\`.
- \`pnpm run test:site\`: 207 passed, 0 failed. \`tests/site/launch-build.test.mjs\` (with new redirect assertions): 9/9. \`tests/release/launch-contract.test.mjs\`: 6/6.
- Workflow YAML parses.

## After merge
The push to main runs \`site-artifact.yml\`, which deploys the compiled.run artifact with the redirects and re-deploys oxc.tsrx.dev. The new \"Prove production is serving this build\" step will fail loudly if the redirect is not live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production routing and CI verification for the public docs site; misconfigured redirects could break bookmarks and npm README links until fixed.
> 
> **Overview**
> **`https://oxc.tsrx.dev` is now the canonical docs home.** Legacy **`compiled.run/oxc-tsrx`** (and every path under it) is served as a **permanent redirect** to the same path on the canonical site; **`compiled.run`** root and **`/guessless`** stay as-is.
> 
> **Build & deploy wiring:** `docs/site.config.mjs` adds **`redirectTo`** (set for non-canonical builds). `docs/build.mjs` emits matching **`vercel.json` redirects** and points the domain-root landing link at **`https://oxc.tsrx.dev/`** instead of the old base path. The **`deploy`** job in **`site-artifact.yml`** now **proves 308/301 + `Location`** for several `/oxc-tsrx` URLs (including query strings) and still **SHA-256s the non-redirected root `index.html`** so the run proves its own artifact—not old docs content.
> 
> **Link updates:** READMEs and package **`homepage`** fields move to **`https://oxc.tsrx.dev`**. **`tests/site/launch-build.test.mjs`** and release contract tests assert redirect behavior and the new homepage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2cd964095db5498c5192bb1a13a337ab9e9dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->