### PR TITLE
fix(parser): port scoped style parser from tsrx#46

### DIFF
--- a/crates/tsrx_parser_engine/src/pipeline.rs
+++ b/crates/tsrx_parser_engine/src/pipeline.rs
@@ -13,7 +13,10 @@ use tsrx_syntax::{
     Overlay, OverlayView, PARSER_RECOVERY_DIAGNOSTIC, ProjectionView, project_for_parser,
     recover_for_parser, scan_for_parser,
 };
-use tsrx_tape_schema::{CommentTable, DiagnosticTable, FlatTape, ModuleTable, TapeSpan};
+use tsrx_tape_schema::{
+    CommentTable, DiagnosticPhase, DiagnosticSeverity, DiagnosticTable, FlatTape, ModuleTable,
+    TapeSpan,
+};
 
 use crate::{
     TsrxParseError, TsrxParseOptions, TsrxParseRecovery, TsrxParseResult,
@@ -22,7 +25,9 @@ use crate::{
         grammar_result_with_rejection_module_names, projection_grammar_result,
     },
     lexical, projection,
-    reconstruct::{finalize_reachable_spans, reconstruct_projected},
+    reconstruct::{
+        collect_multiple_output_diagnostics, finalize_reachable_spans, reconstruct_projected,
+    },
     recovery,
     results::{reconstruct_diagnostics, reconstruct_module},
     utf16_result::Utf16WorkObserver,
@@ -419,6 +424,30 @@ impl ProjectedCompletion<'_, '_, '_, '_> {
             &authored_starts,
             &finalization_index,
         )?;
+        let multiple_outputs = collect_multiple_output_diagnostics(&self.tape)?;
+        for diagnostic in &multiple_outputs {
+            let labels = self.errors.append_labels([(
+                TapeSpan::new(diagnostic.span.start, diagnostic.span.end),
+                None,
+                true,
+            )])?;
+            self.errors.push_diagnostic(
+                DiagnosticPhase::Grammar,
+                DiagnosticSeverity::Error,
+                diagnostic.message,
+                labels,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )?;
+        }
+        if !multiple_outputs.is_empty() {
+            render_diagnostic_codeframes(self.filename, self.source, &mut self.errors)
+                .map_err(TsrxParseError::from)?;
+        }
         if !self.defer_compaction {
             self.tape.compact_reachable()?;
         }

--- a/crates/tsrx_parser_engine/src/reconstruct/code_blocks.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/code_blocks.rs
@@ -482,28 +482,63 @@ fn take_code_block_render(
     tape: &mut FlatTape,
     body: RecordIndex,
 ) -> Result<ValueRef, TsrxParseError> {
-    let mut render = None;
+    let items: Vec<(RecordIndex, ValueRef)> = tape.values_indexed(body).collect();
+    let mut output_indexes = Vec::new();
+    let mut seen_output = false;
     let mut trailing_semicolon = false;
-    for value in tape.values(body) {
-        if render.is_some() {
-            if !trailing_semicolon && is_dynamic_semicolon(tape, value) {
-                trailing_semicolon = true;
-                continue;
-            }
-            return Err(TsrxParseError::AuthoredGrammar(
-                "render expression precedes another statement".to_string(),
-            ));
+    for (index, (_entry, value)) in items.iter().copied().enumerate() {
+        if render_expression(tape, value)?.is_some() {
+            output_indexes.push(index);
+            seen_output = true;
+            trailing_semicolon = false;
+            continue;
         }
-        render = render_expression(tape, value)?;
+        if !seen_output {
+            continue;
+        }
+        if !trailing_semicolon && is_dynamic_semicolon(tape, value) {
+            trailing_semicolon = true;
+            continue;
+        }
+        return Err(TsrxParseError::AuthoredGrammar(
+            "render expression precedes another statement".to_string(),
+        ));
     }
-    let Some(render) = render else {
+    let Some(&last_output) = output_indexes.last() else {
         return tape.push_scalar("null").map_err(Into::into);
     };
+    for &index in &output_indexes {
+        if index == last_output {
+            continue;
+        }
+        let (entry, value) = items[index];
+        if let Some(expression) = expression_statement_jsx_child(tape, value)? {
+            tape.set_list_value(entry, expression)?;
+        }
+    }
     if trailing_semicolon {
         tape.pop_list_value(body)?;
     }
-    tape.pop_list_value(body)?;
-    Ok(render)
+    let render_value = tape.pop_list_value(body)?;
+    render_expression(tape, render_value)?
+        .ok_or(TsrxParseError::Unsupported("code block render is not a JSX child"))
+}
+
+fn expression_statement_jsx_child(
+    tape: &FlatTape,
+    statement: ValueRef,
+) -> Result<Option<ValueRef>, TsrxParseError> {
+    let Some(statement) = statement.as_object() else {
+        return Ok(None);
+    };
+    if !has_type(tape, statement, r#""ExpressionStatement""#) {
+        return Ok(None);
+    }
+    let expression = field_value(tape, statement, "expression")?;
+    let Some(object) = expression.as_object() else {
+        return Ok(None);
+    };
+    Ok(is_jsx_child_type(tape, object).then_some(expression))
 }
 
 fn block_code_block_placement(

--- a/crates/tsrx_parser_engine/src/reconstruct/mod.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/mod.rs
@@ -2,6 +2,11 @@
 //! `program` fixes the order the passes run in and `spans` closes them out, mapping every
 //! reachable node back into authored coordinates.
 
+use tsrx_syntax::ByteSpan;
+use tsrx_tape_schema::{FlatTape, RecordIndex};
+
+use crate::TsrxParseError;
+
 mod access;
 mod code_blocks;
 mod control;
@@ -25,3 +30,163 @@ mod try_catch;
 
 pub(super) use program::reconstruct_projected;
 pub(super) use spans::finalize_reachable_spans;
+
+use access::{
+    field_value, has_type, is_jsx_child_type, list_field, object_field, object_type, scalar_u32,
+};
+
+pub(super) const MULTIPLE_OUTPUTS_MESSAGE: &str =
+    "A code block renders a single node; wrap multiple nodes or text in a fragment '<>…</>'.";
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RecoverableDiagnostic {
+    pub(super) message: &'static str,
+    pub(super) span: ByteSpan,
+}
+
+pub(super) fn collect_multiple_output_diagnostics(
+    tape: &FlatTape,
+) -> Result<Vec<RecoverableDiagnostic>, TsrxParseError> {
+    let mut diagnostics = Vec::new();
+    for raw in 0..tape.object_count() {
+        let raw = u32::try_from(raw).map_err(|_| {
+            TsrxParseError::ResourceExhausted("object index exceeds the 32-bit tape limit")
+        })?;
+        let object = RecordIndex::new(raw);
+        match object_type(tape, object) {
+            Some(r#""JSXCodeBlock""#) => {
+                report_code_block_outputs(tape, object, &mut diagnostics)?;
+            }
+            Some(r#""JSXIfExpression""#) => {
+                report_if_outputs(tape, object, &mut diagnostics)?;
+            }
+            Some(r#""JSXForExpression""#) => {
+                report_for_outputs(tape, object, &mut diagnostics)?;
+            }
+            Some(r#""JSXTryExpression""#) => {
+                report_try_outputs(tape, object, &mut diagnostics)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(diagnostics)
+}
+
+fn report_code_block_outputs(
+    tape: &FlatTape,
+    block: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    let mut outputs = statement_list_outputs(tape, list_field(tape, block, "body")?)?;
+    if let Some(render) = nullable_object(tape, block, "render")? {
+        if is_jsx_child_type(tape, render) {
+            outputs.push(render);
+        }
+    }
+    push_later_outputs(tape, &outputs, diagnostics)?;
+    Ok(())
+}
+
+fn report_if_outputs(
+    tape: &FlatTape,
+    if_node: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    report_block_outputs(tape, object_field(tape, if_node, "consequent")?, diagnostics)?;
+    let Some(alternate) = nullable_object(tape, if_node, "alternate")? else {
+        return Ok(());
+    };
+    if has_type(tape, alternate, r#""BlockStatement""#) {
+        report_block_outputs(tape, alternate, diagnostics)?;
+    } else if has_type(tape, alternate, r#""IfStatement""#) {
+        report_if_outputs(tape, alternate, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn report_for_outputs(
+    tape: &FlatTape,
+    for_node: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    report_block_outputs(tape, object_field(tape, for_node, "body")?, diagnostics)?;
+    if let Some(empty) = nullable_object(tape, for_node, "empty")? {
+        report_block_outputs(tape, empty, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn report_try_outputs(
+    tape: &FlatTape,
+    try_node: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    report_block_outputs(tape, object_field(tape, try_node, "block")?, diagnostics)?;
+    if let Some(pending) = nullable_object(tape, try_node, "pending")? {
+        report_block_outputs(tape, pending, diagnostics)?;
+    }
+    if let Some(handler) = nullable_object(tape, try_node, "handler")? {
+        report_block_outputs(tape, object_field(tape, handler, "body")?, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn report_block_outputs(
+    tape: &FlatTape,
+    block: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    if !has_type(tape, block, r#""BlockStatement""#) {
+        return Ok(());
+    }
+    let outputs = statement_list_outputs(tape, list_field(tape, block, "body")?)?;
+    push_later_outputs(tape, &outputs, diagnostics)
+}
+
+fn statement_list_outputs(
+    tape: &FlatTape,
+    list: RecordIndex,
+) -> Result<Vec<RecordIndex>, TsrxParseError> {
+    let mut outputs = Vec::new();
+    for value in tape.values(list) {
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        if is_jsx_child_type(tape, object) {
+            outputs.push(object);
+        }
+    }
+    Ok(outputs)
+}
+
+fn push_later_outputs(
+    tape: &FlatTape,
+    outputs: &[RecordIndex],
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    for &output in outputs.iter().skip(1) {
+        diagnostics.push(RecoverableDiagnostic {
+            message: MULTIPLE_OUTPUTS_MESSAGE,
+            span: ByteSpan::new(
+                scalar_u32(tape, output, "start")?,
+                scalar_u32(tape, output, "end")?,
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn nullable_object(
+    tape: &FlatTape,
+    object: RecordIndex,
+    name: &str,
+) -> Result<Option<RecordIndex>, TsrxParseError> {
+    let value = field_value(tape, object, name)?;
+    if tape.scalar(value) == Some("null") {
+        return Ok(None);
+    }
+    value
+        .as_object()
+        .map(Some)
+        .ok_or(TsrxParseError::Unsupported("nullable ESTree field is not an object"))
+}

--- a/crates/tsrx_parser_engine/src/reconstruct/mod.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/mod.rs
@@ -77,11 +77,11 @@ fn report_code_block_outputs(
     block: RecordIndex,
     diagnostics: &mut Vec<RecoverableDiagnostic>,
 ) -> Result<(), TsrxParseError> {
-    let mut outputs = statement_list_outputs(tape, list_field(tape, block, "body")?)?;
-    if let Some(render) = nullable_object(tape, block, "render")? {
-        if is_jsx_child_type(tape, render) {
-            outputs.push(render);
-        }
+    let mut outputs = statement_list_outputs(tape, list_field(tape, block, "body")?);
+    if let Some(render) = nullable_object(tape, block, "render")?
+        && is_jsx_child_type(tape, render)
+    {
+        outputs.push(render);
     }
     push_later_outputs(tape, &outputs, diagnostics)?;
     Ok(())
@@ -139,14 +139,11 @@ fn report_block_outputs(
     if !has_type(tape, block, r#""BlockStatement""#) {
         return Ok(());
     }
-    let outputs = statement_list_outputs(tape, list_field(tape, block, "body")?)?;
+    let outputs = statement_list_outputs(tape, list_field(tape, block, "body")?);
     push_later_outputs(tape, &outputs, diagnostics)
 }
 
-fn statement_list_outputs(
-    tape: &FlatTape,
-    list: RecordIndex,
-) -> Result<Vec<RecordIndex>, TsrxParseError> {
+fn statement_list_outputs(tape: &FlatTape, list: RecordIndex) -> Vec<RecordIndex> {
     let mut outputs = Vec::new();
     for value in tape.values(list) {
         let Some(object) = value.as_object() else {
@@ -156,7 +153,7 @@ fn statement_list_outputs(
             outputs.push(object);
         }
     }
-    Ok(outputs)
+    outputs
 }
 
 fn push_later_outputs(

--- a/crates/tsrx_parser_engine/src/reconstruct/style.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/style.rs
@@ -89,20 +89,20 @@ fn collect_projected_styles(
         if scalar_field(tape, name, "name")? != r#""style""# {
             continue;
         }
-        let owner = *expected_order
-            .get(next)
-            .ok_or(TsrxParseError::Unsupported("projected style has no authored owner"))?;
+        let start = map_endpoint(segments, scalar_u32(tape, opening, "start")?, true).ok_or(
+            TsrxParseError::Unsupported("projected style start is outside authored source"),
+        )?;
+        // `<style>{expr}</style>` stays an ordinary JSXElement. Skip those openings so they
+        // do not steal a reserved raw-style owner.
+        let Some(&owner) = expected_order.get(next) else {
+            continue;
+        };
         let expected = overlay
             .style_blocks
             .get(owner)
             .ok_or(TsrxParseError::Unsupported("unknown authored style owner"))?;
-        let start = map_endpoint(segments, scalar_u32(tape, opening, "start")?, true).ok_or(
-            TsrxParseError::Unsupported("projected style start is outside authored source"),
-        )?;
         if start != expected.element.start {
-            return Err(TsrxParseError::Unsupported(
-                "projected styles are not in canonical opening order",
-            ));
+            continue;
         }
         let element = parents
             .parent_container(ValueRef::object(opening))
@@ -206,7 +206,7 @@ fn reconstruct_style_element(
                 "self-closing style has projected closing content",
             ));
         }
-        (None, None)
+        (None, "")
     } else {
         let (closing, closing_name, closing_span, css) = consume_paired_style_scaffold(
             tape,
@@ -216,10 +216,10 @@ fn reconstruct_style_element(
             closing_value,
             segments,
         )?;
-        (Some((closing, closing_name, closing_span)), Some(css))
+        (Some((closing, closing_name, closing_span)), css)
     };
     let children =
-        if let Some(css) = css { build_style_children(tape, css, starts)? } else { children };
+        if style.self_closing { children } else { build_style_children(tape, css, starts)? };
 
     rebuild_style_opening(
         tape,
@@ -371,7 +371,7 @@ fn rebuild_style_element_node(
     children: RecordIndex,
     opening: RecordIndex,
     closing: Option<RecordIndex>,
-    css: Option<&str>,
+    css: &str,
     starts: &mut Vec<AuthoredStart>,
 ) -> Result<(), TsrxParseError> {
     tape.clear_fields(element)?;
@@ -385,10 +385,8 @@ fn rebuild_style_element_node(
         tape.push_scalar("null")?
     };
     tape.append_field(element, "closingElement", closing)?;
-    if let Some(css) = css {
-        let css = tape.push_json_string_scalar(css)?;
-        tape.append_field(element, "css", css)?;
-    }
+    let css = tape.push_json_string_scalar(css)?;
+    tape.append_field(element, "css", css)?;
     record_authored_span(starts, element, span);
     Ok(())
 }

--- a/crates/tsrx_parser_engine/tests/style_elements.rs
+++ b/crates/tsrx_parser_engine/tests/style_elements.rs
@@ -120,11 +120,11 @@ fn distinguishes_empty_paired_self_closing_and_uppercase_style_elements() {
     require_type(tape, style, "JSXStyleElement");
     assert_eq!(
         field_names(tape, style),
-        ["type", "start", "end", "metadata", "children", "openingElement", "closingElement",]
+        ["type", "start", "end", "metadata", "children", "openingElement", "closingElement", "css",]
     );
     assert!(list_field(tape, style, "children").is_empty());
     assert_eq!(tape.scalar(field(tape, style, "closingElement")), Some("null"));
-    assert!(optional_field(tape, style, "css").is_none());
+    assert_eq!(scalar_field(tape, style, "css"), "\"\"");
     let opening = object_field(tape, style, "openingElement");
     assert_eq!(scalar_field(tape, opening, "selfClosing"), "true");
     assert_eq!(list_field(tape, opening, "attributes").len(), 2);
@@ -195,7 +195,8 @@ fn nested_style_attributes_keep_preorder_owners_and_independent_raw_payloads() {
     let inner = object_field(tape, container, "expression");
     for style in [outer, inner] {
         require_type(tape, style, "JSXStyleElement");
-        assert!(optional_field(tape, style, "css").is_none());
+        assert_eq!(scalar_field(tape, style, "css"), "\"\"");
+        assert!(list_field(tape, style, "children").is_empty());
     }
     assert_eq!(count_type(tape, "JSXStyleElement"), 2);
     assert_no_scaffold(tape);

--- a/crates/tsrx_parser_engine/tests/style_syntax.rs
+++ b/crates/tsrx_parser_engine/tests/style_syntax.rs
@@ -1,0 +1,619 @@
+//! Parser cases from the tsrx `style-syntax` table (tsrx-org/tsrx#46 / A1).
+
+#[expect(
+    dead_code,
+    reason = "the shared test-support module is compiled into every integration binary and each one uses a different part of it"
+)]
+mod support;
+
+use support::{
+    assert_no_scaffold, field, list_field, object_field, one_object, optional_field, program_body,
+    require_type, scalar_field, span,
+};
+use tsrx_parser_engine::{TsrxParseRequest, TsrxParseResult, parse_tsrx};
+use tsrx_tape_schema::{
+    Completeness, DiagnosticPhase, FlatTape, ParseCompleteness, RecordIndex, ValueRef,
+};
+
+const CSS: &str = ".a { color: red; }";
+const MULTIPLE_OUTPUTS: &str =
+    "A code block renders a single node; wrap multiple nodes or text in a fragment '<>…</>'.";
+
+fn parse(source: &str) -> TsrxParseResult {
+    parse_tsrx(&TsrxParseRequest { source }).unwrap_or_else(|error| {
+        panic!("style-syntax fixture failed as an operational error: {error}")
+    })
+}
+
+fn tape_of(result: &TsrxParseResult) -> &FlatTape {
+    assert!(result.program.is_some(), "style-syntax fixture must keep a Program");
+    result.program()
+}
+
+fn objects(values: &[ValueRef]) -> Vec<RecordIndex> {
+    values.iter().map(|value| value.as_object().expect("list object")).collect()
+}
+
+fn component_block(tape: &FlatTape) -> RecordIndex {
+    let function = one_object(&program_body(tape));
+    require_type(tape, function, "FunctionDeclaration");
+    let block = object_field(tape, function, "body");
+    require_type(tape, block, "JSXCodeBlock");
+    block
+}
+
+fn returned(tape: &FlatTape) -> RecordIndex {
+    let function = one_object(&program_body(tape));
+    let body = object_field(tape, function, "body");
+    require_type(tape, body, "BlockStatement");
+    let statement = one_object(&list_field(tape, body, "body"));
+    require_type(tape, statement, "ReturnStatement");
+    object_field(tape, statement, "argument")
+}
+
+fn exported_init(tape: &FlatTape) -> RecordIndex {
+    let export = one_object(&program_body(tape));
+    require_type(tape, export, "ExportNamedDeclaration");
+    let declaration = object_field(tape, export, "declaration");
+    let declarator = one_object(&list_field(tape, declaration, "declarations"));
+    object_field(tape, declarator, "init")
+}
+
+fn code_block_body(tape: &FlatTape, block: RecordIndex) -> Vec<RecordIndex> {
+    objects(&list_field(tape, block, "body"))
+}
+
+fn nullable_object(tape: &FlatTape, object: RecordIndex, name: &str) -> Option<RecordIndex> {
+    let value = field(tape, object, name);
+    if tape.scalar(value) == Some("null") {
+        None
+    } else {
+        Some(value.as_object().expect("nullable object"))
+    }
+}
+
+fn block_statements(tape: &FlatTape, block: RecordIndex) -> Vec<RecordIndex> {
+    require_type(tape, block, "BlockStatement");
+    objects(&list_field(tape, block, "body"))
+}
+
+fn json_string(value: &str) -> String {
+    format!("\"{value}\"")
+}
+
+fn attribute_names(tape: &FlatTape, style: RecordIndex) -> Vec<String> {
+    let opening = object_field(tape, style, "openingElement");
+    list_field(tape, opening, "attributes")
+        .into_iter()
+        .map(|value| {
+            let attribute = value.as_object().expect("JSXAttribute");
+            let name = object_field(tape, attribute, "name");
+            scalar_field(tape, name, "name").trim_matches('"').to_string()
+        })
+        .collect()
+}
+
+fn apply_expression_type(tape: &FlatTape, style: RecordIndex) -> Option<String> {
+    let opening = object_field(tape, style, "openingElement");
+    for value in list_field(tape, opening, "attributes") {
+        let attribute = value.as_object().expect("JSXAttribute");
+        let name = object_field(tape, attribute, "name");
+        if scalar_field(tape, name, "name") != r#""apply""# {
+            continue;
+        }
+        let container = object_field(tape, attribute, "value");
+        require_type(tape, container, "JSXExpressionContainer");
+        let expression = object_field(tape, container, "expression");
+        return Some(scalar_field(tape, expression, "type").trim_matches('"').to_string());
+    }
+    None
+}
+
+fn assert_style_self(
+    tape: &FlatTape,
+    style: RecordIndex,
+    attributes: &[&str],
+    apply: Option<&str>,
+) {
+    require_type(tape, style, "JSXStyleElement");
+    let opening = object_field(tape, style, "openingElement");
+    assert_eq!(scalar_field(tape, opening, "selfClosing"), "true");
+    assert_eq!(attribute_names(tape, style), attributes);
+    assert_eq!(apply_expression_type(tape, style).as_deref(), apply);
+    assert!(list_field(tape, style, "children").is_empty());
+    assert_eq!(scalar_field(tape, style, "css"), "\"\"");
+    assert_eq!(tape.scalar(field(tape, style, "closingElement")), Some("null"));
+    let metadata = object_field(tape, style, "metadata");
+    assert!(optional_field(tape, metadata, "styleScopeHash").is_none());
+}
+
+fn assert_style_body(
+    tape: &FlatTape,
+    style: RecordIndex,
+    css: &str,
+    attributes: &[&str],
+    apply: Option<&str>,
+) {
+    require_type(tape, style, "JSXStyleElement");
+    let opening = object_field(tape, style, "openingElement");
+    assert_eq!(scalar_field(tape, opening, "selfClosing"), "false");
+    assert_eq!(attribute_names(tape, style), attributes);
+    assert_eq!(apply_expression_type(tape, style).as_deref(), apply);
+    let stylesheet = one_object(&list_field(tape, style, "children"));
+    require_type(tape, stylesheet, "StyleSheet");
+    assert_eq!(scalar_field(tape, style, "css"), json_string(css));
+    object_field(tape, style, "closingElement");
+}
+
+fn assert_element(tape: &FlatTape, element: RecordIndex, name: &str) {
+    require_type(tape, element, "JSXElement");
+    let opening = object_field(tape, element, "openingElement");
+    let identifier = object_field(tape, opening, "name");
+    assert_eq!(scalar_field(tape, identifier, "name"), json_string(name));
+}
+
+fn assert_style_host(tape: &FlatTape, element: RecordIndex, containers: usize) {
+    assert_element(tape, element, "style");
+    let children = objects(&list_field(tape, element, "children"));
+    let expression_children = children
+        .iter()
+        .copied()
+        .filter(|child| scalar_field(tape, *child, "type") == r#""JSXExpressionContainer""#)
+        .collect::<Vec<_>>();
+    assert_eq!(expression_children.len(), containers);
+    assert!(optional_field(tape, element, "css").is_none());
+}
+
+fn assert_no_parser_errors(result: &TsrxParseResult) {
+    assert_eq!(result.status, ParseCompleteness::Complete, "{:?}", result.errors);
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+}
+
+fn assert_multiple_outputs(result: &TsrxParseResult, start: u32, end: u32) {
+    assert!(result.program.is_some());
+    assert!(result.completeness.contains(Completeness::HAS_PROGRAM));
+    assert!(result.completeness.contains(Completeness::HAS_ERRORS));
+    let error = result
+        .errors
+        .records()
+        .iter()
+        .find(|error| error.phase == DiagnosticPhase::Grammar)
+        .expect("multiple-outputs grammar diagnostic");
+    assert_eq!(result.errors.string(error.message), Some(MULTIPLE_OUTPUTS));
+    let labels = result.errors.labels(error.labels).expect("grammar labels");
+    assert_eq!(labels.len(), 1);
+    assert_eq!(labels[0].span.start, start);
+    assert_eq!(labels[0].span.end, end);
+}
+
+#[test]
+fn self_closing_style_forms_keep_empty_css_and_attributes() {
+    let cases: [(&str, &[&str], Option<&str>); 5] = [
+        ("function App() @{ <><style /><div /></> }", &[], None),
+        ("function App() @{ <><style apply={theme} /><div /></> }", &["apply"], Some("Identifier")),
+        (
+            "function App() @{ <><style apply={[a, b]} /><div /></> }",
+            &["apply"],
+            Some("ArrayExpression"),
+        ),
+        (
+            "function App() @{ <><style apply={ns.dark} /><div /></> }",
+            &["apply"],
+            Some("MemberExpression"),
+        ),
+        (
+            "function App() @{ <><style ref={r} apply={theme} /><div /></> }",
+            &["ref", "apply"],
+            Some("Identifier"),
+        ),
+    ];
+    for (source, attributes, apply) in cases {
+        let result = parse(source);
+        assert_no_parser_errors(&result);
+        let tape = tape_of(&result);
+        let render = object_field(tape, component_block(tape), "render");
+        let style = objects(&list_field(tape, render, "children"))[0];
+        assert_style_self(tape, style, attributes, apply);
+        assert_no_scaffold(tape);
+    }
+}
+
+#[test]
+fn bodied_style_forms_keep_sheet_css_and_apply() {
+    let source = format!("function App() @{{ <><style apply={{t}}>{CSS}</style><div /></> }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let style = objects(&list_field(tape, render, "children"))[0];
+    assert_style_body(tape, style, CSS, &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+
+    let source = format!("function App() {{ return <style>{CSS}</style>; }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_body(tape, returned(tape), CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_before_output_in_code_block_is_multiple_outputs() {
+    let source = "function App() @{ const x = 1; <style apply={a} /> <div /> }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 51, 58);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 2);
+    require_type(tape, body[0], "VariableDeclaration");
+    assert_style_self(tape, body[1], &["apply"], Some("Identifier"));
+    assert_element(tape, object_field(tape, block, "render"), "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_after_output_in_code_block_is_multiple_outputs() {
+    let source = format!("function App() @{{ <div /> <style>{CSS}</style> }}");
+    let result = parse(&source);
+    assert_multiple_outputs(&result, 26, 59);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    assert_element(tape, body[0], "div");
+    assert_style_body(tape, object_field(tape, block, "render"), CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn lone_style_in_code_block_parses_as_render() {
+    let source = format!("function App() @{{ <style>{CSS}</style> }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    assert!(code_block_body(tape, block).is_empty());
+    assert_style_body(tape, object_field(tape, block, "render"), CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragment_is_the_valid_code_block_form_for_style_and_output() {
+    let source = "function App() @{ const x = 1; <><style apply={a} /><div /></> }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    require_type(tape, body[0], "VariableDeclaration");
+    let render = object_field(tape, block, "render");
+    require_type(tape, render, "JSXFragment");
+    let children = objects(&list_field(tape, render, "children"));
+    assert_style_self(tape, children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, children[1], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn nested_code_block_keeps_its_own_style_inside_a_fragment() {
+    let source = "function App() @{ <><style apply={a} /><div>@{ <><style apply={b} /><span /></> }</div></> }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let children = objects(&list_field(tape, render, "children"));
+    let div_children = objects(&list_field(tape, children[1], "children"));
+    let nested = div_children[0];
+    require_type(tape, nested, "JSXCodeBlock");
+    assert!(code_block_body(tape, nested).is_empty());
+    let nested_render = object_field(tape, nested, "render");
+    require_type(tape, nested_render, "JSXFragment");
+    let nested_children = objects(&list_field(tape, nested_render, "children"));
+    assert_style_self(tape, nested_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, nested_children[1], "span");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn assigned_code_block_keeps_theme_in_setup_and_applying_fragment() {
+    let source = format!(
+        "const something = @{{\n\tconst theme = <style>{CSS}</style>;\n\t<>\n\t\t<style apply={{theme}}>{CSS}</style>\n\t\t<div />\n\t</>\n}};"
+    );
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let declaration = one_object(&program_body(tape));
+    let declarator = one_object(&list_field(tape, declaration, "declarations"));
+    let block = object_field(tape, declarator, "init");
+    require_type(tape, block, "JSXCodeBlock");
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    require_type(tape, body[0], "VariableDeclaration");
+    let render = object_field(tape, block, "render");
+    require_type(tape, render, "JSXFragment");
+    let children = objects(&list_field(tape, render, "children"));
+    assert_style_body(tape, children[0], CSS, &["apply"], Some("Identifier"));
+    assert_element(tape, children[1], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_beside_output_in_if_consequent_is_multiple_outputs() {
+    let source = "function App() @{ @if (ok) { <style apply={a} /> <b /> } }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 49, 54);
+    let tape = tape_of(&result);
+    let if_node = object_field(tape, component_block(tape), "render");
+    require_type(tape, if_node, "JSXIfExpression");
+    let consequent = block_statements(tape, object_field(tape, if_node, "consequent"));
+    assert_eq!(consequent.len(), 2);
+    assert_style_self(tape, consequent[0], &["apply"], Some("Identifier"));
+    assert_element(tape, consequent[1], "b");
+    assert!(nullable_object(tape, if_node, "alternate").is_none());
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn lone_style_in_if_consequent_parses() {
+    let source = "function App() @{ @if (ok) { <style apply={a} /> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let if_node = object_field(tape, component_block(tape), "render");
+    let consequent = block_statements(tape, object_field(tape, if_node, "consequent"));
+    assert_eq!(consequent.len(), 1);
+    assert_style_self(tape, consequent[0], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_if_and_else() {
+    let source = "function App() @{ @if (ok) { <><style apply={a} /><b /></> } @else { <><i /><style apply={c} /></> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let if_node = object_field(tape, component_block(tape), "render");
+    let consequent = block_statements(tape, object_field(tape, if_node, "consequent"));
+    require_type(tape, consequent[0], "JSXFragment");
+    let consequent_children = objects(&list_field(tape, consequent[0], "children"));
+    assert_style_self(tape, consequent_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, consequent_children[1], "b");
+    let alternate = block_statements(tape, object_field(tape, if_node, "alternate"));
+    require_type(tape, alternate[0], "JSXFragment");
+    let alternate_children = objects(&list_field(tape, alternate[0], "children"));
+    assert_element(tape, alternate_children[0], "i");
+    assert_style_self(tape, alternate_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_beside_output_in_for_body_is_multiple_outputs() {
+    let source = "function App() @{ @for (const x of xs) { <style apply={a} /> <b>{x}</b> } }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 61, 71);
+    let tape = tape_of(&result);
+    let for_node = object_field(tape, component_block(tape), "render");
+    require_type(tape, for_node, "JSXForExpression");
+    let body = block_statements(tape, object_field(tape, for_node, "body"));
+    assert_eq!(body.len(), 2);
+    assert_style_self(tape, body[0], &["apply"], Some("Identifier"));
+    assert_element(tape, body[1], "b");
+    assert!(nullable_object(tape, for_node, "empty").is_none());
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_for_and_empty() {
+    let source = "function App() @{ @for (const x of xs) { <><style apply={a} /><b>{x}</b></> } @empty { <><i /><style apply={c} /></> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let for_node = object_field(tape, component_block(tape), "render");
+    let body = block_statements(tape, object_field(tape, for_node, "body"));
+    let body_children = objects(&list_field(tape, body[0], "children"));
+    assert_style_self(tape, body_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, body_children[1], "b");
+    let empty = block_statements(tape, object_field(tape, for_node, "empty"));
+    let empty_children = objects(&list_field(tape, empty[0], "children"));
+    assert_element(tape, empty_children[0], "i");
+    assert_style_self(tape, empty_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_switch_cases() {
+    let source = "function App() @{ @switch (k) { @case 1: { <><style apply={a} /><b /></> } @default: { <><i /><style apply={c} /></> } } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let switch = object_field(tape, component_block(tape), "render");
+    require_type(tape, switch, "JSXSwitchExpression");
+    let cases = objects(&list_field(tape, switch, "cases"));
+    assert_eq!(cases.len(), 2);
+    require_type(tape, object_field(tape, cases[0], "test"), "Literal");
+    assert_eq!(tape.scalar(field(tape, cases[1], "test")), Some("null"));
+    let first = objects(&list_field(tape, cases[0], "consequent"));
+    let first_children = objects(&list_field(tape, first[0], "children"));
+    assert_style_self(tape, first_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, first_children[1], "b");
+    let default = objects(&list_field(tape, cases[1], "consequent"));
+    let default_children = objects(&list_field(tape, default[0], "children"));
+    assert_element(tape, default_children[0], "i");
+    assert_style_self(tape, default_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_beside_output_in_try_block_is_multiple_outputs() {
+    let source = "function App() @{ @try { <style apply={a} /> <b /> } @catch (e) { <i /> } }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 45, 50);
+    let tape = tape_of(&result);
+    let try_node = object_field(tape, component_block(tape), "render");
+    require_type(tape, try_node, "JSXTryExpression");
+    let block = block_statements(tape, object_field(tape, try_node, "block"));
+    assert_style_self(tape, block[0], &["apply"], Some("Identifier"));
+    assert_element(tape, block[1], "b");
+    assert!(nullable_object(tape, try_node, "pending").is_none());
+    let handler = object_field(tape, try_node, "handler");
+    require_type(tape, handler, "CatchClause");
+    let handler_body = block_statements(tape, object_field(tape, handler, "body"));
+    assert_element(tape, handler_body[0], "i");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_try_pending_and_catch() {
+    let source = "function App() @{ @try { <><style apply={a} /><b /></> } @pending { <><style apply={p} /><u /></> } @catch (e) { <><i /><style apply={c} /></> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let try_node = object_field(tape, component_block(tape), "render");
+    let block_children = objects(&list_field(
+        tape,
+        block_statements(tape, object_field(tape, try_node, "block"))[0],
+        "children",
+    ));
+    assert_style_self(tape, block_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, block_children[1], "b");
+    let pending_children = objects(&list_field(
+        tape,
+        block_statements(tape, object_field(tape, try_node, "pending"))[0],
+        "children",
+    ));
+    assert_style_self(tape, pending_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, pending_children[1], "u");
+    let handler = object_field(tape, try_node, "handler");
+    let handler_children = objects(&list_field(
+        tape,
+        block_statements(tape, object_field(tape, handler, "body"))[0],
+        "children",
+    ));
+    assert_element(tape, handler_children[0], "i");
+    assert_style_self(tape, handler_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn sibling_style_blocks_live_in_fragment_children() {
+    let source = format!(
+        "function App() {{ return <><style apply={{a}} /><style>{CSS}</style><div /></>; }}"
+    );
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let fragment = returned(tape);
+    require_type(tape, fragment, "JSXFragment");
+    let children = objects(&list_field(tape, fragment, "children"));
+    assert_style_self(tape, children[0], &["apply"], Some("Identifier"));
+    assert_style_body(tape, children[1], CSS, &[], None);
+    assert_element(tape, children[2], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn expression_child_style_is_an_ordinary_jsx_element() {
+    let result = parse("function App() { return <style>{css}</style>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_host(tape, returned(tape), 1);
+    assert_no_scaffold(tape);
+
+    let result = parse("function App() @{ <section><style>{css}</style><div /></section> }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let section = object_field(tape, component_block(tape), "render");
+    assert_element(tape, section, "section");
+    let children = objects(&list_field(tape, section, "children"));
+    assert_style_host(tape, children[0], 1);
+    assert_element(tape, children[1], "div");
+    assert_no_scaffold(tape);
+
+    let result = parse("function App() { return <section><style>\n\t{css}\n</style></section>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let section = returned(tape);
+    let children = objects(&list_field(tape, section, "children"));
+    assert_style_host(tape, children[0], 1);
+    assert_no_scaffold(tape);
+
+    let result = parse("function App() { return <style>{reset}{theme}</style>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_host(tape, returned(tape), 2);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn brace_inside_css_text_still_parses_as_a_bodied_style() {
+    let result = parse("function App() @{ <><style>.a{color:red}</style><div /></> }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let style = objects(&list_field(tape, render, "children"))[0];
+    assert_style_body(tape, style, ".a{color:red}", &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn module_scope_style_forms_parse() {
+    let result = parse("export const theme = <style apply={[a, b]} />;");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_self(tape, exported_init(tape), &["apply"], Some("ArrayExpression"));
+    assert_no_scaffold(tape);
+
+    let source = format!("<style>{CSS}</style>;\nexport function App() {{ return <div />; }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let first = program_body(tape)[0].as_object().expect("bare style");
+    assert_style_body(tape, first, CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn head_style_has_no_scope_hash_on_the_tape() {
+    let result =
+        parse("function App() { return <head><style>body { margin: 0; }</style></head>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let head = returned(tape);
+    let style = objects(&list_field(tape, head, "children"))[0];
+    assert_style_body(tape, style, "body { margin: 0; }", &[], None);
+    let metadata = object_field(tape, style, "metadata");
+    assert!(optional_field(tape, metadata, "styleScopeHash").is_none());
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn raw_style_in_a_switch_case_does_not_break_the_following_case() {
+    let source = "function App() @{ @switch (k) { @case 1: { <style>.a{color:red}</style> } @case 2: { <div /> } } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let switch = object_field(tape, component_block(tape), "render");
+    require_type(tape, switch, "JSXSwitchExpression");
+    let cases = objects(&list_field(tape, switch, "cases"));
+    assert_eq!(cases.len(), 2);
+    let first = objects(&list_field(tape, cases[0], "consequent"));
+    assert_style_body(tape, first[0], ".a{color:red}", &[], None);
+    let second = objects(&list_field(tape, cases[1], "consequent"));
+    assert_element(tape, second[0], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn expression_child_style_does_not_steal_a_sibling_raw_style_owner() {
+    let source = "function App() @{ <><style>{css}</style><style>.a{color:red}</style></> }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let children = objects(&list_field(tape, render, "children"));
+    assert_style_host(tape, children[0], 1);
+    assert_style_body(tape, children[1], ".a{color:red}", &[], None);
+    assert_no_scaffold(tape);
+}

--- a/crates/tsrx_parser_engine/tests/style_syntax.rs
+++ b/crates/tsrx_parser_engine/tests/style_syntax.rs
@@ -8,7 +8,7 @@ mod support;
 
 use support::{
     assert_no_scaffold, field, list_field, object_field, one_object, optional_field, program_body,
-    require_type, scalar_field, span,
+    require_type, scalar_field,
 };
 use tsrx_parser_engine::{TsrxParseRequest, TsrxParseResult, parse_tsrx};
 use tsrx_tape_schema::{
@@ -159,8 +159,8 @@ fn assert_style_host(tape: &FlatTape, element: RecordIndex, containers: usize) {
         .iter()
         .copied()
         .filter(|child| scalar_field(tape, *child, "type") == r#""JSXExpressionContainer""#)
-        .collect::<Vec<_>>();
-    assert_eq!(expression_children.len(), containers);
+        .count();
+    assert_eq!(expression_children, containers);
     assert!(optional_field(tape, element, "css").is_none());
 }
 
@@ -170,7 +170,17 @@ fn assert_no_parser_errors(result: &TsrxParseResult) {
 }
 
 fn assert_multiple_outputs(result: &TsrxParseResult, start: u32, end: u32) {
-    assert!(result.program.is_some());
+    assert!(
+        result.program.is_some(),
+        "expected recovered program; status={:?} errors={:?}",
+        result.status,
+        result
+            .errors
+            .records()
+            .iter()
+            .map(|error| result.errors.string(error.message).unwrap_or("<missing>"))
+            .collect::<Vec<_>>(),
+    );
     assert!(result.completeness.contains(Completeness::HAS_PROGRAM));
     assert!(result.completeness.contains(Completeness::HAS_ERRORS));
     let error = result

--- a/crates/tsrx_parser_engine/tests/utf16_bridge.rs
+++ b/crates/tsrx_parser_engine/tests/utf16_bridge.rs
@@ -923,7 +923,7 @@ fn style_payload_boundaries_ignore_quoted_greater_than_and_self_closing_attribut
                     == Some(r#""JSXStyleElement""#)
             })
             .expect("self-closing style");
-        assert!(result.program().field_index(style, "css").is_none());
+        assert_eq!(scalar_field(result.program(), style, "css"), "\"\"");
     }
 }
 

--- a/crates/tsrx_syntax/src/parser_projection/builder.rs
+++ b/crates/tsrx_syntax/src/parser_projection/builder.rs
@@ -532,8 +532,10 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
-    /// Writes the `;` that a line-leading markup opening implies, immediately before the opening
-    /// so the authored `<` is still copied verbatim and every authored byte keeps its segment.
+    /// Writes the `;` that a new statement-level markup opening implies, immediately before the
+    /// opening so the authored `<` is still copied verbatim and every authored byte keeps its
+    /// segment. Used for line-leading markup and for a sibling JSX statement after another JSX
+    /// tree.
     pub(super) fn statement_boundary(&mut self, boundary: u32) -> Result<(), ProjectionError> {
         let offset = *self
             .overlay

--- a/crates/tsrx_syntax/src/parser_scanner/jsx.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/jsx.rs
@@ -212,10 +212,11 @@ impl Scanner<'_> {
 
         // `<style>{expr}</style>` is ordinary JSX: the first non-whitespace child is `{`.
         let raw_style = style && !first_non_whitespace_is_open_brace(self.bytes, index);
-        if style && !raw_style {
-            if let Some(owner) = parser_style_owner {
-                self.abandon_reserved_style(owner)?;
-            }
+        if style
+            && !raw_style
+            && let Some(owner) = parser_style_owner
+        {
+            self.abandon_reserved_style(owner)?;
         }
 
         if raw_style {

--- a/crates/tsrx_syntax/src/parser_scanner/jsx.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/jsx.rs
@@ -210,7 +210,15 @@ impl Scanner<'_> {
             return Ok(index);
         }
 
-        if style {
+        // `<style>{expr}</style>` is ordinary JSX: the first non-whitespace child is `{`.
+        let raw_style = style && !first_non_whitespace_is_open_brace(self.bytes, index);
+        if style && !raw_style {
+            if let Some(owner) = parser_style_owner {
+                self.abandon_reserved_style(owner)?;
+            }
+        }
+
+        if raw_style {
             let Some(relative_close) = find_bytes(&self.bytes[index..], b"</style>") else {
                 return Err(ProjectionError::UnterminatedSyntax {
                     offset: to_u32(start)?,
@@ -519,6 +527,21 @@ impl Scanner<'_> {
         })
     }
 
+    fn abandon_reserved_style(&mut self, owner: u32) -> Result<(), ProjectionError> {
+        let index = usize::try_from(owner).map_err(|_| ProjectionError::StructuralMismatch)?;
+        if index >= self.style_blocks.len() {
+            return Err(ProjectionError::StructuralMismatch);
+        }
+        self.style_blocks.remove(index);
+        for token in &mut self.embedded_tokens {
+            if token.kind == EmbeddedKind::StyleContent && token.owner > owner {
+                token.owner =
+                    token.owner.checked_sub(1).ok_or(ProjectionError::StructuralMismatch)?;
+            }
+        }
+        Ok(())
+    }
+
     fn jsx_shorthand_identifier(&self, start: usize, end: usize) -> Option<ByteSpan> {
         let identifier_start = start.checked_add(1)?;
         let identifier_end = end.checked_sub(1)?;
@@ -551,6 +574,14 @@ impl Scanner<'_> {
         self.identifier_start_width(index + 1).is_some()
             || self.bytes.get(index + 1).is_some_and(|byte| matches!(byte, b'>' | b'{'))
     }
+}
+
+fn first_non_whitespace_is_open_brace(bytes: &[u8], start: usize) -> bool {
+    let mut index = start;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    bytes.get(index) == Some(&b'{')
 }
 
 fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -112,9 +112,11 @@ impl Scanner<'_> {
                 {
                     let checkpoint = self.checkpoint();
                     let committed = self.committed_jsx_opening(index);
-                    if !can_start_jsx {
-                        // Only the line-leading rule admitted this opening, so the legal-TSX lane
-                        // needs an explicit `;` where TSRX read a statement boundary.
+                    if !can_start_jsx || !can_start_expression {
+                        // Legal TSX cannot place two JSX trees in one expression. Insert `;`
+                        // when this opening starts a new statement: either the line-leading
+                        // exception (`!can_start_jsx`) or a sibling after a completed JSX
+                        // statement (`!can_start_expression`).
                         self.statement_boundaries.push(to_u32(index)?);
                     }
                     match self.scan_jsx_element(index) {

--- a/crates/tsrx_syntax/src/projection/builder.rs
+++ b/crates/tsrx_syntax/src/projection/builder.rs
@@ -578,8 +578,10 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
-    /// Writes the `;` that a line-leading markup opening implies, immediately before the opening
-    /// so the authored `<` is still copied verbatim and every authored byte keeps its segment.
+    /// Writes the `;` that a new statement-level markup opening implies, immediately before the
+    /// opening so the authored `<` is still copied verbatim and every authored byte keeps its
+    /// segment. Used for line-leading markup and for a sibling JSX statement after another JSX
+    /// tree.
     fn statement_boundary(&mut self, boundary: u32) -> Result<(), ProjectionError> {
         let offset = *self
             .overlay

--- a/crates/tsrx_syntax/src/scanner/jsx.rs
+++ b/crates/tsrx_syntax/src/scanner/jsx.rs
@@ -134,7 +134,8 @@ impl Scanner<'_> {
             return Ok(index);
         }
 
-        if style {
+        // `<style>{expr}</style>` is ordinary JSX: the first non-whitespace child is `{`.
+        if style && !first_non_whitespace_is_open_brace(self.bytes, index) {
             let Some(relative_close) = find_bytes(&self.bytes[index..], b"</style>") else {
                 return Err(ProjectionError::UnterminatedSyntax {
                     offset: to_u32(start)?,
@@ -583,4 +584,12 @@ impl Scanner<'_> {
         }
         Ok(())
     }
+}
+
+fn first_non_whitespace_is_open_brace(bytes: &[u8], start: usize) -> bool {
+    let mut index = start;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    bytes.get(index) == Some(&b'{')
 }

--- a/crates/tsrx_syntax/src/scanner/mod.rs
+++ b/crates/tsrx_syntax/src/scanner/mod.rs
@@ -159,9 +159,11 @@ impl<'a> Scanner<'a> {
                 {
                     let checkpoint = self.checkpoint();
                     let committed = self.committed_jsx_opening(index);
-                    if !can_start_jsx {
-                        // Only the line-leading rule admitted this opening, so the legal-TSX lane
-                        // needs an explicit `;` where TSRX read a statement boundary.
+                    if !can_start_jsx || !can_start_expression {
+                        // Legal TSX cannot place two JSX trees in one expression. Insert `;`
+                        // when this opening starts a new statement: either the line-leading
+                        // exception (`!can_start_jsx`) or a sibling after a completed JSX
+                        // statement (`!can_start_expression`).
                         self.statement_boundaries.push(to_u32(index)?);
                     }
                     match self.scan_jsx_element(index) {

--- a/packages/toolchain/dist/tsrx-core-compat/facade.js
+++ b/packages/toolchain/dist/tsrx-core-compat/facade.js
@@ -949,7 +949,7 @@ function materializeCompatibilityProgram(program, source, filename, loose, posit
 			if (value.pending != null && value.pendingKeyword == null) value.pendingKeyword = keywordSpan(source, "@pending", value.block?.end ?? value.start, value.pending?.end ?? value.end, positionAt);
 			if (value.handler != null && value.handlerKeyword == null) value.handlerKeyword = keywordSpan(source, "@catch", value.pending?.end ?? value.block?.end ?? value.start, value.handler?.end ?? value.end, positionAt);
 		}
-		if (value.type === "JSXStyleElement" && typeof value.css === "string") {
+		if (value.type === "JSXStyleElement" && typeof value.css === "string" && value.openingElement?.selfClosing !== true) {
 			const style = parse_style(value.css, {
 				filename,
 				line: value.openingElement?.loc?.start?.line ?? value.loc?.start?.line ?? 1,

--- a/packages/tsrx-core-compat/dist/facade.js
+++ b/packages/tsrx-core-compat/dist/facade.js
@@ -949,7 +949,7 @@ function materializeCompatibilityProgram(program, source, filename, loose, posit
 			if (value.pending != null && value.pendingKeyword == null) value.pendingKeyword = keywordSpan(source, "@pending", value.block?.end ?? value.start, value.pending?.end ?? value.end, positionAt);
 			if (value.handler != null && value.handlerKeyword == null) value.handlerKeyword = keywordSpan(source, "@catch", value.pending?.end ?? value.block?.end ?? value.start, value.handler?.end ?? value.end, positionAt);
 		}
-		if (value.type === "JSXStyleElement" && typeof value.css === "string") {
+		if (value.type === "JSXStyleElement" && typeof value.css === "string" && value.openingElement?.selfClosing !== true) {
 			const style = parse_style(value.css, {
 				filename,
 				line: value.openingElement?.loc?.start?.line ?? value.loc?.start?.line ?? 1,

--- a/packages/tsrx-core-compat/src/facade.ts
+++ b/packages/tsrx-core-compat/src/facade.ts
@@ -1268,7 +1268,11 @@ function materializeCompatibilityProgram(program, source, filename, loose, posit
       }
     }
 
-    if (value.type === "JSXStyleElement" && typeof value.css === "string") {
+    if (
+      value.type === "JSXStyleElement" &&
+      typeof value.css === "string" &&
+      value.openingElement?.selfClosing !== true
+    ) {
       const style = parse_style(
         value.css,
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports the RFC scoped-`<style>` parser behaviors from [`tsrx-org/tsrx#46`](https://github.com/tsrx-org/tsrx/issues/46) / A1 (`feat/scoped-styles-apply`, tsrx-org/tsrx#53) into this oxc/tsrx reconstruct path so Octane can stop relying on the JS-parser fallback for these shapes.

## Behaviors
- Self-closing `<style … />` is a `JSXStyleElement` with `selfClosing: true`, `children: []`, `css: ''`, attributes preserved, and no `styleScopeHash`. The JS facade skips `parse_style` / hash on self-closing nodes.
- A `<style>` beside another output in `@{…}` / `@if` / `@for` / `@try` bodies is the ordinary multiple-outputs diagnostic on the later node (recovered tree: last output becomes `render` in code blocks; both stay in control-flow clause lists). Lone `<style>` as the only output parses (analyzer diagnostic, not parser). `@switch` case bodies still do not report multiple outputs.
- Adjacent statement-level JSX is projected with a synthetic `;` so OXC can parse it; reconstruct strips that semicolon and keeps both outputs.
- `<style>{expr}</style>` is a plain `JSXElement` when the first non-whitespace child after the opening tag is `{`.
- Raw-text `</style>` restores tokenizer context; a following `@case` still parses.

Spec table: `packages/tsrx/tests/utils/fixtures/style-syntax.js` on `feat/scoped-styles-apply`.

## Tests
`crates/tsrx_parser_engine/tests/style_syntax.rs` mirrors that table against the authored tape (no facade hash). Existing self-closing style assertions now expect `css: ''`.

`cargo test -p tsrx_parser_engine -p tsrx_syntax` and `cargo clippy -p tsrx_parser_engine -p tsrx_syntax --tests -- -D warnings` are green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9b257d2-dbf9-4baa-ae85-de0381143a0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9b257d2-dbf9-4baa-ae85-de0381143a0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

