### PR TITLE
fix(parser): port released scoped style parser from tsrx#46

### DIFF
--- a/crates/tsrx_parser_engine/src/entry.rs
+++ b/crates/tsrx_parser_engine/src/entry.rs
@@ -17,7 +17,11 @@ use crate::{
 /// # Errors
 ///
 /// Malformed, unsupported, or OXC-rejected authored grammar is returned as a structured
-/// [`ParseCompleteness::Failed`](tsrx_tape_schema::ParseCompleteness::Failed) result with null `program` and `module` records. Returns
+/// [`ParseCompleteness::Failed`](tsrx_tape_schema::ParseCompleteness::Failed) result with null `program` and `module` records. One
+/// grammar error is recoverable: a `@{ … }` body or control-flow clause with more than one
+/// output node keeps its reconstructed `Program` and is returned as
+/// [`ParseCompleteness::Recovered`](tsrx_tape_schema::ParseCompleteness::Recovered), never
+/// `COMPLETE`, with a grammar diagnostic on every later output. Returns
 /// [`TsrxParseError`] only for operational failures such as unsupported coordinate domains,
 /// capacity exhaustion, or an internal projection/reconstruction invariant.
 pub fn parse_tsrx(request: &TsrxParseRequest<'_>) -> Result<TsrxParseResult, TsrxParseError> {
@@ -32,7 +36,10 @@ pub fn parse_tsrx(request: &TsrxParseRequest<'_>) -> Result<TsrxParseResult, Tsr
 /// a structured [`ParseCompleteness::Failed`](tsrx_tape_schema::ParseCompleteness::Failed) result
 /// with null `program` and `module` records. Editor recovery may instead retain a usable OXC
 /// partial tree and mark it
-/// [`ParseCompleteness::Recovered`](tsrx_tape_schema::ParseCompleteness::Recovered). Requested
+/// [`ParseCompleteness::Recovered`](tsrx_tape_schema::ParseCompleteness::Recovered). Under every
+/// recovery option, a body with more than one output node is the same recoverable grammar
+/// error: the reconstructed `Program` is kept, the result is `Recovered` rather than
+/// `COMPLETE`, and each later output carries a grammar diagnostic. Requested
 /// semantic diagnostics are likewise returned as structured result data. Returns an error only
 /// for operational failures such as unsupported coordinate domains, capacity exhaustion, or an
 /// internal projection/reconstruction invariant.

--- a/crates/tsrx_parser_engine/src/pipeline.rs
+++ b/crates/tsrx_parser_engine/src/pipeline.rs
@@ -13,7 +13,10 @@ use tsrx_syntax::{
     Overlay, OverlayView, PARSER_RECOVERY_DIAGNOSTIC, ProjectionView, project_for_parser,
     recover_for_parser, scan_for_parser,
 };
-use tsrx_tape_schema::{CommentTable, DiagnosticTable, FlatTape, ModuleTable, TapeSpan};
+use tsrx_tape_schema::{
+    CommentTable, DiagnosticPhase, DiagnosticSeverity, DiagnosticTable, FlatTape, ModuleTable,
+    TapeSpan,
+};
 
 use crate::{
     TsrxParseError, TsrxParseOptions, TsrxParseRecovery, TsrxParseResult,
@@ -22,7 +25,9 @@ use crate::{
         grammar_result_with_rejection_module_names, projection_grammar_result,
     },
     lexical, projection,
-    reconstruct::{finalize_reachable_spans, reconstruct_projected},
+    reconstruct::{
+        collect_multiple_output_diagnostics, finalize_reachable_spans, reconstruct_projected,
+    },
     recovery,
     results::{reconstruct_diagnostics, reconstruct_module},
     utf16_result::Utf16WorkObserver,
@@ -419,6 +424,30 @@ impl ProjectedCompletion<'_, '_, '_, '_> {
             &authored_starts,
             &finalization_index,
         )?;
+        let multiple_outputs = collect_multiple_output_diagnostics(&self.tape)?;
+        for diagnostic in &multiple_outputs {
+            let labels = self.errors.append_labels([(
+                TapeSpan::new(diagnostic.span.start, diagnostic.span.end),
+                None,
+                true,
+            )])?;
+            self.errors.push_diagnostic(
+                DiagnosticPhase::Grammar,
+                DiagnosticSeverity::Error,
+                diagnostic.message,
+                labels,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )?;
+        }
+        if !multiple_outputs.is_empty() {
+            render_diagnostic_codeframes(self.filename, self.source, &mut self.errors)
+                .map_err(TsrxParseError::from)?;
+        }
         if !self.defer_compaction {
             self.tape.compact_reachable()?;
         }

--- a/crates/tsrx_parser_engine/src/pipeline.rs
+++ b/crates/tsrx_parser_engine/src/pipeline.rs
@@ -26,7 +26,8 @@ use crate::{
     },
     lexical, projection,
     reconstruct::{
-        collect_multiple_output_diagnostics, finalize_reachable_spans, reconstruct_projected,
+        RecoverableDiagnostic, collect_multiple_output_diagnostics, finalize_reachable_spans,
+        reconstruct_projected,
     },
     recovery,
     results::{reconstruct_diagnostics, reconstruct_module},
@@ -78,7 +79,40 @@ pub(super) fn parse_tsrx_utf8_source<W: Utf16WorkObserver>(
     ) else {
         return Ok(failure);
     };
-    recovery::finish(recovered, failure, &recovery_source)
+    recovery::finish(recovered, failure, &recovery_source, source, options.filename)
+}
+
+/// Records the recoverable multiple-output grammar diagnostics on a result that keeps its
+/// reconstructed `Program`, rendering their codeframes against the authored source.
+pub(super) fn push_multiple_output_diagnostics(
+    errors: &mut DiagnosticTable,
+    diagnostics: &[RecoverableDiagnostic],
+    filename: &str,
+    source: &str,
+) -> Result<(), TsrxParseError> {
+    for diagnostic in diagnostics {
+        let labels = errors.append_labels([(
+            TapeSpan::new(diagnostic.span.start, diagnostic.span.end),
+            None,
+            true,
+        )])?;
+        errors.push_diagnostic(
+            DiagnosticPhase::Grammar,
+            DiagnosticSeverity::Error,
+            diagnostic.message,
+            labels,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )?;
+    }
+    if !diagnostics.is_empty() {
+        render_diagnostic_codeframes(filename, source, errors).map_err(TsrxParseError::from)?;
+    }
+    Ok(())
 }
 
 fn parse_tsrx_utf8_source_once<W: Utf16WorkObserver>(
@@ -424,29 +458,17 @@ impl ProjectedCompletion<'_, '_, '_, '_> {
             &authored_starts,
             &finalization_index,
         )?;
+        // A later output node is authored grammar the reconstruction recovered from, so the
+        // result keeps its Program but is never reported as a complete parse.
         let multiple_outputs = collect_multiple_output_diagnostics(&self.tape)?;
-        for diagnostic in &multiple_outputs {
-            let labels = self.errors.append_labels([(
-                TapeSpan::new(diagnostic.span.start, diagnostic.span.end),
-                None,
-                true,
-            )])?;
-            self.errors.push_diagnostic(
-                DiagnosticPhase::Grammar,
-                DiagnosticSeverity::Error,
-                diagnostic.message,
-                labels,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )?;
-        }
         if !multiple_outputs.is_empty() {
-            render_diagnostic_codeframes(self.filename, self.source, &mut self.errors)
-                .map_err(TsrxParseError::from)?;
+            self.recovered = true;
+            push_multiple_output_diagnostics(
+                &mut self.errors,
+                &multiple_outputs,
+                self.filename,
+                self.source,
+            )?;
         }
         if !self.defer_compaction {
             self.tape.compact_reachable()?;

--- a/crates/tsrx_parser_engine/src/reconstruct/code_blocks.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/code_blocks.rs
@@ -482,28 +482,63 @@ fn take_code_block_render(
     tape: &mut FlatTape,
     body: RecordIndex,
 ) -> Result<ValueRef, TsrxParseError> {
-    let mut render = None;
+    let items: Vec<(RecordIndex, ValueRef)> = tape.values_indexed(body).collect();
+    let mut output_indexes = Vec::new();
+    let mut seen_output = false;
     let mut trailing_semicolon = false;
-    for value in tape.values(body) {
-        if render.is_some() {
-            if !trailing_semicolon && is_dynamic_semicolon(tape, value) {
-                trailing_semicolon = true;
-                continue;
-            }
-            return Err(TsrxParseError::AuthoredGrammar(
-                "render expression precedes another statement".to_string(),
-            ));
+    for (index, (_entry, value)) in items.iter().copied().enumerate() {
+        if render_expression(tape, value)?.is_some() {
+            output_indexes.push(index);
+            seen_output = true;
+            trailing_semicolon = false;
+            continue;
         }
-        render = render_expression(tape, value)?;
+        if !seen_output {
+            continue;
+        }
+        if !trailing_semicolon && is_dynamic_semicolon(tape, value) {
+            trailing_semicolon = true;
+            continue;
+        }
+        return Err(TsrxParseError::AuthoredGrammar(
+            "render expression precedes another statement".to_string(),
+        ));
     }
-    let Some(render) = render else {
+    let Some(&last_output) = output_indexes.last() else {
         return tape.push_scalar("null").map_err(Into::into);
     };
+    for &index in &output_indexes {
+        if index == last_output {
+            continue;
+        }
+        let (entry, value) = items[index];
+        if let Some(expression) = expression_statement_jsx_child(tape, value)? {
+            tape.set_list_value(entry, expression)?;
+        }
+    }
     if trailing_semicolon {
         tape.pop_list_value(body)?;
     }
-    tape.pop_list_value(body)?;
-    Ok(render)
+    let render_value = tape.pop_list_value(body)?;
+    render_expression(tape, render_value)?
+        .ok_or(TsrxParseError::Unsupported("code block render is not a JSX child"))
+}
+
+fn expression_statement_jsx_child(
+    tape: &FlatTape,
+    statement: ValueRef,
+) -> Result<Option<ValueRef>, TsrxParseError> {
+    let Some(statement) = statement.as_object() else {
+        return Ok(None);
+    };
+    if !has_type(tape, statement, r#""ExpressionStatement""#) {
+        return Ok(None);
+    }
+    let expression = field_value(tape, statement, "expression")?;
+    let Some(object) = expression.as_object() else {
+        return Ok(None);
+    };
+    Ok(is_jsx_child_type(tape, object).then_some(expression))
 }
 
 fn block_code_block_placement(

--- a/crates/tsrx_parser_engine/src/reconstruct/mod.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/mod.rs
@@ -2,6 +2,11 @@
 //! `program` fixes the order the passes run in and `spans` closes them out, mapping every
 //! reachable node back into authored coordinates.
 
+use tsrx_syntax::ByteSpan;
+use tsrx_tape_schema::{FlatTape, RecordIndex};
+
+use crate::TsrxParseError;
+
 mod access;
 mod code_blocks;
 mod control;
@@ -25,3 +30,160 @@ mod try_catch;
 
 pub(super) use program::reconstruct_projected;
 pub(super) use spans::finalize_reachable_spans;
+
+use access::{
+    field_value, has_type, is_jsx_child_type, list_field, object_field, object_type, scalar_u32,
+};
+
+pub(super) const MULTIPLE_OUTPUTS_MESSAGE: &str =
+    "A code block renders a single node; wrap multiple nodes or text in a fragment '<>…</>'.";
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RecoverableDiagnostic {
+    pub(super) message: &'static str,
+    pub(super) span: ByteSpan,
+}
+
+pub(super) fn collect_multiple_output_diagnostics(
+    tape: &FlatTape,
+) -> Result<Vec<RecoverableDiagnostic>, TsrxParseError> {
+    let mut diagnostics = Vec::new();
+    for raw in 0..tape.object_count() {
+        let raw = u32::try_from(raw).map_err(|_| {
+            TsrxParseError::ResourceExhausted("object index exceeds the 32-bit tape limit")
+        })?;
+        let object = RecordIndex::new(raw);
+        match object_type(tape, object) {
+            Some(r#""JSXCodeBlock""#) => {
+                report_code_block_outputs(tape, object, &mut diagnostics)?;
+            }
+            Some(r#""JSXIfExpression""#) => {
+                report_if_outputs(tape, object, &mut diagnostics)?;
+            }
+            Some(r#""JSXForExpression""#) => {
+                report_for_outputs(tape, object, &mut diagnostics)?;
+            }
+            Some(r#""JSXTryExpression""#) => {
+                report_try_outputs(tape, object, &mut diagnostics)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(diagnostics)
+}
+
+fn report_code_block_outputs(
+    tape: &FlatTape,
+    block: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    let mut outputs = statement_list_outputs(tape, list_field(tape, block, "body")?);
+    if let Some(render) = nullable_object(tape, block, "render")?
+        && is_jsx_child_type(tape, render)
+    {
+        outputs.push(render);
+    }
+    push_later_outputs(tape, &outputs, diagnostics)?;
+    Ok(())
+}
+
+fn report_if_outputs(
+    tape: &FlatTape,
+    if_node: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    report_block_outputs(tape, object_field(tape, if_node, "consequent")?, diagnostics)?;
+    let Some(alternate) = nullable_object(tape, if_node, "alternate")? else {
+        return Ok(());
+    };
+    if has_type(tape, alternate, r#""BlockStatement""#) {
+        report_block_outputs(tape, alternate, diagnostics)?;
+    } else if has_type(tape, alternate, r#""IfStatement""#) {
+        report_if_outputs(tape, alternate, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn report_for_outputs(
+    tape: &FlatTape,
+    for_node: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    report_block_outputs(tape, object_field(tape, for_node, "body")?, diagnostics)?;
+    if let Some(empty) = nullable_object(tape, for_node, "empty")? {
+        report_block_outputs(tape, empty, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn report_try_outputs(
+    tape: &FlatTape,
+    try_node: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    report_block_outputs(tape, object_field(tape, try_node, "block")?, diagnostics)?;
+    if let Some(pending) = nullable_object(tape, try_node, "pending")? {
+        report_block_outputs(tape, pending, diagnostics)?;
+    }
+    if let Some(handler) = nullable_object(tape, try_node, "handler")? {
+        report_block_outputs(tape, object_field(tape, handler, "body")?, diagnostics)?;
+    }
+    Ok(())
+}
+
+fn report_block_outputs(
+    tape: &FlatTape,
+    block: RecordIndex,
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    if !has_type(tape, block, r#""BlockStatement""#) {
+        return Ok(());
+    }
+    let outputs = statement_list_outputs(tape, list_field(tape, block, "body")?);
+    push_later_outputs(tape, &outputs, diagnostics)
+}
+
+fn statement_list_outputs(tape: &FlatTape, list: RecordIndex) -> Vec<RecordIndex> {
+    let mut outputs = Vec::new();
+    for value in tape.values(list) {
+        let Some(object) = value.as_object() else {
+            continue;
+        };
+        if is_jsx_child_type(tape, object) {
+            outputs.push(object);
+        }
+    }
+    outputs
+}
+
+fn push_later_outputs(
+    tape: &FlatTape,
+    outputs: &[RecordIndex],
+    diagnostics: &mut Vec<RecoverableDiagnostic>,
+) -> Result<(), TsrxParseError> {
+    for &output in outputs.iter().skip(1) {
+        diagnostics.push(RecoverableDiagnostic {
+            message: MULTIPLE_OUTPUTS_MESSAGE,
+            span: ByteSpan::new(
+                scalar_u32(tape, output, "start")?,
+                scalar_u32(tape, output, "end")?,
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn nullable_object(
+    tape: &FlatTape,
+    object: RecordIndex,
+    name: &str,
+) -> Result<Option<RecordIndex>, TsrxParseError> {
+    let value = field_value(tape, object, name)?;
+    if tape.scalar(value) == Some("null") {
+        return Ok(None);
+    }
+    value
+        .as_object()
+        .map(Some)
+        .ok_or(TsrxParseError::Unsupported("nullable ESTree field is not an object"))
+}

--- a/crates/tsrx_parser_engine/src/reconstruct/style.rs
+++ b/crates/tsrx_parser_engine/src/reconstruct/style.rs
@@ -89,20 +89,20 @@ fn collect_projected_styles(
         if scalar_field(tape, name, "name")? != r#""style""# {
             continue;
         }
-        let owner = *expected_order
-            .get(next)
-            .ok_or(TsrxParseError::Unsupported("projected style has no authored owner"))?;
+        let start = map_endpoint(segments, scalar_u32(tape, opening, "start")?, true).ok_or(
+            TsrxParseError::Unsupported("projected style start is outside authored source"),
+        )?;
+        // `<style>{expr}</style>` stays an ordinary JSXElement. Skip those openings so they
+        // do not steal a reserved raw-style owner.
+        let Some(&owner) = expected_order.get(next) else {
+            continue;
+        };
         let expected = overlay
             .style_blocks
             .get(owner)
             .ok_or(TsrxParseError::Unsupported("unknown authored style owner"))?;
-        let start = map_endpoint(segments, scalar_u32(tape, opening, "start")?, true).ok_or(
-            TsrxParseError::Unsupported("projected style start is outside authored source"),
-        )?;
         if start != expected.element.start {
-            return Err(TsrxParseError::Unsupported(
-                "projected styles are not in canonical opening order",
-            ));
+            continue;
         }
         let element = parents
             .parent_container(ValueRef::object(opening))
@@ -206,7 +206,7 @@ fn reconstruct_style_element(
                 "self-closing style has projected closing content",
             ));
         }
-        (None, None)
+        (None, "")
     } else {
         let (closing, closing_name, closing_span, css) = consume_paired_style_scaffold(
             tape,
@@ -216,10 +216,10 @@ fn reconstruct_style_element(
             closing_value,
             segments,
         )?;
-        (Some((closing, closing_name, closing_span)), Some(css))
+        (Some((closing, closing_name, closing_span)), css)
     };
     let children =
-        if let Some(css) = css { build_style_children(tape, css, starts)? } else { children };
+        if style.self_closing { children } else { build_style_children(tape, css, starts)? };
 
     rebuild_style_opening(
         tape,
@@ -371,7 +371,7 @@ fn rebuild_style_element_node(
     children: RecordIndex,
     opening: RecordIndex,
     closing: Option<RecordIndex>,
-    css: Option<&str>,
+    css: &str,
     starts: &mut Vec<AuthoredStart>,
 ) -> Result<(), TsrxParseError> {
     tape.clear_fields(element)?;
@@ -385,10 +385,8 @@ fn rebuild_style_element_node(
         tape.push_scalar("null")?
     };
     tape.append_field(element, "closingElement", closing)?;
-    if let Some(css) = css {
-        let css = tape.push_json_string_scalar(css)?;
-        tape.append_field(element, "css", css)?;
-    }
+    let css = tape.push_json_string_scalar(css)?;
+    tape.append_field(element, "css", css)?;
     record_authored_span(starts, element, span);
     Ok(())
 }

--- a/crates/tsrx_parser_engine/src/recovery.rs
+++ b/crates/tsrx_parser_engine/src/recovery.rs
@@ -1,10 +1,12 @@
 //! Mapping a parser-owned editor recovery candidate back to authored result coordinates.
 
 use tsrx_syntax::ParserRecovery;
-use tsrx_tape_schema::{ParseCompleteness, TapeSpan};
+use tsrx_tape_schema::{DiagnosticPhase, DiagnosticTable, ParseCompleteness, TapeSpan};
 
 use crate::{
     TsrxParseError, TsrxParseResult,
+    pipeline::push_multiple_output_diagnostics,
+    reconstruct::{MULTIPLE_OUTPUTS_MESSAGE, collect_multiple_output_diagnostics},
     utf16_result::{program_reachable_objects, try_map_program_spans},
 };
 
@@ -12,8 +14,19 @@ pub(super) fn finish(
     mut recovered: TsrxParseResult,
     failure: TsrxParseResult,
     source: &ParserRecovery,
+    authored_source: &str,
+    filename: &str,
 ) -> Result<TsrxParseResult, TsrxParseError> {
-    if recovered.status != ParseCompleteness::Complete {
+    // A candidate is usable when the repaired source parsed completely, or when the only thing
+    // keeping it from `Complete` is the recoverable multiple-output grammar diagnostic: that
+    // tree is still the editor's best view, and its diagnostics are re-derived below in
+    // authored coordinates instead of being dropped with the candidate.
+    let usable = match recovered.status {
+        ParseCompleteness::Complete => true,
+        ParseCompleteness::Recovered => only_multiple_output_diagnostics(&recovered.errors),
+        ParseCompleteness::Failed => false,
+    };
+    if !usable {
         return Ok(failure);
     }
     let mut program = recovered
@@ -32,15 +45,34 @@ pub(super) fn finish(
     recovered.comments.try_map_spans(|span| map_span(source, span))?;
     recovered.rejection_module_names.try_map_spans(|span| map_span(source, span))?;
 
+    let mut errors = failure.errors;
+    if recovered.status == ParseCompleteness::Recovered {
+        let multiple_outputs = collect_multiple_output_diagnostics(&program)?;
+        push_multiple_output_diagnostics(
+            &mut errors,
+            &multiple_outputs,
+            filename,
+            authored_source,
+        )?;
+    }
+
     Ok(TsrxParseResult::recovered(
         program,
         recovered.module,
         recovered.comments,
-        failure.errors,
+        errors,
         failure.suppressed_diagnostics.saturating_add(recovered.suppressed_diagnostics),
         recovered.needs_compaction,
         std::mem::take(&mut recovered.rejection_module_names),
     ))
+}
+
+fn only_multiple_output_diagnostics(errors: &DiagnosticTable) -> bool {
+    !errors.is_empty()
+        && errors.records().iter().all(|record| {
+            record.phase == DiagnosticPhase::Grammar
+                && errors.string(record.message) == Some(MULTIPLE_OUTPUTS_MESSAGE)
+        })
 }
 
 fn map_span(source: &ParserRecovery, span: TapeSpan) -> Result<TapeSpan, TsrxParseError> {

--- a/crates/tsrx_parser_engine/tests/recovery.rs
+++ b/crates/tsrx_parser_engine/tests/recovery.rs
@@ -4,12 +4,44 @@
 )]
 mod support;
 
-use support::{object_field, program_body, require_type, span};
+use support::{list_field, object_field, program_body, require_type, span};
 use tsrx_parser_engine::{
     TsrxParseOptions, TsrxParseRecovery, TsrxParseRequest, TsrxParseResult, TsrxUtf16ParseRequest,
     parse_tsrx, parse_tsrx_utf16_with_options, parse_tsrx_with_options,
 };
-use tsrx_tape_schema::{Completeness, ParseCompleteness};
+use tsrx_tape_schema::{Completeness, DiagnosticPhase, ParseCompleteness};
+
+const MULTIPLE_OUTPUTS: &str =
+    "A code block renders a single node; wrap multiple nodes or text in a fragment '<>…</>'.";
+const RECOVERY_DIAGNOSTIC: &str = "incomplete TSRX editor snapshot";
+
+fn diagnostic_messages(result: &TsrxParseResult) -> Vec<&str> {
+    result
+        .errors
+        .records()
+        .iter()
+        .map(|record| result.errors.string(record.message).expect("diagnostic message"))
+        .collect()
+}
+
+fn multiple_output_label(result: &TsrxParseResult) -> (u32, u32) {
+    let record = result
+        .errors
+        .records()
+        .iter()
+        .find(|record| result.errors.string(record.message) == Some(MULTIPLE_OUTPUTS))
+        .expect("multiple-outputs diagnostic");
+    assert_eq!(record.phase, DiagnosticPhase::Grammar);
+    let labels = result.errors.labels(record.labels).expect("labels");
+    assert_eq!(labels.len(), 1);
+    (labels[0].span.start, labels[0].span.end)
+}
+
+fn expect_span(source: &str, needle: &str) -> (u32, u32) {
+    let start = source.find(needle).expect("needle in source");
+    let start = u32::try_from(start).expect("fixture offset");
+    (start, start + u32::try_from(needle.len()).expect("fixture length"))
+}
 
 fn recover(source: &str) -> TsrxParseResult {
     parse_tsrx_with_options(
@@ -146,4 +178,67 @@ fn editor_recovery_composes_repair_offsets_with_the_utf16_bridge() {
             .labels(diagnostic.labels)
             .is_some_and(|labels| labels.iter().all(|label| label.span.end <= unit_len))
     }));
+}
+
+#[test]
+fn snapshot_repair_keeps_a_multiple_output_tree_and_its_diagnostics() {
+    // The unclosed `@{` is repaired by the editor snapshot recovery; the repaired source still
+    // has two output nodes, which is the recoverable grammar error, not a reason to drop the
+    // repaired tree and its diagnostic.
+    let source = "export function View() @{\n  <style apply={a} />\n  <div />";
+    assert_eq!(
+        parse_tsrx(&TsrxParseRequest { source }).expect("strict").status,
+        ParseCompleteness::Failed
+    );
+
+    let result = recover(source);
+    assert_recovered(&result, source);
+    assert_eq!(diagnostic_messages(&result), [RECOVERY_DIAGNOSTIC, MULTIPLE_OUTPUTS]);
+    assert_eq!(multiple_output_label(&result), expect_span(source, "<div />"));
+
+    let tape = result.program.as_ref().expect("recovered Program");
+    let export = program_body(tape)[0].as_object().expect("export");
+    let function = object_field(tape, export, "declaration");
+    let block = object_field(tape, function, "body");
+    require_type(tape, block, "JSXCodeBlock");
+    let body = list_field(tape, block, "body");
+    assert_eq!(body.len(), 1);
+    let style = body[0].as_object().expect("style statement");
+    require_type(tape, style, "JSXStyleElement");
+    assert_eq!(span(tape, style), expect_span(source, "<style apply={a} />"));
+    let render = object_field(tape, block, "render");
+    require_type(tape, render, "JSXElement");
+    assert_eq!(span(tape, render), expect_span(source, "<div />"));
+}
+
+#[test]
+fn oxc_partial_recovery_keeps_the_multiple_output_diagnostic() {
+    let source = "function View() @{ const value; <style apply={a} /> <main /> }";
+    let result = recover(source);
+    assert_recovered(&result, source);
+    assert!(diagnostic_messages(&result).contains(&MULTIPLE_OUTPUTS));
+    assert_eq!(multiple_output_label(&result), expect_span(source, "<main />"));
+
+    let tape = result.program.as_ref().expect("recovered Program");
+    let function = program_body(tape)[0].as_object().expect("function");
+    let block = object_field(tape, function, "body");
+    require_type(tape, block, "JSXCodeBlock");
+    require_type(tape, object_field(tape, block, "render"), "JSXElement");
+}
+
+#[test]
+fn multiple_outputs_are_recovered_under_every_recovery_option() {
+    let source = "function View() @{ <style apply={a} /> <main /> }";
+    for recovery in [TsrxParseRecovery::None, TsrxParseRecovery::Editor] {
+        let result = parse_tsrx_with_options(
+            &TsrxParseRequest { source },
+            TsrxParseOptions { recovery, ..TsrxParseOptions::default() },
+        )
+        .expect("multiple outputs are result data");
+        assert_eq!(result.status, ParseCompleteness::Recovered, "{recovery:?}");
+        assert!(!result.completeness.contains(Completeness::COMPLETE), "{recovery:?}");
+        assert!(result.completeness.contains(Completeness::HAS_PROGRAM), "{recovery:?}");
+        assert_eq!(diagnostic_messages(&result), [MULTIPLE_OUTPUTS], "{recovery:?}");
+        assert_eq!(multiple_output_label(&result), expect_span(source, "<main />"));
+    }
 }

--- a/crates/tsrx_parser_engine/tests/style_elements.rs
+++ b/crates/tsrx_parser_engine/tests/style_elements.rs
@@ -120,11 +120,11 @@ fn distinguishes_empty_paired_self_closing_and_uppercase_style_elements() {
     require_type(tape, style, "JSXStyleElement");
     assert_eq!(
         field_names(tape, style),
-        ["type", "start", "end", "metadata", "children", "openingElement", "closingElement",]
+        ["type", "start", "end", "metadata", "children", "openingElement", "closingElement", "css",]
     );
     assert!(list_field(tape, style, "children").is_empty());
     assert_eq!(tape.scalar(field(tape, style, "closingElement")), Some("null"));
-    assert!(optional_field(tape, style, "css").is_none());
+    assert_eq!(scalar_field(tape, style, "css"), "\"\"");
     let opening = object_field(tape, style, "openingElement");
     assert_eq!(scalar_field(tape, opening, "selfClosing"), "true");
     assert_eq!(list_field(tape, opening, "attributes").len(), 2);
@@ -195,7 +195,8 @@ fn nested_style_attributes_keep_preorder_owners_and_independent_raw_payloads() {
     let inner = object_field(tape, container, "expression");
     for style in [outer, inner] {
         require_type(tape, style, "JSXStyleElement");
-        assert!(optional_field(tape, style, "css").is_none());
+        assert_eq!(scalar_field(tape, style, "css"), "\"\"");
+        assert!(list_field(tape, style, "children").is_empty());
     }
     assert_eq!(count_type(tape, "JSXStyleElement"), 2);
     assert_no_scaffold(tape);

--- a/crates/tsrx_parser_engine/tests/style_syntax.rs
+++ b/crates/tsrx_parser_engine/tests/style_syntax.rs
@@ -167,6 +167,8 @@ fn assert_style_host(tape: &FlatTape, element: RecordIndex, containers: usize) {
 
 fn assert_no_parser_errors(result: &TsrxParseResult) {
     assert_eq!(result.status, ParseCompleteness::Complete, "{:?}", result.errors);
+    assert!(result.completeness.contains(Completeness::COMPLETE));
+    assert!(!result.completeness.contains(Completeness::HAS_ERRORS));
     assert!(result.errors.is_empty(), "{:?}", result.errors);
 }
 
@@ -182,14 +184,16 @@ fn assert_multiple_outputs(result: &TsrxParseResult, start: u32, end: u32) {
             .map(|error| result.errors.string(error.message).unwrap_or("<missing>"))
             .collect::<Vec<_>>(),
     );
+    // The tree is recovered from a grammar error: never a complete parse, even under the
+    // default (non-editor) recovery option.
+    assert_eq!(result.status, ParseCompleteness::Recovered);
+    assert!(!result.completeness.contains(Completeness::COMPLETE));
     assert!(result.completeness.contains(Completeness::HAS_PROGRAM));
     assert!(result.completeness.contains(Completeness::HAS_ERRORS));
-    let error = result
-        .errors
-        .records()
-        .iter()
-        .find(|error| error.phase == DiagnosticPhase::Grammar)
-        .expect("multiple-outputs grammar diagnostic");
+    let records = result.errors.records();
+    assert_eq!(records.len(), 1, "exactly one diagnostic for one later output");
+    let error = &records[0];
+    assert_eq!(error.phase, DiagnosticPhase::Grammar);
     assert_eq!(result.errors.string(error.message), Some(MULTIPLE_OUTPUTS));
     let labels = result.errors.labels(error.labels).expect("grammar labels");
     assert_eq!(labels.len(), 1);
@@ -626,5 +630,33 @@ fn expression_child_style_does_not_steal_a_sibling_raw_style_owner() {
     let children = objects(&list_field(tape, render, "children"));
     assert_style_host(tape, children[0], 1);
     assert_style_body(tape, children[1], ".a{color:red}", &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn adjacent_non_style_jsx_in_code_block_is_multiple_outputs() {
+    let source = "function App() @{ <a /> <b /> }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 24, 29);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    assert_element(tape, body[0], "a");
+    assert_element(tape, object_field(tape, block, "render"), "b");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn authored_semicolon_between_outputs_is_still_multiple_outputs() {
+    let source = "function App() @{ <a />; <b /> }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 25, 30);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    assert_element(tape, body[0], "a");
+    assert_element(tape, object_field(tape, block, "render"), "b");
     assert_no_scaffold(tape);
 }

--- a/crates/tsrx_parser_engine/tests/style_syntax.rs
+++ b/crates/tsrx_parser_engine/tests/style_syntax.rs
@@ -1,0 +1,630 @@
+//! Parser cases from the released tsrx `style-syntax` table
+//! (`packages/tsrx/tests/utils/fixtures/style-syntax.js` on tsrx `main`).
+
+#[expect(
+    dead_code,
+    reason = "the shared test-support module is compiled into every integration binary and each one uses a different part of it"
+)]
+mod support;
+
+use support::{
+    assert_no_scaffold, field, list_field, object_field, one_object, optional_field, program_body,
+    require_type, scalar_field,
+};
+use tsrx_parser_engine::{TsrxParseRequest, TsrxParseResult, parse_tsrx};
+use tsrx_tape_schema::{
+    Completeness, DiagnosticPhase, FlatTape, ParseCompleteness, RecordIndex, ValueRef,
+};
+
+const CSS: &str = ".a { color: red; }";
+const MULTIPLE_OUTPUTS: &str =
+    "A code block renders a single node; wrap multiple nodes or text in a fragment '<>…</>'.";
+
+fn parse(source: &str) -> TsrxParseResult {
+    parse_tsrx(&TsrxParseRequest { source }).unwrap_or_else(|error| {
+        panic!("style-syntax fixture failed as an operational error: {error}")
+    })
+}
+
+fn tape_of(result: &TsrxParseResult) -> &FlatTape {
+    assert!(result.program.is_some(), "style-syntax fixture must keep a Program");
+    result.program()
+}
+
+fn objects(values: &[ValueRef]) -> Vec<RecordIndex> {
+    values.iter().map(|value| value.as_object().expect("list object")).collect()
+}
+
+fn component_block(tape: &FlatTape) -> RecordIndex {
+    let function = one_object(&program_body(tape));
+    require_type(tape, function, "FunctionDeclaration");
+    let block = object_field(tape, function, "body");
+    require_type(tape, block, "JSXCodeBlock");
+    block
+}
+
+fn returned(tape: &FlatTape) -> RecordIndex {
+    let function = one_object(&program_body(tape));
+    let body = object_field(tape, function, "body");
+    require_type(tape, body, "BlockStatement");
+    let statement = one_object(&list_field(tape, body, "body"));
+    require_type(tape, statement, "ReturnStatement");
+    object_field(tape, statement, "argument")
+}
+
+fn exported_init(tape: &FlatTape) -> RecordIndex {
+    let export = one_object(&program_body(tape));
+    require_type(tape, export, "ExportNamedDeclaration");
+    let declaration = object_field(tape, export, "declaration");
+    let declarator = one_object(&list_field(tape, declaration, "declarations"));
+    object_field(tape, declarator, "init")
+}
+
+fn code_block_body(tape: &FlatTape, block: RecordIndex) -> Vec<RecordIndex> {
+    objects(&list_field(tape, block, "body"))
+}
+
+fn nullable_object(tape: &FlatTape, object: RecordIndex, name: &str) -> Option<RecordIndex> {
+    let value = field(tape, object, name);
+    if tape.scalar(value) == Some("null") {
+        None
+    } else {
+        Some(value.as_object().expect("nullable object"))
+    }
+}
+
+fn block_statements(tape: &FlatTape, block: RecordIndex) -> Vec<RecordIndex> {
+    require_type(tape, block, "BlockStatement");
+    objects(&list_field(tape, block, "body"))
+}
+
+fn json_string(value: &str) -> String {
+    format!("\"{value}\"")
+}
+
+fn attribute_names(tape: &FlatTape, style: RecordIndex) -> Vec<String> {
+    let opening = object_field(tape, style, "openingElement");
+    list_field(tape, opening, "attributes")
+        .into_iter()
+        .map(|value| {
+            let attribute = value.as_object().expect("JSXAttribute");
+            let name = object_field(tape, attribute, "name");
+            scalar_field(tape, name, "name").trim_matches('"').to_string()
+        })
+        .collect()
+}
+
+fn apply_expression_type(tape: &FlatTape, style: RecordIndex) -> Option<String> {
+    let opening = object_field(tape, style, "openingElement");
+    for value in list_field(tape, opening, "attributes") {
+        let attribute = value.as_object().expect("JSXAttribute");
+        let name = object_field(tape, attribute, "name");
+        if scalar_field(tape, name, "name") != r#""apply""# {
+            continue;
+        }
+        let container = object_field(tape, attribute, "value");
+        require_type(tape, container, "JSXExpressionContainer");
+        let expression = object_field(tape, container, "expression");
+        return Some(scalar_field(tape, expression, "type").trim_matches('"').to_string());
+    }
+    None
+}
+
+fn assert_style_self(
+    tape: &FlatTape,
+    style: RecordIndex,
+    attributes: &[&str],
+    apply: Option<&str>,
+) {
+    require_type(tape, style, "JSXStyleElement");
+    let opening = object_field(tape, style, "openingElement");
+    assert_eq!(scalar_field(tape, opening, "selfClosing"), "true");
+    assert_eq!(attribute_names(tape, style), attributes);
+    assert_eq!(apply_expression_type(tape, style).as_deref(), apply);
+    assert!(list_field(tape, style, "children").is_empty());
+    assert_eq!(scalar_field(tape, style, "css"), "\"\"");
+    assert_eq!(tape.scalar(field(tape, style, "closingElement")), Some("null"));
+    let metadata = object_field(tape, style, "metadata");
+    assert!(optional_field(tape, metadata, "styleScopeHash").is_none());
+}
+
+fn assert_style_body(
+    tape: &FlatTape,
+    style: RecordIndex,
+    css: &str,
+    attributes: &[&str],
+    apply: Option<&str>,
+) {
+    require_type(tape, style, "JSXStyleElement");
+    let opening = object_field(tape, style, "openingElement");
+    assert_eq!(scalar_field(tape, opening, "selfClosing"), "false");
+    assert_eq!(attribute_names(tape, style), attributes);
+    assert_eq!(apply_expression_type(tape, style).as_deref(), apply);
+    let stylesheet = one_object(&list_field(tape, style, "children"));
+    require_type(tape, stylesheet, "StyleSheet");
+    assert_eq!(scalar_field(tape, style, "css"), json_string(css));
+    object_field(tape, style, "closingElement");
+}
+
+fn assert_element(tape: &FlatTape, element: RecordIndex, name: &str) {
+    require_type(tape, element, "JSXElement");
+    let opening = object_field(tape, element, "openingElement");
+    let identifier = object_field(tape, opening, "name");
+    assert_eq!(scalar_field(tape, identifier, "name"), json_string(name));
+}
+
+fn assert_style_host(tape: &FlatTape, element: RecordIndex, containers: usize) {
+    assert_element(tape, element, "style");
+    let children = objects(&list_field(tape, element, "children"));
+    let expression_children = children
+        .iter()
+        .copied()
+        .filter(|child| scalar_field(tape, *child, "type") == r#""JSXExpressionContainer""#)
+        .count();
+    assert_eq!(expression_children, containers);
+    assert!(optional_field(tape, element, "css").is_none());
+}
+
+fn assert_no_parser_errors(result: &TsrxParseResult) {
+    assert_eq!(result.status, ParseCompleteness::Complete, "{:?}", result.errors);
+    assert!(result.errors.is_empty(), "{:?}", result.errors);
+}
+
+fn assert_multiple_outputs(result: &TsrxParseResult, start: u32, end: u32) {
+    assert!(
+        result.program.is_some(),
+        "expected recovered program; status={:?} errors={:?}",
+        result.status,
+        result
+            .errors
+            .records()
+            .iter()
+            .map(|error| result.errors.string(error.message).unwrap_or("<missing>"))
+            .collect::<Vec<_>>(),
+    );
+    assert!(result.completeness.contains(Completeness::HAS_PROGRAM));
+    assert!(result.completeness.contains(Completeness::HAS_ERRORS));
+    let error = result
+        .errors
+        .records()
+        .iter()
+        .find(|error| error.phase == DiagnosticPhase::Grammar)
+        .expect("multiple-outputs grammar diagnostic");
+    assert_eq!(result.errors.string(error.message), Some(MULTIPLE_OUTPUTS));
+    let labels = result.errors.labels(error.labels).expect("grammar labels");
+    assert_eq!(labels.len(), 1);
+    assert_eq!(labels[0].span.start, start);
+    assert_eq!(labels[0].span.end, end);
+}
+
+#[test]
+fn self_closing_style_forms_keep_empty_css_and_attributes() {
+    let cases: [(&str, &[&str], Option<&str>); 5] = [
+        ("function App() @{ <><style /><div /></> }", &[], None),
+        ("function App() @{ <><style apply={theme} /><div /></> }", &["apply"], Some("Identifier")),
+        (
+            "function App() @{ <><style apply={[a, b]} /><div /></> }",
+            &["apply"],
+            Some("ArrayExpression"),
+        ),
+        (
+            "function App() @{ <><style apply={ns.dark} /><div /></> }",
+            &["apply"],
+            Some("MemberExpression"),
+        ),
+        (
+            "function App() @{ <><style ref={r} apply={theme} /><div /></> }",
+            &["ref", "apply"],
+            Some("Identifier"),
+        ),
+    ];
+    for (source, attributes, apply) in cases {
+        let result = parse(source);
+        assert_no_parser_errors(&result);
+        let tape = tape_of(&result);
+        let render = object_field(tape, component_block(tape), "render");
+        let style = objects(&list_field(tape, render, "children"))[0];
+        assert_style_self(tape, style, attributes, apply);
+        assert_no_scaffold(tape);
+    }
+}
+
+#[test]
+fn bodied_style_forms_keep_sheet_css_and_apply() {
+    let source = format!("function App() @{{ <><style apply={{t}}>{CSS}</style><div /></> }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let style = objects(&list_field(tape, render, "children"))[0];
+    assert_style_body(tape, style, CSS, &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+
+    let source = format!("function App() {{ return <style>{CSS}</style>; }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_body(tape, returned(tape), CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_before_output_in_code_block_is_multiple_outputs() {
+    let source = "function App() @{ const x = 1; <style apply={a} /> <div /> }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 51, 58);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 2);
+    require_type(tape, body[0], "VariableDeclaration");
+    assert_style_self(tape, body[1], &["apply"], Some("Identifier"));
+    assert_element(tape, object_field(tape, block, "render"), "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_after_output_in_code_block_is_multiple_outputs() {
+    let source = format!("function App() @{{ <div /> <style>{CSS}</style> }}");
+    let result = parse(&source);
+    assert_multiple_outputs(&result, 26, 59);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    assert_element(tape, body[0], "div");
+    assert_style_body(tape, object_field(tape, block, "render"), CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn lone_style_in_code_block_parses_as_render() {
+    let source = format!("function App() @{{ <style>{CSS}</style> }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    assert!(code_block_body(tape, block).is_empty());
+    assert_style_body(tape, object_field(tape, block, "render"), CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragment_is_the_valid_code_block_form_for_style_and_output() {
+    let source = "function App() @{ const x = 1; <><style apply={a} /><div /></> }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let block = component_block(tape);
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    require_type(tape, body[0], "VariableDeclaration");
+    let render = object_field(tape, block, "render");
+    require_type(tape, render, "JSXFragment");
+    let children = objects(&list_field(tape, render, "children"));
+    assert_style_self(tape, children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, children[1], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn nested_code_block_keeps_its_own_style_inside_a_fragment() {
+    let source = "function App() @{ <><style apply={a} /><div>@{ <><style apply={b} /><span /></> }</div></> }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let children = objects(&list_field(tape, render, "children"));
+    let div_children = objects(&list_field(tape, children[1], "children"));
+    let nested = div_children[0];
+    require_type(tape, nested, "JSXCodeBlock");
+    assert!(code_block_body(tape, nested).is_empty());
+    let nested_render = object_field(tape, nested, "render");
+    require_type(tape, nested_render, "JSXFragment");
+    let nested_children = objects(&list_field(tape, nested_render, "children"));
+    assert_style_self(tape, nested_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, nested_children[1], "span");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn assigned_code_block_keeps_theme_in_setup_and_applying_fragment() {
+    let source = format!(
+        "const something = @{{\n\tconst theme = <style>{CSS}</style>;\n\t<>\n\t\t<style apply={{theme}}>{CSS}</style>\n\t\t<div />\n\t</>\n}};"
+    );
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let declaration = one_object(&program_body(tape));
+    let declarator = one_object(&list_field(tape, declaration, "declarations"));
+    let block = object_field(tape, declarator, "init");
+    require_type(tape, block, "JSXCodeBlock");
+    let body = code_block_body(tape, block);
+    assert_eq!(body.len(), 1);
+    require_type(tape, body[0], "VariableDeclaration");
+    let render = object_field(tape, block, "render");
+    require_type(tape, render, "JSXFragment");
+    let children = objects(&list_field(tape, render, "children"));
+    assert_style_body(tape, children[0], CSS, &["apply"], Some("Identifier"));
+    assert_element(tape, children[1], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_beside_output_in_if_consequent_is_multiple_outputs() {
+    let source = "function App() @{ @if (ok) { <style apply={a} /> <b /> } }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 49, 54);
+    let tape = tape_of(&result);
+    let if_node = object_field(tape, component_block(tape), "render");
+    require_type(tape, if_node, "JSXIfExpression");
+    let consequent = block_statements(tape, object_field(tape, if_node, "consequent"));
+    assert_eq!(consequent.len(), 2);
+    assert_style_self(tape, consequent[0], &["apply"], Some("Identifier"));
+    assert_element(tape, consequent[1], "b");
+    assert!(nullable_object(tape, if_node, "alternate").is_none());
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn lone_style_in_if_consequent_parses() {
+    let source = "function App() @{ @if (ok) { <style apply={a} /> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let if_node = object_field(tape, component_block(tape), "render");
+    let consequent = block_statements(tape, object_field(tape, if_node, "consequent"));
+    assert_eq!(consequent.len(), 1);
+    assert_style_self(tape, consequent[0], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_if_and_else() {
+    let source = "function App() @{ @if (ok) { <><style apply={a} /><b /></> } @else { <><i /><style apply={c} /></> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let if_node = object_field(tape, component_block(tape), "render");
+    let consequent = block_statements(tape, object_field(tape, if_node, "consequent"));
+    require_type(tape, consequent[0], "JSXFragment");
+    let consequent_children = objects(&list_field(tape, consequent[0], "children"));
+    assert_style_self(tape, consequent_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, consequent_children[1], "b");
+    let alternate = block_statements(tape, object_field(tape, if_node, "alternate"));
+    require_type(tape, alternate[0], "JSXFragment");
+    let alternate_children = objects(&list_field(tape, alternate[0], "children"));
+    assert_element(tape, alternate_children[0], "i");
+    assert_style_self(tape, alternate_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_beside_output_in_for_body_is_multiple_outputs() {
+    let source = "function App() @{ @for (const x of xs) { <style apply={a} /> <b>{x}</b> } }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 61, 71);
+    let tape = tape_of(&result);
+    let for_node = object_field(tape, component_block(tape), "render");
+    require_type(tape, for_node, "JSXForExpression");
+    let body = block_statements(tape, object_field(tape, for_node, "body"));
+    assert_eq!(body.len(), 2);
+    assert_style_self(tape, body[0], &["apply"], Some("Identifier"));
+    assert_element(tape, body[1], "b");
+    assert!(nullable_object(tape, for_node, "empty").is_none());
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_for_and_empty() {
+    let source = "function App() @{ @for (const x of xs) { <><style apply={a} /><b>{x}</b></> } @empty { <><i /><style apply={c} /></> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let for_node = object_field(tape, component_block(tape), "render");
+    let body = block_statements(tape, object_field(tape, for_node, "body"));
+    let body_children = objects(&list_field(tape, body[0], "children"));
+    assert_style_self(tape, body_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, body_children[1], "b");
+    let empty = block_statements(tape, object_field(tape, for_node, "empty"));
+    let empty_children = objects(&list_field(tape, empty[0], "children"));
+    assert_element(tape, empty_children[0], "i");
+    assert_style_self(tape, empty_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_switch_cases() {
+    let source = "function App() @{ @switch (k) { @case 1: { <><style apply={a} /><b /></> } @default: { <><i /><style apply={c} /></> } } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let switch = object_field(tape, component_block(tape), "render");
+    require_type(tape, switch, "JSXSwitchExpression");
+    let cases = objects(&list_field(tape, switch, "cases"));
+    assert_eq!(cases.len(), 2);
+    require_type(tape, object_field(tape, cases[0], "test"), "Literal");
+    assert_eq!(tape.scalar(field(tape, cases[1], "test")), Some("null"));
+    let first = objects(&list_field(tape, cases[0], "consequent"));
+    let first_children = objects(&list_field(tape, first[0], "children"));
+    assert_style_self(tape, first_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, first_children[1], "b");
+    let default = objects(&list_field(tape, cases[1], "consequent"));
+    let default_children = objects(&list_field(tape, default[0], "children"));
+    assert_element(tape, default_children[0], "i");
+    assert_style_self(tape, default_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn style_beside_output_in_try_block_is_multiple_outputs() {
+    let source = "function App() @{ @try { <style apply={a} /> <b /> } @catch (e) { <i /> } }";
+    let result = parse(source);
+    assert_multiple_outputs(&result, 45, 50);
+    let tape = tape_of(&result);
+    let try_node = object_field(tape, component_block(tape), "render");
+    require_type(tape, try_node, "JSXTryExpression");
+    let block = block_statements(tape, object_field(tape, try_node, "block"));
+    assert_style_self(tape, block[0], &["apply"], Some("Identifier"));
+    assert_element(tape, block[1], "b");
+    assert!(nullable_object(tape, try_node, "pending").is_none());
+    let handler = object_field(tape, try_node, "handler");
+    require_type(tape, handler, "CatchClause");
+    let handler_body = block_statements(tape, object_field(tape, handler, "body"));
+    assert_element(tape, handler_body[0], "i");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn fragments_hold_style_and_output_inside_try_pending_and_catch() {
+    let source = "function App() @{ @try { <><style apply={a} /><b /></> } @pending { <><style apply={p} /><u /></> } @catch (e) { <><i /><style apply={c} /></> } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let try_node = object_field(tape, component_block(tape), "render");
+    let block_children = objects(&list_field(
+        tape,
+        block_statements(tape, object_field(tape, try_node, "block"))[0],
+        "children",
+    ));
+    assert_style_self(tape, block_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, block_children[1], "b");
+    let pending_children = objects(&list_field(
+        tape,
+        block_statements(tape, object_field(tape, try_node, "pending"))[0],
+        "children",
+    ));
+    assert_style_self(tape, pending_children[0], &["apply"], Some("Identifier"));
+    assert_element(tape, pending_children[1], "u");
+    let handler = object_field(tape, try_node, "handler");
+    let handler_children = objects(&list_field(
+        tape,
+        block_statements(tape, object_field(tape, handler, "body"))[0],
+        "children",
+    ));
+    assert_element(tape, handler_children[0], "i");
+    assert_style_self(tape, handler_children[1], &["apply"], Some("Identifier"));
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn sibling_style_blocks_live_in_fragment_children() {
+    let source = format!(
+        "function App() {{ return <><style apply={{a}} /><style>{CSS}</style><div /></>; }}"
+    );
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let fragment = returned(tape);
+    require_type(tape, fragment, "JSXFragment");
+    let children = objects(&list_field(tape, fragment, "children"));
+    assert_style_self(tape, children[0], &["apply"], Some("Identifier"));
+    assert_style_body(tape, children[1], CSS, &[], None);
+    assert_element(tape, children[2], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn expression_child_style_is_an_ordinary_jsx_element() {
+    let result = parse("function App() { return <style>{css}</style>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_host(tape, returned(tape), 1);
+    assert_no_scaffold(tape);
+
+    let result = parse("function App() @{ <section><style>{css}</style><div /></section> }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let section = object_field(tape, component_block(tape), "render");
+    assert_element(tape, section, "section");
+    let children = objects(&list_field(tape, section, "children"));
+    assert_style_host(tape, children[0], 1);
+    assert_element(tape, children[1], "div");
+    assert_no_scaffold(tape);
+
+    let result = parse("function App() { return <section><style>\n\t{css}\n</style></section>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let section = returned(tape);
+    let children = objects(&list_field(tape, section, "children"));
+    assert_style_host(tape, children[0], 1);
+    assert_no_scaffold(tape);
+
+    let result = parse("function App() { return <style>{reset}{theme}</style>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_host(tape, returned(tape), 2);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn brace_inside_css_text_still_parses_as_a_bodied_style() {
+    let result = parse("function App() @{ <><style>.a{color:red}</style><div /></> }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let style = objects(&list_field(tape, render, "children"))[0];
+    assert_style_body(tape, style, ".a{color:red}", &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn module_scope_style_forms_parse() {
+    let result = parse("export const theme = <style apply={[a, b]} />;");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    assert_style_self(tape, exported_init(tape), &["apply"], Some("ArrayExpression"));
+    assert_no_scaffold(tape);
+
+    let source = format!("<style>{CSS}</style>;\nexport function App() {{ return <div />; }}");
+    let result = parse(&source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let first = program_body(tape)[0].as_object().expect("bare style");
+    assert_style_body(tape, first, CSS, &[], None);
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn head_style_has_no_scope_hash_on_the_tape() {
+    let result =
+        parse("function App() { return <head><style>body { margin: 0; }</style></head>; }");
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let head = returned(tape);
+    let style = objects(&list_field(tape, head, "children"))[0];
+    assert_style_body(tape, style, "body { margin: 0; }", &[], None);
+    let metadata = object_field(tape, style, "metadata");
+    assert!(optional_field(tape, metadata, "styleScopeHash").is_none());
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn raw_style_in_a_switch_case_does_not_break_the_following_case() {
+    let source = "function App() @{ @switch (k) { @case 1: { <style>.a{color:red}</style> } @case 2: { <div /> } } }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let switch = object_field(tape, component_block(tape), "render");
+    require_type(tape, switch, "JSXSwitchExpression");
+    let cases = objects(&list_field(tape, switch, "cases"));
+    assert_eq!(cases.len(), 2);
+    let first = objects(&list_field(tape, cases[0], "consequent"));
+    assert_style_body(tape, first[0], ".a{color:red}", &[], None);
+    let second = objects(&list_field(tape, cases[1], "consequent"));
+    assert_element(tape, second[0], "div");
+    assert_no_scaffold(tape);
+}
+
+#[test]
+fn expression_child_style_does_not_steal_a_sibling_raw_style_owner() {
+    let source = "function App() @{ <><style>{css}</style><style>.a{color:red}</style></> }";
+    let result = parse(source);
+    assert_no_parser_errors(&result);
+    let tape = tape_of(&result);
+    let render = object_field(tape, component_block(tape), "render");
+    let children = objects(&list_field(tape, render, "children"));
+    assert_style_host(tape, children[0], 1);
+    assert_style_body(tape, children[1], ".a{color:red}", &[], None);
+    assert_no_scaffold(tape);
+}

--- a/crates/tsrx_parser_engine/tests/utf16_bridge.rs
+++ b/crates/tsrx_parser_engine/tests/utf16_bridge.rs
@@ -923,7 +923,7 @@ fn style_payload_boundaries_ignore_quoted_greater_than_and_self_closing_attribut
                     == Some(r#""JSXStyleElement""#)
             })
             .expect("self-closing style");
-        assert!(result.program().field_index(style, "css").is_none());
+        assert_eq!(scalar_field(result.program(), style, "css"), "\"\"");
     }
 }
 

--- a/crates/tsrx_parser_engine/tests/utf16_bridge.rs
+++ b/crates/tsrx_parser_engine/tests/utf16_bridge.rs
@@ -1142,3 +1142,27 @@ fn release_dense_module_and_diagnostic_scaling_campaign_is_linear() {
     assert_linear_scaling("module", &counts, &module_medians);
     assert_linear_scaling("diagnostic", &counts, &diagnostic_medians);
 }
+
+#[test]
+fn multiple_output_diagnostics_use_original_utf16_units() {
+    let source = "function App() @{ <a title=\"😀\" /> <b /> }";
+    let units = utf16(source);
+    assert_eq!(units.len(), 42);
+    assert_eq!(source.len(), 44);
+
+    let result = parse_units(&units);
+    assert_eq!(result.status, ParseCompleteness::Recovered);
+    assert_eq!(result.coordinate_domain, CoordinateDomain::OriginalUtf16Units);
+    let tape = result.program();
+    let block = object_at(tape, "JSXCodeBlock", (15, 42));
+    let render = object_field(tape, block, "render");
+    assert_eq!(span(tape, render), (35, 40));
+    object_at(tape, "JSXElement", (18, 34));
+
+    let records = result.errors.records();
+    assert_eq!(records.len(), 1);
+    let labels = result.errors.labels(records[0].labels).expect("labels");
+    assert_eq!(labels.len(), 1);
+    assert_eq!((labels[0].span.start, labels[0].span.end), (35, 40));
+    assert_no_private_markers_in_diagnostics(&result.errors);
+}

--- a/crates/tsrx_syntax/src/parser_projection/builder.rs
+++ b/crates/tsrx_syntax/src/parser_projection/builder.rs
@@ -532,8 +532,10 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
-    /// Writes the `;` that a line-leading markup opening implies, immediately before the opening
-    /// so the authored `<` is still copied verbatim and every authored byte keeps its segment.
+    /// Writes the `;` that a new statement-level markup opening implies, immediately before the
+    /// opening so the authored `<` is still copied verbatim and every authored byte keeps its
+    /// segment. Used for line-leading markup and for a sibling JSX statement after another JSX
+    /// tree.
     pub(super) fn statement_boundary(&mut self, boundary: u32) -> Result<(), ProjectionError> {
         let offset = *self
             .overlay

--- a/crates/tsrx_syntax/src/parser_scanner/jsx.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/jsx.rs
@@ -210,7 +210,16 @@ impl Scanner<'_> {
             return Ok(index);
         }
 
-        if style {
+        // `<style>{expr}</style>` is ordinary JSX: the first non-whitespace child is `{`.
+        let raw_style = style && !first_non_whitespace_is_open_brace(self.bytes, index);
+        if style
+            && !raw_style
+            && let Some(owner) = parser_style_owner
+        {
+            self.abandon_reserved_style(owner)?;
+        }
+
+        if raw_style {
             let Some(relative_close) = find_bytes(&self.bytes[index..], b"</style>") else {
                 return Err(ProjectionError::UnterminatedSyntax {
                     offset: to_u32(start)?,
@@ -519,6 +528,21 @@ impl Scanner<'_> {
         })
     }
 
+    fn abandon_reserved_style(&mut self, owner: u32) -> Result<(), ProjectionError> {
+        let index = usize::try_from(owner).map_err(|_| ProjectionError::StructuralMismatch)?;
+        if index >= self.style_blocks.len() {
+            return Err(ProjectionError::StructuralMismatch);
+        }
+        self.style_blocks.remove(index);
+        for token in &mut self.embedded_tokens {
+            if token.kind == EmbeddedKind::StyleContent && token.owner > owner {
+                token.owner =
+                    token.owner.checked_sub(1).ok_or(ProjectionError::StructuralMismatch)?;
+            }
+        }
+        Ok(())
+    }
+
     fn jsx_shorthand_identifier(&self, start: usize, end: usize) -> Option<ByteSpan> {
         let identifier_start = start.checked_add(1)?;
         let identifier_end = end.checked_sub(1)?;
@@ -551,6 +575,14 @@ impl Scanner<'_> {
         self.identifier_start_width(index + 1).is_some()
             || self.bytes.get(index + 1).is_some_and(|byte| matches!(byte, b'>' | b'{'))
     }
+}
+
+fn first_non_whitespace_is_open_brace(bytes: &[u8], start: usize) -> bool {
+    let mut index = start;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    bytes.get(index) == Some(&b'{')
 }
 
 fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {

--- a/crates/tsrx_syntax/src/parser_scanner/region.rs
+++ b/crates/tsrx_syntax/src/parser_scanner/region.rs
@@ -112,9 +112,11 @@ impl Scanner<'_> {
                 {
                     let checkpoint = self.checkpoint();
                     let committed = self.committed_jsx_opening(index);
-                    if !can_start_jsx {
-                        // Only the line-leading rule admitted this opening, so the legal-TSX lane
-                        // needs an explicit `;` where TSRX read a statement boundary.
+                    if !can_start_jsx || !can_start_expression {
+                        // Legal TSX cannot place two JSX trees in one expression. Insert `;`
+                        // when this opening starts a new statement: either the line-leading
+                        // exception (`!can_start_jsx`) or a sibling after a completed JSX
+                        // statement (`!can_start_expression`).
                         self.statement_boundaries.push(to_u32(index)?);
                     }
                     match self.scan_jsx_element(index) {

--- a/crates/tsrx_syntax/src/projection/builder.rs
+++ b/crates/tsrx_syntax/src/projection/builder.rs
@@ -578,8 +578,10 @@ impl<'a> Builder<'a> {
         Ok(())
     }
 
-    /// Writes the `;` that a line-leading markup opening implies, immediately before the opening
-    /// so the authored `<` is still copied verbatim and every authored byte keeps its segment.
+    /// Writes the `;` that a new statement-level markup opening implies, immediately before the
+    /// opening so the authored `<` is still copied verbatim and every authored byte keeps its
+    /// segment. Used for line-leading markup and for a sibling JSX statement after another JSX
+    /// tree.
     fn statement_boundary(&mut self, boundary: u32) -> Result<(), ProjectionError> {
         let offset = *self
             .overlay

--- a/crates/tsrx_syntax/src/scanner/jsx.rs
+++ b/crates/tsrx_syntax/src/scanner/jsx.rs
@@ -134,7 +134,8 @@ impl Scanner<'_> {
             return Ok(index);
         }
 
-        if style {
+        // `<style>{expr}</style>` is ordinary JSX: the first non-whitespace child is `{`.
+        if style && !first_non_whitespace_is_open_brace(self.bytes, index) {
             let Some(relative_close) = find_bytes(&self.bytes[index..], b"</style>") else {
                 return Err(ProjectionError::UnterminatedSyntax {
                     offset: to_u32(start)?,
@@ -583,4 +584,12 @@ impl Scanner<'_> {
         }
         Ok(())
     }
+}
+
+fn first_non_whitespace_is_open_brace(bytes: &[u8], start: usize) -> bool {
+    let mut index = start;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    bytes.get(index) == Some(&b'{')
 }

--- a/crates/tsrx_syntax/src/scanner/mod.rs
+++ b/crates/tsrx_syntax/src/scanner/mod.rs
@@ -159,9 +159,11 @@ impl<'a> Scanner<'a> {
                 {
                     let checkpoint = self.checkpoint();
                     let committed = self.committed_jsx_opening(index);
-                    if !can_start_jsx {
-                        // Only the line-leading rule admitted this opening, so the legal-TSX lane
-                        // needs an explicit `;` where TSRX read a statement boundary.
+                    if !can_start_jsx || !can_start_expression {
+                        // Legal TSX cannot place two JSX trees in one expression. Insert `;`
+                        // when this opening starts a new statement: either the line-leading
+                        // exception (`!can_start_jsx`) or a sibling after a completed JSX
+                        // statement (`!can_start_expression`).
                         self.statement_boundaries.push(to_u32(index)?);
                     }
                     match self.scan_jsx_element(index) {

--- a/packages/toolchain/dist/tsrx-core-compat/facade.js
+++ b/packages/toolchain/dist/tsrx-core-compat/facade.js
@@ -949,7 +949,7 @@ function materializeCompatibilityProgram(program, source, filename, loose, posit
 			if (value.pending != null && value.pendingKeyword == null) value.pendingKeyword = keywordSpan(source, "@pending", value.block?.end ?? value.start, value.pending?.end ?? value.end, positionAt);
 			if (value.handler != null && value.handlerKeyword == null) value.handlerKeyword = keywordSpan(source, "@catch", value.pending?.end ?? value.block?.end ?? value.start, value.handler?.end ?? value.end, positionAt);
 		}
-		if (value.type === "JSXStyleElement" && typeof value.css === "string") {
+		if (value.type === "JSXStyleElement" && typeof value.css === "string" && value.openingElement?.selfClosing !== true) {
 			const style = parse_style(value.css, {
 				filename,
 				line: value.openingElement?.loc?.start?.line ?? value.loc?.start?.line ?? 1,

--- a/packages/tsrx-core-compat/dist/facade.js
+++ b/packages/tsrx-core-compat/dist/facade.js
@@ -949,7 +949,7 @@ function materializeCompatibilityProgram(program, source, filename, loose, posit
 			if (value.pending != null && value.pendingKeyword == null) value.pendingKeyword = keywordSpan(source, "@pending", value.block?.end ?? value.start, value.pending?.end ?? value.end, positionAt);
 			if (value.handler != null && value.handlerKeyword == null) value.handlerKeyword = keywordSpan(source, "@catch", value.pending?.end ?? value.block?.end ?? value.start, value.handler?.end ?? value.end, positionAt);
 		}
-		if (value.type === "JSXStyleElement" && typeof value.css === "string") {
+		if (value.type === "JSXStyleElement" && typeof value.css === "string" && value.openingElement?.selfClosing !== true) {
 			const style = parse_style(value.css, {
 				filename,
 				line: value.openingElement?.loc?.start?.line ?? value.loc?.start?.line ?? 1,

--- a/packages/tsrx-core-compat/src/facade.ts
+++ b/packages/tsrx-core-compat/src/facade.ts
@@ -1268,7 +1268,11 @@ function materializeCompatibilityProgram(program, source, filename, loose, posit
       }
     }
 
-    if (value.type === "JSXStyleElement" && typeof value.css === "string") {
+    if (
+      value.type === "JSXStyleElement" &&
+      typeof value.css === "string" &&
+      value.openingElement?.selfClosing !== true
+    ) {
       const style = parse_style(
         value.css,
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refreshed port of the released `@tsrx/core` scoped-`<style>` parser into this repo’s reconstruct path, as Leon asked for on closed #68.

This supersedes [#68](https://github.com/tsrx-org/oxc/pull/68). That PR was opened against `feat/scoped-styles-apply` before RFC tsrx-org/tsrx#53 landed on tsrx `main` (2026-09-05). This branch is rebuilt from current oxc `main` against the **released** table:

- tsrx `packages/tsrx/tests/utils/fixtures/style-syntax.js` (`@tsrx/core/test-harness/style-syntax`)
- replayed by `packages/tsrx/tests/utils/parser.test.js` (`STYLE_SYNTAX_CASES`)
- tracked by [tsrx-org/tsrx#46](https://github.com/tsrx-org/tsrx/issues/46)

Work is only in **tsrx-org/oxc** (not the archived `oxc-tsrx` package).

## Behaviors (current tsrx `main`, amendment A1)

- Self-closing `<style … />` is a `JSXStyleElement` with `selfClosing: true`, `children: []`, `css: ''`, attributes preserved, and no `styleScopeHash`. The JS facade skips `parse_style` / hash on self-closing nodes.
- A `<style>` block is an output node. Beside another output in `@{…}` / `@if` / `@for` / `@try` it is the ordinary multiple-outputs diagnostic on the later node (recovered tree: last output becomes `render` in code blocks; both stay in control-flow clause lists). Lone `<style>` as the only output parses (analyzer diagnostic, not parser). `@switch` case bodies still do not report multiple outputs.
- Adjacent statement-level JSX is projected with a synthetic `;` so OXC can parse it; reconstruct strips that semicolon and keeps both outputs.
- `<style>{expr}</style>` is a plain `JSXElement` when the first non-whitespace child after the opening tag is `{`.
- Raw-text `</style>` restores scanner context; a following `@case` still parses.

## Tests

`crates/tsrx_parser_engine/tests/style_syntax.rs` mirrors the current tsrx style-syntax table against the authored tape (no facade hash). Existing self-closing style assertions now expect `css: ''`.

## What changed vs #68

The required parser shapes did **not** drift after A1: the released table still treats `<style>` as an output node (D3 sibling relaxation stays reverted) and still classifies `<style>{expr}</style>` as ordinary JSX. This PR rebuilds that port on current oxc `main` instead of reopening the deleted #68 branch.

`@leonidaz` — please review. `@trueadm` if you have a chance as well. `@thejackshelton` FYI from the #68 close thread.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5184e07-9ea7-4fa0-bae9-ea001934187d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5184e07-9ea7-4fa0-bae9-ea001934187d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

