### PR TITLE
chore(release): count the second @tsrx/oxc pin in two tests

### DIFF
--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -273,7 +273,7 @@ const textTargets: any[] = [
   },
 
   { file: "tests/editor/official-oxc-toolchain-run.mjs", slots: [[DEP, 4]] },
-  { file: "tests/editor/oxlint-multiplexer.test.mjs", slots: [[DEP, 1]] },
+  { file: "tests/editor/oxlint-multiplexer.test.mjs", slots: [[DEP, 2]] },
   { file: "tests/editor/package.test.mjs", slots: [[ASSERT_DEP, 1]] },
   { file: "tests/editor/vscode-run.mjs", slots: [[DEP, 1]] },
   {
@@ -318,7 +318,7 @@ const textTargets: any[] = [
   {
     file: "tests/packaging/toolchain-compat.test.mjs",
     slots: [
-      [DEP, 1],
+      [DEP, 2],
       [PROVIDER_VERSION, 1],
     ],
   },


### PR DESCRIPTION
The Manual Release dry run for 0.10.0 failed at the version-sync gate: two test files carry a second literal @tsrx/oxc pin after #71. Declares them so the cut propagates both. `node scripts/sync-version.ts --check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates declared slot counts in the version-sync script; no runtime or test logic changes.
> 
> **Overview**
> Fixes the **version-sync gate** (`node scripts/sync-version.ts --check`) after two packaging/editor tests gained a **second** literal `"@tsrx/oxc"` dependency pin (post-#71).
> 
> In `scripts/sync-version.ts`, the `DEP` slot counts for `tests/editor/oxlint-multiplexer.test.mjs` and `tests/packaging/toolchain-compat.test.mjs` are bumped from **1 → 2**, so release cuts rewrite **both** pins instead of failing exhaustiveness checks or leaving one stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3cdb0db4f309a5bfe88dd3f15b2f61f827ea0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->