### PR TITLE
fix(toolchain): gitignore-aware .tsrx discovery and a file channel for long file lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
 name = "oxc_tsrx_cli"
 version = "0.10.0"
 dependencies = [
+ "ignore",
  "oxc_adapter",
  "rayon",
  "serde_json",

--- a/crates/oxc_tsrx_cli/Cargo.toml
+++ b/crates/oxc_tsrx_cli/Cargo.toml
@@ -13,6 +13,7 @@ name = "oxc-tsrx"
 path = "src/main.rs"
 
 [dependencies]
+ignore = "0.4.25"
 oxc_adapter = { path = "../oxc_adapter" }
 rayon = "1.11.0"
 serde_json = "1.0.150"

--- a/crates/oxc_tsrx_cli/src/fmt.rs
+++ b/crates/oxc_tsrx_cli/src/fmt.rs
@@ -25,6 +25,11 @@ Mode options:
     --stdin-filepath=PATH   Read stdin, infer the source type, and print formatted source
     -c, --config=PATH       Use an explicit JSON/JSONC Oxfmt configuration
     --threads=INT           Worker count for explicit multi-file formatting
+    --paths-file=PATH       Read more paths from PATH, one per line, so a list
+                            larger than the host's argument limit still arrives
+    --discover              Print {files:[...]}: every .tsrx file under the named
+                            paths, walked with .gitignore honoured and node_modules
+                            skipped, exactly as the drop-in oxfmt discovers them
     -h, --help              Show this help
     -V, --version           Show the package and canonical OXC revision
 
@@ -149,6 +154,10 @@ fn run(arguments: impl Iterator<Item = String>) -> Result<u8, String> {
     }
     if arguments.iter().any(|argument| matches!(argument.as_str(), "-V" | "--version")) {
         println!("oxc-tsrx-fmt {} (OXC {})", env!("CARGO_PKG_VERSION"), tsrx_format::OXC_REVISION);
+        return Ok(0);
+    }
+    if arguments.iter().any(|argument| argument == "--discover") {
+        println!("{}", crate::paths::run_discover(&arguments)?);
         return Ok(0);
     }
     let args = parse_args(arguments.into_iter())?;
@@ -278,6 +287,10 @@ fn parse_args(mut arguments: impl Iterator<Item = String>) -> Result<Args, Strin
                 let value = arguments.next().ok_or("--config-base requires a path")?;
                 set_once_path(&mut config_base, value, "--config-base")?;
             }
+            "--paths-file" => {
+                let value = arguments.next().ok_or("--paths-file requires a path")?;
+                files.extend(crate::paths::read_paths_file(Path::new(&value))?);
+            }
             "-h" | "--help" | "-V" | "--version" => unreachable!("handled before parsing"),
             value if value.starts_with("--stdin-filepath=") => {
                 let path = value.trim_start_matches("--stdin-filepath=");
@@ -302,6 +315,11 @@ fn parse_args(mut arguments: impl Iterator<Item = String>) -> Result<Args, Strin
                     return Err("--config-base requires a path".to_string());
                 }
                 set_once_path(&mut config_base, path.to_string(), "--config-base")?;
+            }
+            value if value.starts_with("--paths-file=") => {
+                files.extend(crate::paths::read_paths_file(Path::new(
+                    value.trim_start_matches("--paths-file="),
+                ))?);
             }
             value if value.starts_with('-') => {
                 return Err(format!("unsupported option: {value}"));

--- a/crates/oxc_tsrx_cli/src/lint.rs
+++ b/crates/oxc_tsrx_cli/src/lint.rs
@@ -15,6 +15,7 @@ const HELP: &str = "\
 OXC for TSRX linter
 
 Usage: oxc-tsrx-lint [--fix] [--format=json] [-D RULE] PATH...
+       oxc-tsrx-lint --discover PATH...
 
 Options:
     --fix                   Apply the safe fixes and write the changed files
@@ -25,6 +26,11 @@ Options:
     --type-aware            Enable the type-aware rules
     --type-check            Enable the type-aware rules and type checking
     --format json           Output format; json is the only value, and the default
+    --paths-file PATH       Read more paths from PATH, one per line, so a list
+                            larger than the host's argument limit still arrives
+    --discover              Print {files:[...]}: every .tsrx file under the named
+                            paths, walked with .gitignore honoured and node_modules
+                            skipped, exactly as the drop-in oxlint discovers them
     -h, --help              Show this help
     -V, --version           Show the package and canonical OXC revision
 
@@ -91,6 +97,11 @@ fn run(arguments: impl Iterator<Item = String>) -> Result<u8, String> {
     // arrives in the stdin request, so it is answered before argument parsing.
     if arguments.iter().any(|argument| argument == MAP_PLUGIN_DIAGNOSTICS) {
         return map_plugin_diagnostics();
+    }
+    // Discovery answers before parsing too: it takes paths and a paths file and nothing else.
+    if arguments.iter().any(|argument| argument == "--discover") {
+        println!("{}", crate::paths::run_discover(&arguments)?);
+        return Ok(0);
     }
     // The projection flag is answered after parsing, but the parser has never heard of it, so it
     // is filtered out on the way in rather than taught as an option that takes no value.
@@ -385,12 +396,21 @@ fn parse_arguments(mut arguments: impl Iterator<Item = String>) -> Result<Parsed
                     Some(PathBuf::from(arguments.next().ok_or("--config-base requires a path")?));
             }
             "--fix" => fix = true,
+            "--paths-file" => {
+                let path = arguments.next().ok_or("--paths-file requires a path")?;
+                files.extend(crate::paths::read_paths_file(Path::new(&path))?);
+            }
             "--type-aware" => type_aware = true,
             "--type-check" => {
                 type_aware = true;
                 type_check = true;
             }
             "-h" | "--help" | "-V" | "--version" => unreachable!("handled before parsing"),
+            value if value.starts_with("--paths-file=") => {
+                files.extend(crate::paths::read_paths_file(Path::new(
+                    value.trim_start_matches("--paths-file="),
+                ))?);
+            }
             value if value.starts_with('-') => {
                 return Err(format!("unsupported option in the current native CLI: {value}"));
             }

--- a/crates/oxc_tsrx_cli/src/main.rs
+++ b/crates/oxc_tsrx_cli/src/main.rs
@@ -26,6 +26,7 @@
 mod fmt;
 mod lint;
 mod lsp;
+mod paths;
 
 use std::{env, path::Path, process::ExitCode};
 

--- a/crates/oxc_tsrx_cli/src/paths.rs
+++ b/crates/oxc_tsrx_cli/src/paths.rs
@@ -1,0 +1,192 @@
+//! The two channels that carry a file list into a leaf without going through
+//! `argv`, and the discovery walk that produces one.
+//!
+//! The drop-in `oxlint`/`oxfmt` commands discover `.tsrx` files in Node and hand
+//! the list to these leaves. A list on the command line has two failure modes
+//! that only show up on real repositories: it exceeds the host's argument limit
+//! (`E2BIG` on macOS and Linux past about a megabyte, a 32 KiB command line on
+//! Windows, which a few hundred paths reach), and it is only as good as the
+//! walk that produced it. Discovery that skipped nothing but `node_modules`
+//! handed a monorepo's gitignored worktree copies to the leaf by the hundred
+//! thousand. So the walk lives here, on the same `ignore` crate canonical Oxlint
+//! walks with, and the list travels in a file.
+
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Reads a newline-separated path list. Empty lines are skipped and a trailing
+/// carriage return is trimmed, so a list written on Windows reads the same.
+pub(crate) fn read_paths_file(path: &Path) -> Result<Vec<PathBuf>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("unable to read --paths-file {}: {error}", path.display()))?;
+    Ok(content
+        .lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect())
+}
+
+fn is_tsrx(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "tsrx")
+}
+
+fn absolute(path: &Path) -> Result<PathBuf, String> {
+    std::path::absolute(path).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+/// Every `.tsrx` file under `roots`, absolute and sorted. A root that is a file
+/// is kept as named, exactly as canonical Oxlint keeps a file it was pointed at.
+/// A root that is a directory is walked with `.gitignore`, `.ignore`, and the
+/// repository's exclude file honoured, whether or not a `.git` directory exists,
+/// which is canonical Oxlint's behaviour too; `node_modules` and `.git` are
+/// never entered.
+pub(crate) fn discover_tsrx(roots: &[PathBuf]) -> Result<Vec<PathBuf>, String> {
+    let mut files = BTreeSet::new();
+    let mut directories = Vec::new();
+    for root in roots {
+        let metadata = fs::metadata(root)
+            .map_err(|error| format!("cannot discover under {}: {error}", root.display()))?;
+        if metadata.is_dir() {
+            directories.push(root.clone());
+        } else if metadata.is_file() && is_tsrx(root) {
+            files.insert(absolute(root)?);
+        }
+    }
+    if let Some((first, rest)) = directories.split_first() {
+        let mut builder = ignore::WalkBuilder::new(first);
+        for directory in rest {
+            builder.add(directory);
+        }
+        builder
+            .hidden(false)
+            .follow_links(false)
+            .require_git(false)
+            .git_ignore(true)
+            .git_exclude(true)
+            .git_global(true)
+            .ignore(true)
+            .filter_entry(|entry| {
+                let name = entry.file_name();
+                name != "node_modules" && name != ".git"
+            });
+        for entry in builder.build() {
+            let entry = entry.map_err(|error| format!("discovery failed: {error}"))?;
+            if entry.file_type().is_some_and(|kind| !kind.is_dir()) && is_tsrx(entry.path()) {
+                files.insert(absolute(entry.path())?);
+            }
+        }
+    }
+    Ok(files.into_iter().collect())
+}
+
+/// The `--discover` mode shared by the leaves: print `{"files":[...]}` for the
+/// roots named on the command line or in a `--paths-file`, and nothing else.
+pub(crate) fn run_discover(arguments: &[String]) -> Result<String, String> {
+    let mut roots = Vec::new();
+    let mut iterator = arguments.iter();
+    while let Some(argument) = iterator.next() {
+        match argument.as_str() {
+            "--discover" => {}
+            "--paths-file" => {
+                let path = iterator.next().ok_or("--paths-file requires a path")?;
+                roots.extend(read_paths_file(Path::new(path))?);
+            }
+            value if value.starts_with("--paths-file=") => {
+                roots
+                    .extend(read_paths_file(Path::new(value.trim_start_matches("--paths-file=")))?);
+            }
+            value if value.starts_with('-') => {
+                return Err(format!("--discover takes paths only, not {value}"));
+            }
+            value => roots.push(PathBuf::from(value)),
+        }
+    }
+    if roots.is_empty() {
+        return Err("--discover requires at least one path".to_string());
+    }
+    let files = discover_tsrx(&roots)?
+        .into_iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    serde_json::to_string(&serde_json::json!({ "files": files }))
+        .map_err(|error| format!("unable to encode the discovery report: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, fs, path::PathBuf, sync::atomic::AtomicU32, sync::atomic::Ordering};
+
+    use super::{discover_tsrx, read_paths_file, run_discover};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn scratch() -> PathBuf {
+        let directory = env::temp_dir().join(format!(
+            "oxc-tsrx-paths-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&directory).unwrap();
+        directory
+    }
+
+    #[test]
+    fn a_paths_file_lists_one_path_per_line_and_tolerates_windows_line_ends() {
+        let directory = scratch();
+        let list = directory.join("paths.txt");
+        fs::write(&list, "src/a.tsrx\r\n\nsrc/b.tsrx\n").unwrap();
+        assert_eq!(
+            read_paths_file(&list).unwrap(),
+            vec![PathBuf::from("src/a.tsrx"), PathBuf::from("src/b.tsrx")]
+        );
+        let missing = read_paths_file(&directory.join("absent.txt")).unwrap_err();
+        assert!(missing.contains("--paths-file"), "{missing}");
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn discovery_honours_gitignore_without_a_git_directory_and_keeps_named_files() {
+        let directory = scratch();
+        fs::create_dir_all(directory.join("src/deep")).unwrap();
+        fs::create_dir_all(directory.join("ignored/copy")).unwrap();
+        fs::create_dir_all(directory.join("node_modules/dep")).unwrap();
+        fs::create_dir_all(directory.join(".hidden")).unwrap();
+        fs::write(directory.join(".gitignore"), "ignored/\n").unwrap();
+        fs::write(directory.join("src/a.tsrx"), "").unwrap();
+        fs::write(directory.join("src/deep/b.tsrx"), "").unwrap();
+        fs::write(directory.join("src/c.ts"), "").unwrap();
+        fs::write(directory.join("ignored/copy/d.tsrx"), "").unwrap();
+        fs::write(directory.join("node_modules/dep/e.tsrx"), "").unwrap();
+        fs::write(directory.join(".hidden/f.tsrx"), "").unwrap();
+
+        let found = discover_tsrx(std::slice::from_ref(&directory)).unwrap();
+        let relative = found
+            .iter()
+            .map(|path| {
+                path.strip_prefix(std::path::absolute(&directory).unwrap())
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(relative, vec![".hidden/f.tsrx", "src/a.tsrx", "src/deep/b.tsrx"]);
+
+        // A file named outright is kept even though its directory is ignored.
+        let named = discover_tsrx(&[directory.join("ignored/copy/d.tsrx")]).unwrap();
+        assert_eq!(named.len(), 1);
+        assert!(named[0].ends_with("d.tsrx"));
+
+        let report = run_discover(&[
+            "--discover".to_string(),
+            directory.join("src").to_string_lossy().into_owned(),
+        ])
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&report).unwrap();
+        assert_eq!(parsed["files"].as_array().unwrap().len(), 2);
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,7 +29,7 @@ The install links seven commands into `node_modules/.bin`:
 | `oxlint` | you type it | The linter. Sends `.tsrx` to the TSRX engine and everything else to official Oxlint. |
 | `oxfmt` | you type it | The formatter, with the same split. |
 | `oxc-tsrx` | you type it | `providers`, `status`, `setup`, `remove`. Described in the next section. |
-| `oxc-tsrx-lint` | leaf executor | The native linter, given explicit files only. `oxlint` dispatches to it. It prints JSON, and it has no `--help`. |
+| `oxc-tsrx-lint` | leaf executor | The native linter, given explicit files, a `--paths-file`, or `--discover PATH...` to list the `.tsrx` files under a path with `.gitignore` honoured. `oxlint` dispatches to it. It prints JSON. |
 | `oxc-tsrx-fmt` | leaf executor | The native formatter. `oxfmt` dispatches to it. `--help` works here. |
 | `oxc-tsrx-lsp` | leaf executor | The native language server. Editors launch it through `oxlint --lsp`. |
 | `tsgolint` | not this project | It arrives with the `oxlint-tsgolint` dependency, the official type-aware runner used by `--type-aware` and `--type-check`. You never call it directly, and calling it prints upstream's own "unsupported entrypoint" warning. |

--- a/licenses/RUST_DEPENDENCIES.md
+++ b/licenses/RUST_DEPENDENCIES.md
@@ -6,7 +6,7 @@ build dependency closure of the three binaries in `oxc_tsrx_cli` and the
 native addon in `parser_napi_binding`; benchmark and development-only
 dependencies are excluded.
 
-- Cargo.lock SHA-256: `c92aa5609d3d5dd040d32e7123c967d940a97637e9ce6513a3a47ef697e3d98c`
+- Cargo.lock SHA-256: `c76db7fbeb1e176a5e0bb58acf810eb505597c6c795e2c56f70b8388451ba1a5`
 - Canonical OXC revision: `8e0ed2ebb96137fb1611cdbd5742d5cb46037d40`
 - Shipping third-party packages: 220
 - Accepted license policy: `licenses/allowed-rust-license-expressions.json`

--- a/licenses/rust-dependencies.json
+++ b/licenses/rust-dependencies.json
@@ -5,7 +5,7 @@
     "oxc_tsrx_cli@0.10.0",
     "parser_napi_binding@0.10.0"
   ],
-  "cargoLockSha256": "c92aa5609d3d5dd040d32e7123c967d940a97637e9ce6513a3a47ef697e3d98c",
+  "cargoLockSha256": "c76db7fbeb1e176a5e0bb58acf810eb505597c6c795e2c56f70b8388451ba1a5",
   "oxcRevision": "8e0ed2ebb96137fb1611cdbd5742d5cb46037d40",
   "licenseSelectionPolicy": "Each Cargo expression is reviewed; selectedDistributionLicense records the basis used for binary distribution.",
   "packageCount": 220,

--- a/packages/toolchain/dist/format-cli.js
+++ b/packages/toolchain/dist/format-cli.js
@@ -1,6 +1,6 @@
-import { resolvePackageBinary } from "./package-binary.js";
 import { runCaptured, runPassthrough } from "./process.js";
-import { argumentValue, canonicalToolEnvironment, discoverTsrxFiles, isViteConfigPath, prepareVitePlusConfig, removeExplicitTsrx, replaceConfigArgument, resolveNativeCommand } from "./runtime.js";
+import { resolvePackageBinary } from "./package-binary.js";
+import { argumentValue, canonicalToolEnvironment, discoverTsrxFiles, isViteConfigPath, pathArguments, prepareVitePlusConfig, removeExplicitTsrx, replaceConfigArgument, resolveNativeCommand } from "./runtime.js";
 import { VALUE_OPTIONS, parseOxfmtInvocation, parseOxfmtOption } from "./format-invocation.js";
 import { isAbsolute, relative } from "node:path";
 import { readFileSync } from "node:fs";
@@ -231,7 +231,7 @@ async function runCli(args, options = {}) {
 		}
 	}
 	const positions = invocation.positionals;
-	const files = await discoverTsrxFiles(positions, cwd);
+	const files = await discoverTsrxFiles(positions, cwd, "format");
 	if (files.length > 0 || hasTsrxPositional(positions)) {
 		const unknown = unknownCanonicalOption(args);
 		if (unknown !== null) {
@@ -242,13 +242,15 @@ async function runCli(args, options = {}) {
 	const explicitConfig = argumentValue(args, /* @__PURE__ */ new Set(["-c", "--config"]));
 	const bridgeViteConfig = explicitConfig === null || isViteConfigPath(explicitConfig);
 	const viteConfig = files.length > 0 && bridgeViteConfig ? await prepareVitePlusConfig("fmt", cwd, isViteConfigPath(explicitConfig) ? explicitConfig : null) : null;
+	let nativePaths = null;
 	try {
 		const stripped = removeExplicitTsrx(args, VALUE_OPTIONS);
 		const shouldRunUpstream = !stripped.hadPositionals || stripped.remainingPositionals > 0;
 		const upstream = resolvePackageBinary("oxfmt-current", "oxfmt", import.meta.url);
 		const useMaterializedUpstreamConfig = Boolean(viteConfig && !viteConfig.requiresAuthoredBase);
 		const upstreamArgs = useMaterializedUpstreamConfig ? replaceConfigArgument(stripped.args, viteConfig.path) : stripped.args;
-		const nativeArgs = files.length > 0 ? nativeArguments(args, withCwdRelativePaths(files, cwd), viteConfig) : null;
+		nativePaths = files.length > 0 ? await pathArguments(withCwdRelativePaths(files, cwd)) : null;
+		const nativeArgs = nativePaths ? nativeArguments(args, nativePaths.args, viteConfig) : null;
 		const nativeCommand = nativeArgs ? resolveNativeCommand("format", nativeArgs) : null;
 		const [upstreamResult, nativeResult] = await Promise.all([shouldRunUpstream ? runCaptured(process.execPath, [upstream, ...upstreamArgs], {
 			cwd,
@@ -269,6 +271,7 @@ async function runCli(args, options = {}) {
 		process.stderr.write(attributeNativeErrors(mergeFormatStderr(upstreamResult, nativeResult, stdout)));
 		return Math.max(upstreamResult.status, nativeResult.status);
 	} finally {
+		await nativePaths?.cleanup();
 		await viteConfig?.cleanup();
 	}
 }

--- a/packages/toolchain/dist/lint-cli.js
+++ b/packages/toolchain/dist/lint-cli.js
@@ -1,6 +1,6 @@
-import { resolvePackageBinary } from "./package-binary.js";
 import { runCaptured, runPassthrough } from "./process.js";
-import { argumentValue, canonicalToolEnvironment, discoverTsrxFiles, ensureSupportedOutput, isViteConfigPath, prepareVitePlusConfig, removeExplicitTsrx, replaceConfigArgument, resolveNativeCommand } from "./runtime.js";
+import { resolvePackageBinary } from "./package-binary.js";
+import { argumentValue, canonicalToolEnvironment, discoverTsrxFiles, ensureSupportedOutput, isViteConfigPath, pathArguments, prepareVitePlusConfig, removeExplicitTsrx, replaceConfigArgument, resolveNativeCommand } from "./runtime.js";
 import { DELEGATE_ONLY, VALUE_OPTIONS, parseOxlintInvocation, parseOxlintOption, withOxlintOutputFormat } from "./lint-invocation.js";
 import { jsPluginUnmappedNote, preparePluginLane } from "./lint-js-plugins.js";
 import { readFile } from "node:fs/promises";
@@ -379,6 +379,7 @@ async function runCli(args, options = {}) {
 	}
 	const pluginLaneActive = pluginLane?.status === "active";
 	if (pluginLaneActive && !args.includes("--silent")) process.stderr.write(`${pluginLane.notice}\n`);
+	let nativePaths = null;
 	try {
 		const stripped = removeExplicitTsrx(args, VALUE_OPTIONS);
 		const shouldRunUpstream = !stripped.hadPositionals || stripped.remainingPositionals > 0;
@@ -396,7 +397,8 @@ async function runCli(args, options = {}) {
 		let upstreamArgs = withOxlintOutputFormat(stripped.args, "json");
 		if (useMaterializedUpstreamConfig) upstreamArgs = replaceConfigArgument(upstreamArgs, viteConfig.path);
 		const nativeResolvedConfig = pluginLane?.nativeConfig ?? viteConfig;
-		const nativeArgs = files.length > 0 ? nativeArguments(args, files, nativeResolvedConfig) : null;
+		nativePaths = files.length > 0 ? await pathArguments(files) : null;
+		const nativeArgs = nativePaths ? nativeArguments(args, nativePaths.args, nativeResolvedConfig) : null;
 		const nativeCommand = nativeArgs ? resolveNativeCommand("lint", nativeArgs) : null;
 		let upstreamPromise;
 		if (!shouldRunUpstream) upstreamPromise = Promise.resolve({
@@ -480,6 +482,7 @@ async function runCli(args, options = {}) {
 		return Math.max(upstreamResult.status, nativeResult.status, denyWarnings && warnings > 0 ? 1 : 0, exceedsMaximum ? 1 : 0, pluginErrors ? 1 : 0);
 	} finally {
 		await pluginLane?.cleanup?.();
+		await nativePaths?.cleanup();
 		await viteConfig?.cleanup();
 	}
 }

--- a/packages/toolchain/dist/lint-js-plugins.js
+++ b/packages/toolchain/dist/lint-js-plugins.js
@@ -1,6 +1,6 @@
-import { resolvePackageBinary } from "./package-binary.js";
 import { runCaptured } from "./process.js";
-import { resolveNativeCommand } from "./runtime.js";
+import { resolvePackageBinary } from "./package-binary.js";
+import { pathArguments, resolveNativeCommand } from "./runtime.js";
 import { createRequire } from "node:module";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
@@ -434,8 +434,14 @@ async function preparePluginLane({ cwd, files, viteConfig, explicitConfig }) {
 async function emitProjections(cwd, files, nativeConfig) {
 	const args = ["--emit-plugin-projection"];
 	if (nativeConfig) args.push("--config", nativeConfig.path, "--config-base", nativeConfig.base);
-	const command = resolveNativeCommand("lint", [...args, ...files]);
-	const result = await runCaptured(command.executable, command.args, { cwd });
+	const paths = await pathArguments(files);
+	let result;
+	try {
+		const command = resolveNativeCommand("lint", [...args, ...paths.args]);
+		result = await runCaptured(command.executable, command.args, { cwd });
+	} finally {
+		await paths.cleanup();
+	}
 	if (result.status !== 0) throw new Error(`the native TSRX projection needed for JS plugins failed:\n${result.stderr || result.stdout}`);
 	let parsed;
 	try {

--- a/packages/toolchain/dist/lint-prestart.js
+++ b/packages/toolchain/dist/lint-prestart.js
@@ -1,5 +1,5 @@
-import { resolvePackageBinary } from "./package-binary.js";
 import { runCaptured } from "./process.js";
+import { resolvePackageBinary } from "./package-binary.js";
 //#region src/lint-prestart.ts
 function startCanonicalOxlint(args, cwd = process.cwd(), env = process.env) {
 	const binary = resolvePackageBinary("oxlint-current", "oxlint", import.meta.url);

--- a/packages/toolchain/dist/runtime.js
+++ b/packages/toolchain/dist/runtime.js
@@ -1,6 +1,6 @@
 import { nativePackageName, nativeTargetForHost } from "./native-targets.js";
-import { resolvePackageBinary } from "./package-binary.js";
 import { runCaptured, runPassthrough } from "./process.js";
+import { resolvePackageBinary } from "./package-binary.js";
 import { createRequire } from "node:module";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, parse, resolve, sep } from "node:path";
@@ -254,7 +254,7 @@ function slash(path) {
 function hasMagic(path) {
 	return /[*?[\]{}()!]/u.test(path);
 }
-async function classifyPattern(raw, cwd, positives, patterns) {
+async function classifyPattern(raw, cwd, positives, patterns, directories) {
 	const negative = raw.startsWith("!");
 	const value = negative ? raw.slice(1) : raw;
 	const absolute = isAbsolute(value) ? value : resolve(cwd, value);
@@ -266,31 +266,93 @@ async function classifyPattern(raw, cwd, positives, patterns) {
 			return;
 		}
 		if (metadata.isDirectory()) {
-			patterns.push(`${negative ? "!" : ""}${slash(join(absolute, "**/*.tsrx"))}`);
+			if (negative) patterns.push(`!${slash(join(absolute, "**/*.tsrx"))}`);
+			else directories.push(absolute);
 			return;
 		}
 	} catch {}
 	patterns.push(`${negative ? "!" : ""}${slash(value)}`);
 }
-async function classifyPatterns(inputs, cwd, positives, patterns) {
+async function classifyPatterns(inputs, cwd, positives, patterns, directories) {
 	const classified = await Promise.all(inputs.map(async (input) => {
 		const entryPositives = /* @__PURE__ */ new Set();
 		const entryPatterns = [];
-		await classifyPattern(input, cwd, entryPositives, entryPatterns);
+		const entryDirectories = [];
+		await classifyPattern(input, cwd, entryPositives, entryPatterns, entryDirectories);
 		return {
 			entryPositives,
-			entryPatterns
+			entryPatterns,
+			entryDirectories
 		};
 	}));
-	for (const { entryPositives, entryPatterns } of classified) {
+	for (const { entryPositives, entryPatterns, entryDirectories } of classified) {
 		for (const positive of entryPositives) positives.add(positive);
 		for (const pattern of entryPatterns) patterns.push(pattern);
+		for (const directory of entryDirectories) directories.push(directory);
 	}
 }
-async function discoverTsrxFiles(positionals, cwd = process.cwd()) {
+/**
+* A file list as arguments the native leaf accepts. A short list travels on the
+* command line as before. A long one is written to a temporary file and named
+* with `--paths-file`, because a host's argument limit is reached by a real
+* repository (E2BIG past about a megabyte on macOS and Linux, a 32 KiB command
+* line on Windows, which a few hundred paths fill). The caller disposes of it.
+*/
+async function pathArguments(files, budget = 24e3) {
+	if (files.reduce((total, file) => total + Buffer.byteLength(file) + 1, 0) <= budget) return {
+		args: [...files],
+		cleanup: async () => {}
+	};
+	const directory = await mkdtemp(join(tmpdir(), "oxc-tsrx-paths-"));
+	const path = join(directory, "paths.txt");
+	await writeFile(path, `${files.join("\n")}\n`);
+	return {
+		args: ["--paths-file", path],
+		cleanup: () => rm(directory, {
+			recursive: true,
+			force: true
+		})
+	};
+}
+/**
+* Directories are walked by the native leaf, on the same `ignore` crate
+* canonical Oxlint walks with, so `.gitignore` and `.ignore` files are honoured
+* and `node_modules` and `.git` are never entered. Without that, a monorepo
+* that keeps gitignored copies of itself handed every one of them to the leaf.
+* Returns null when no native package is installed, and the caller falls back
+* to the plain glob so the run can still reach the error that names the missing
+* package.
+*/
+async function walkWithNativeLeaf(directories, cwd, kind) {
+	let command;
+	try {
+		command = resolveNativeCommand(kind, ["--discover"]);
+	} catch {
+		return null;
+	}
+	const paths = await pathArguments(directories);
+	try {
+		const result = await runCaptured(command.executable, [...command.args, ...paths.args], { cwd });
+		if (result.status !== 0) throw new Error(`.tsrx discovery failed: ${(result.stderr || result.stdout).trim()}`);
+		const report = JSON.parse(result.stdout);
+		if (!Array.isArray(report?.files)) throw new Error(".tsrx discovery returned no file list");
+		return report.files.map((file) => resolve(file));
+	} finally {
+		await paths.cleanup();
+	}
+}
+/**
+* `kind` names the leaf that walks directories, `lint` or `format`: both
+* answer `--discover` identically, and each command resolves its own binary.
+*/
+async function discoverTsrxFiles(positionals, cwd = process.cwd(), kind = "lint") {
 	const positives = /* @__PURE__ */ new Set();
 	const patterns = [];
-	await classifyPatterns(positionals.length === 0 ? ["."] : positionals, cwd, positives, patterns);
+	const directories = [];
+	await classifyPatterns(positionals.length === 0 ? ["."] : positionals, cwd, positives, patterns, directories);
+	const walked = directories.length > 0 && !patterns.some((pattern) => pattern.startsWith("!")) ? await walkWithNativeLeaf(directories, cwd, kind) : null;
+	if (walked === null) for (const directory of directories) patterns.push(slash(join(directory, "**/*.tsrx")));
+	else for (const file of walked) positives.add(file);
 	if (patterns.length > 0) {
 		const { glob } = await import("tinyglobby");
 		const matches = await glob(patterns, {
@@ -320,4 +382,4 @@ function ensureSupportedOutput(format, files) {
 	if (files.length > 0 && format !== "default" && format !== "json") throw new Error(`OXC for TSRX currently combines default and json lint output; ${format} is unavailable for mixed .tsrx runs`);
 }
 //#endregion
-export { argumentValue, canonicalToolEnvironment, discoverTsrxFiles, ensureSupportedOutput, isViteConfigPath, platformPackage, prepareVitePlusConfig, removeExplicitTsrx, replaceConfigArgument, resolveNativeBinary, resolveNativeCommand, resolvePackageBinary, runCaptured, runPassthrough };
+export { argumentValue, canonicalToolEnvironment, discoverTsrxFiles, ensureSupportedOutput, isViteConfigPath, pathArguments, platformPackage, prepareVitePlusConfig, removeExplicitTsrx, replaceConfigArgument, resolveNativeBinary, resolveNativeCommand, resolvePackageBinary, runCaptured, runPassthrough };

--- a/packages/toolchain/src/format-cli.ts
+++ b/packages/toolchain/src/format-cli.ts
@@ -4,6 +4,7 @@ import {
   argumentValue,
   canonicalToolEnvironment,
   discoverTsrxFiles,
+  pathArguments,
   isViteConfigPath,
   prepareVitePlusConfig,
   removeExplicitTsrx,
@@ -343,7 +344,7 @@ export async function runCli(args, options: any = {}) {
   }
 
   const positions = invocation.positionals;
-  const files = await discoverTsrxFiles(positions, cwd);
+  const files = await discoverTsrxFiles(positions, cwd, "format");
   // Only this route answers for a `.tsrx` path. An ordinary-only invocation
   // keeps reaching canonical Oxfmt, which prints its own rejection itself, so
   // nothing here can drift from the tool it is reproducing on that path.
@@ -364,6 +365,7 @@ export async function runCli(args, options: any = {}) {
           isViteConfigPath(explicitConfig) ? explicitConfig : null,
         )
       : null;
+  let nativePaths = null;
   try {
     const stripped = removeExplicitTsrx(args, VALUE_OPTIONS);
     const shouldRunUpstream = !stripped.hadPositionals || stripped.remainingPositionals > 0;
@@ -372,8 +374,8 @@ export async function runCli(args, options: any = {}) {
     const upstreamArgs = useMaterializedUpstreamConfig
       ? replaceConfigArgument(stripped.args, viteConfig.path)
       : stripped.args;
-    const nativeArgs =
-      files.length > 0 ? nativeArguments(args, withCwdRelativePaths(files, cwd), viteConfig) : null;
+    nativePaths = files.length > 0 ? await pathArguments(withCwdRelativePaths(files, cwd)) : null;
+    const nativeArgs = nativePaths ? nativeArguments(args, nativePaths.args, viteConfig) : null;
     // Resolve and validate every artifact before either tool can mutate a mixed batch.
     // In particular, a missing platform package must not let canonical Oxfmt
     // rewrite ordinary files before the TSRX lane fails.
@@ -396,6 +398,7 @@ export async function runCli(args, options: any = {}) {
     );
     return Math.max(upstreamResult.status, nativeResult.status);
   } finally {
+    await nativePaths?.cleanup();
     await viteConfig?.cleanup();
   }
 }

--- a/packages/toolchain/src/lint-cli.ts
+++ b/packages/toolchain/src/lint-cli.ts
@@ -4,6 +4,7 @@ import {
   argumentValue,
   canonicalToolEnvironment,
   discoverTsrxFiles,
+  pathArguments,
   ensureSupportedOutput,
   isViteConfigPath,
   prepareVitePlusConfig,
@@ -590,6 +591,7 @@ export async function runCli(args, options: any = {}) {
     process.stderr.write(`${pluginLane.notice}\n`);
   }
 
+  let nativePaths = null;
   try {
     const stripped = removeExplicitTsrx(args, VALUE_OPTIONS);
     const shouldRunUpstream = !stripped.hadPositionals || stripped.remainingPositionals > 0;
@@ -617,8 +619,9 @@ export async function runCli(args, options: any = {}) {
     // minus `jsPlugins`, so `reject_unavailable_lint_capabilities` is never
     // reached and the plugins are hosted exactly once, by Oxlint.
     const nativeResolvedConfig = pluginLane?.nativeConfig ?? viteConfig;
+    nativePaths = files.length > 0 ? await pathArguments(files) : null;
     const nativeArgs =
-      files.length > 0 ? nativeArguments(args, files, nativeResolvedConfig) : null;
+      nativePaths ? nativeArguments(args, nativePaths.args, nativeResolvedConfig) : null;
     // Mutating invocations never prestart. Preflight their native lane before
     // canonical Oxlint can apply fixes to the ordinary half of a mixed batch.
     // Missing or mismatched artifacts therefore fail atomically instead of
@@ -751,6 +754,7 @@ export async function runCli(args, options: any = {}) {
     );
   } finally {
     await pluginLane?.cleanup?.();
+    await nativePaths?.cleanup();
     await viteConfig?.cleanup();
   }
 }

--- a/packages/toolchain/src/lint-js-plugins.ts
+++ b/packages/toolchain/src/lint-js-plugins.ts
@@ -30,7 +30,7 @@ import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, parse, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
-import { resolveNativeCommand, resolvePackageBinary, runCaptured } from "./runtime.js";
+import { pathArguments, resolveNativeCommand, resolvePackageBinary, runCaptured } from "./runtime.js";
 
 // The lane drives the published Oxlint binary through its command line, but the
 // shape of that command line is still a contract: `jsPlugins`, `--format=json`,
@@ -563,8 +563,14 @@ export async function preparePluginLane({ cwd, files, viteConfig, explicitConfig
 async function emitProjections(cwd, files, nativeConfig) {
   const args = ["--emit-plugin-projection"];
   if (nativeConfig) args.push("--config", nativeConfig.path, "--config-base", nativeConfig.base);
-  const command = resolveNativeCommand("lint", [...args, ...files]);
-  const result = await runCaptured(command.executable, command.args, { cwd });
+  const paths = await pathArguments(files);
+  let result;
+  try {
+    const command = resolveNativeCommand("lint", [...args, ...paths.args]);
+    result = await runCaptured(command.executable, command.args, { cwd });
+  } finally {
+    await paths.cleanup();
+  }
   if (result.status !== 0) {
     throw new Error(
       `the native TSRX projection needed for JS plugins failed:\n${result.stderr || result.stdout}`,

--- a/packages/toolchain/src/runtime.ts
+++ b/packages/toolchain/src/runtime.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, parse, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
 import { nativePackageName, nativeTargetForHost } from "./native-targets.js";
+import { runCaptured } from "./process.js";
 
 export { resolvePackageBinary } from "./package-binary.js";
 export { runCaptured, runPassthrough } from "./process.js";
@@ -342,7 +343,7 @@ function hasMagic(path) {
   return /[*?[\]{}()!]/u.test(path);
 }
 
-async function classifyPattern(raw, cwd, positives, patterns) {
+async function classifyPattern(raw, cwd, positives, patterns, directories) {
   const negative = raw.startsWith("!");
   const value = negative ? raw.slice(1) : raw;
   const absolute = isAbsolute(value) ? value : resolve(cwd, value);
@@ -355,7 +356,8 @@ async function classifyPattern(raw, cwd, positives, patterns) {
         return;
       }
       if (metadata.isDirectory()) {
-        patterns.push(`${negative ? "!" : ""}${slash(join(absolute, "**/*.tsrx"))}`);
+        if (negative) patterns.push(`!${slash(join(absolute, "**/*.tsrx"))}`);
+        else directories.push(absolute);
         return;
       }
     } catch {
@@ -367,26 +369,93 @@ async function classifyPattern(raw, cwd, positives, patterns) {
 
 // Order-preserving concurrent classification: explicit file lists can carry a
 // thousand positionals, and one awaited stat per entry costs ~10 ms serially.
-async function classifyPatterns(inputs, cwd, positives, patterns) {
+async function classifyPatterns(inputs, cwd, positives, patterns, directories) {
   const classified = await Promise.all(
     inputs.map(async (input) => {
       const entryPositives = new Set();
       const entryPatterns = [];
-      await classifyPattern(input, cwd, entryPositives, entryPatterns);
-      return { entryPositives, entryPatterns };
+      const entryDirectories = [];
+      await classifyPattern(input, cwd, entryPositives, entryPatterns, entryDirectories);
+      return { entryPositives, entryPatterns, entryDirectories };
     }),
   );
-  for (const { entryPositives, entryPatterns } of classified) {
+  for (const { entryPositives, entryPatterns, entryDirectories } of classified) {
     for (const positive of entryPositives) positives.add(positive);
     for (const pattern of entryPatterns) patterns.push(pattern);
+    for (const directory of entryDirectories) directories.push(directory);
   }
 }
 
-export async function discoverTsrxFiles(positionals, cwd = process.cwd()) {
+/**
+ * A file list as arguments the native leaf accepts. A short list travels on the
+ * command line as before. A long one is written to a temporary file and named
+ * with `--paths-file`, because a host's argument limit is reached by a real
+ * repository (E2BIG past about a megabyte on macOS and Linux, a 32 KiB command
+ * line on Windows, which a few hundred paths fill). The caller disposes of it.
+ */
+export async function pathArguments(files, budget = 24_000) {
+  const bytes = files.reduce((total, file) => total + Buffer.byteLength(file) + 1, 0);
+  if (bytes <= budget) return { args: [...files], cleanup: async () => {} };
+  const directory = await mkdtemp(join(tmpdir(), "oxc-tsrx-paths-"));
+  const path = join(directory, "paths.txt");
+  await writeFile(path, `${files.join("\n")}\n`);
+  return {
+    args: ["--paths-file", path],
+    cleanup: () => rm(directory, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Directories are walked by the native leaf, on the same `ignore` crate
+ * canonical Oxlint walks with, so `.gitignore` and `.ignore` files are honoured
+ * and `node_modules` and `.git` are never entered. Without that, a monorepo
+ * that keeps gitignored copies of itself handed every one of them to the leaf.
+ * Returns null when no native package is installed, and the caller falls back
+ * to the plain glob so the run can still reach the error that names the missing
+ * package.
+ */
+async function walkWithNativeLeaf(directories, cwd, kind) {
+  let command;
+  try {
+    command = resolveNativeCommand(kind, ["--discover"]);
+  } catch {
+    return null;
+  }
+  const paths = await pathArguments(directories);
+  try {
+    const result = await runCaptured(command.executable, [...command.args, ...paths.args], { cwd });
+    if (result.status !== 0) {
+      throw new Error(`.tsrx discovery failed: ${(result.stderr || result.stdout).trim()}`);
+    }
+    const report = JSON.parse(result.stdout);
+    if (!Array.isArray(report?.files)) throw new Error(".tsrx discovery returned no file list");
+    return report.files.map((file) => resolve(file));
+  } finally {
+    await paths.cleanup();
+  }
+}
+
+/**
+ * `kind` names the leaf that walks directories, `lint` or `format`: both
+ * answer `--discover` identically, and each command resolves its own binary.
+ */
+export async function discoverTsrxFiles(positionals, cwd = process.cwd(), kind = "lint") {
   const positives = new Set();
   const patterns = [];
+  const directories = [];
   const inputs = positionals.length === 0 ? ["."] : positionals;
-  await classifyPatterns(inputs, cwd, positives, patterns);
+  await classifyPatterns(inputs, cwd, positives, patterns, directories);
+  // A negative pattern has to see the directory walk as a glob to subtract from
+  // it, so that (rare) shape keeps the glob walk for everything.
+  const walked =
+    directories.length > 0 && !patterns.some((pattern) => pattern.startsWith("!"))
+      ? await walkWithNativeLeaf(directories, cwd, kind)
+      : null;
+  if (walked === null) {
+    for (const directory of directories) patterns.push(slash(join(directory, "**/*.tsrx")));
+  } else {
+    for (const file of walked) positives.add(file);
+  }
   if (patterns.length > 0) {
     // Lazy: explicit file lists never glob, and tinyglobby costs a few
     // milliseconds of parse time on every launch otherwise.

--- a/packages/vscode/dist/extension.bundle.cjs
+++ b/packages/vscode/dist/extension.bundle.cjs
@@ -47,8 +47,8 @@ fs = __toESM(fs, 1);
 let path = require("path");
 let node_module = require("node:module");
 let node_fs_promises = require("node:fs/promises");
-let node_url = require("node:url");
 let node_child_process = require("node:child_process");
+let node_url = require("node:url");
 let node_os = require("node:os");
 let url = require("url");
 let module$1 = require("module");
@@ -22639,26 +22639,6 @@ var init_native_targets = __esmMin((() => {
 	]);
 }));
 //#endregion
-//#region packages/toolchain/dist/package-binary.js
-/** Resolve the executable declared by an installed npm package's `bin` field. */
-function resolvePackageBinary(packageName, binaryName, fromUrl) {
-	const localRequire = (0, node_module.createRequire)(fromUrl);
-	const manifestPath = localRequire.resolve(`${packageName}/package.json`);
-	const manifest = localRequire(manifestPath);
-	const declared = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[binaryName];
-	if (typeof declared !== "string" || declared.length === 0) throw new Error(`${packageName} does not declare its ${binaryName} npm binary`);
-	const entry = (0, node_path.resolve)((0, node_path.dirname)(manifestPath), declared);
-	let metadata;
-	try {
-		metadata = (0, node_fs.statSync)(entry);
-	} catch {
-		throw new Error(`${packageName} declares a missing ${binaryName} npm binary at ${entry}`);
-	}
-	if (!metadata.isFile()) throw new Error(`${packageName} declares a non-file ${binaryName} npm binary at ${entry}`);
-	return entry;
-}
-var init_package_binary = __esmMin((() => {}));
-//#endregion
 //#region packages/toolchain/dist/process.js
 function traceRunStart(trace, started, executable, args) {
 	(0, node_fs.appendFileSync)(trace, `${JSON.stringify({
@@ -22744,6 +22724,26 @@ function runPassthrough(executable, args, options = {}) {
 	});
 }
 var init_process = __esmMin((() => {}));
+//#endregion
+//#region packages/toolchain/dist/package-binary.js
+/** Resolve the executable declared by an installed npm package's `bin` field. */
+function resolvePackageBinary(packageName, binaryName, fromUrl) {
+	const localRequire = (0, node_module.createRequire)(fromUrl);
+	const manifestPath = localRequire.resolve(`${packageName}/package.json`);
+	const manifest = localRequire(manifestPath);
+	const declared = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[binaryName];
+	if (typeof declared !== "string" || declared.length === 0) throw new Error(`${packageName} does not declare its ${binaryName} npm binary`);
+	const entry = (0, node_path.resolve)((0, node_path.dirname)(manifestPath), declared);
+	let metadata;
+	try {
+		metadata = (0, node_fs.statSync)(entry);
+	} catch {
+		throw new Error(`${packageName} declares a missing ${binaryName} npm binary at ${entry}`);
+	}
+	if (!metadata.isFile()) throw new Error(`${packageName} declares a non-file ${binaryName} npm binary at ${entry}`);
+	return entry;
+}
+var init_package_binary = __esmMin((() => {}));
 //#endregion
 //#region node_modules/.pnpm/fdir@6.5.0_picomatch@4.0.5/node_modules/fdir/dist/index.mjs
 function cleanPath(path$11) {
@@ -25454,6 +25454,7 @@ var runtime_exports = /* @__PURE__ */ __exportAll({
 	discoverTsrxFiles: () => discoverTsrxFiles,
 	ensureSupportedOutput: () => ensureSupportedOutput,
 	isViteConfigPath: () => isViteConfigPath,
+	pathArguments: () => pathArguments,
 	platformPackage: () => platformPackage,
 	prepareVitePlusConfig: () => prepareVitePlusConfig,
 	removeExplicitTsrx: () => removeExplicitTsrx,
@@ -25673,7 +25674,7 @@ function slash(path) {
 function hasMagic(path) {
 	return /[*?[\]{}()!]/u.test(path);
 }
-async function classifyPattern(raw, cwd, positives, patterns) {
+async function classifyPattern(raw, cwd, positives, patterns, directories) {
 	const negative = raw.startsWith("!");
 	const value = negative ? raw.slice(1) : raw;
 	const absolute = (0, node_path.isAbsolute)(value) ? value : (0, node_path.resolve)(cwd, value);
@@ -25685,31 +25686,93 @@ async function classifyPattern(raw, cwd, positives, patterns) {
 			return;
 		}
 		if (metadata.isDirectory()) {
-			patterns.push(`${negative ? "!" : ""}${slash((0, node_path.join)(absolute, "**/*.tsrx"))}`);
+			if (negative) patterns.push(`!${slash((0, node_path.join)(absolute, "**/*.tsrx"))}`);
+			else directories.push(absolute);
 			return;
 		}
 	} catch {}
 	patterns.push(`${negative ? "!" : ""}${slash(value)}`);
 }
-async function classifyPatterns(inputs, cwd, positives, patterns) {
+async function classifyPatterns(inputs, cwd, positives, patterns, directories) {
 	const classified = await Promise.all(inputs.map(async (input) => {
 		const entryPositives = /* @__PURE__ */ new Set();
 		const entryPatterns = [];
-		await classifyPattern(input, cwd, entryPositives, entryPatterns);
+		const entryDirectories = [];
+		await classifyPattern(input, cwd, entryPositives, entryPatterns, entryDirectories);
 		return {
 			entryPositives,
-			entryPatterns
+			entryPatterns,
+			entryDirectories
 		};
 	}));
-	for (const { entryPositives, entryPatterns } of classified) {
+	for (const { entryPositives, entryPatterns, entryDirectories } of classified) {
 		for (const positive of entryPositives) positives.add(positive);
 		for (const pattern of entryPatterns) patterns.push(pattern);
+		for (const directory of entryDirectories) directories.push(directory);
 	}
 }
-async function discoverTsrxFiles(positionals, cwd = process.cwd()) {
+/**
+* A file list as arguments the native leaf accepts. A short list travels on the
+* command line as before. A long one is written to a temporary file and named
+* with `--paths-file`, because a host's argument limit is reached by a real
+* repository (E2BIG past about a megabyte on macOS and Linux, a 32 KiB command
+* line on Windows, which a few hundred paths fill). The caller disposes of it.
+*/
+async function pathArguments(files, budget = 24e3) {
+	if (files.reduce((total, file) => total + Buffer.byteLength(file) + 1, 0) <= budget) return {
+		args: [...files],
+		cleanup: async () => {}
+	};
+	const directory = await (0, node_fs_promises.mkdtemp)((0, node_path.join)((0, node_os.tmpdir)(), "oxc-tsrx-paths-"));
+	const path = (0, node_path.join)(directory, "paths.txt");
+	await (0, node_fs_promises.writeFile)(path, `${files.join("\n")}\n`);
+	return {
+		args: ["--paths-file", path],
+		cleanup: () => (0, node_fs_promises.rm)(directory, {
+			recursive: true,
+			force: true
+		})
+	};
+}
+/**
+* Directories are walked by the native leaf, on the same `ignore` crate
+* canonical Oxlint walks with, so `.gitignore` and `.ignore` files are honoured
+* and `node_modules` and `.git` are never entered. Without that, a monorepo
+* that keeps gitignored copies of itself handed every one of them to the leaf.
+* Returns null when no native package is installed, and the caller falls back
+* to the plain glob so the run can still reach the error that names the missing
+* package.
+*/
+async function walkWithNativeLeaf(directories, cwd, kind) {
+	let command;
+	try {
+		command = resolveNativeCommand(kind, ["--discover"]);
+	} catch {
+		return null;
+	}
+	const paths = await pathArguments(directories);
+	try {
+		const result = await runCaptured(command.executable, [...command.args, ...paths.args], { cwd });
+		if (result.status !== 0) throw new Error(`.tsrx discovery failed: ${(result.stderr || result.stdout).trim()}`);
+		const report = JSON.parse(result.stdout);
+		if (!Array.isArray(report?.files)) throw new Error(".tsrx discovery returned no file list");
+		return report.files.map((file) => (0, node_path.resolve)(file));
+	} finally {
+		await paths.cleanup();
+	}
+}
+/**
+* `kind` names the leaf that walks directories, `lint` or `format`: both
+* answer `--discover` identically, and each command resolves its own binary.
+*/
+async function discoverTsrxFiles(positionals, cwd = process.cwd(), kind = "lint") {
 	const positives = /* @__PURE__ */ new Set();
 	const patterns = [];
-	await classifyPatterns(positionals.length === 0 ? ["."] : positionals, cwd, positives, patterns);
+	const directories = [];
+	await classifyPatterns(positionals.length === 0 ? ["."] : positionals, cwd, positives, patterns, directories);
+	const walked = directories.length > 0 && !patterns.some((pattern) => pattern.startsWith("!")) ? await walkWithNativeLeaf(directories, cwd, kind) : null;
+	if (walked === null) for (const directory of directories) patterns.push(slash((0, node_path.join)(directory, "**/*.tsrx")));
+	else for (const file of walked) positives.add(file);
 	if (patterns.length > 0) {
 		const { glob } = await Promise.resolve().then(() => (init_dist(), dist_exports));
 		const matches = await glob(patterns, {
@@ -25741,8 +25804,8 @@ function ensureSupportedOutput(format, files) {
 var require$1, runtimeManifest, NATIVE_PROTOCOL_VERSION, OXC_REVISION, ENVIRONMENTS, EXECUTABLE, SUBCOMMANDS, VITE_CONFIG_FILES;
 var init_runtime = __esmMin((() => {
 	init_native_targets();
-	init_package_binary();
 	init_process();
+	init_package_binary();
 	require$1 = (0, node_module.createRequire)(require("url").pathToFileURL(__filename).href);
 	runtimeManifest = require$1("../package.json");
 	NATIVE_PROTOCOL_VERSION = 2;

--- a/packages/vscode/licenses/BUNDLE_DEPENDENCIES.md
+++ b/packages/vscode/licenses/BUNDLE_DEPENDENCIES.md
@@ -10,7 +10,7 @@ Rolldown resolves these modules from. `lockKey` is the matching
 `pnpm-lock.yaml` `packages` entry.
 
 - Bundle: `packages/vscode/dist/extension.bundle.cjs`
-- Bundle SHA-256: `45f5d48168292cbdf8d5437a1cc6b648fa071cc0f626d143f3b98683fe148b59`
+- Bundle SHA-256: `0835f22e5066d4f6d6d2e3d6d287bdb6a8658b820eb7807970529ff1037742ec`
 - pnpm-lock.yaml SHA-256: `ca53e4d37d31a6f0a75c50a7414043b2078367ab67bd390894788b94c0b5927b`
 - Bundled third-party packages: 12
 

--- a/packages/vscode/licenses/bundle-dependencies.json
+++ b/packages/vscode/licenses/bundle-dependencies.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "generatedBy": "scripts/generate-vscode-license-inventory.ts",
   "bundle": "packages/vscode/dist/extension.bundle.cjs",
-  "bundleSha256": "45f5d48168292cbdf8d5437a1cc6b648fa071cc0f626d143f3b98683fe148b59",
+  "bundleSha256": "0835f22e5066d4f6d6d2e3d6d287bdb6a8658b820eb7807970529ff1037742ec",
   "lockfileSha256": "ca53e4d37d31a6f0a75c50a7414043b2078367ab67bd390894788b94c0b5927b",
   "packageCount": 12,
   "packages": [

--- a/tests/config/native-format-config.test.mjs
+++ b/tests/config/native-format-config.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -730,4 +730,30 @@ test("a native format failure is attributed to the command the user ran", async 
   assert.equal(stdin.code, 2, stdin.stdout);
   assert.doesNotMatch(stdin.stderr, /^oxc-tsrx-fmt: /mu, stdin.stderr);
   assert.match(stdin.stderr, /^oxfmt \(oxc-tsrx\): /mu, stdin.stderr);
+});
+
+test("the drop-in oxfmt checks a file list past the argument limit and skips gitignored trees", async () => {
+  // The same discovery and paths-file channel the linter uses (see native-lint-config): a long
+  // list travels in a file instead of argv, and a gitignored copy of the tree is never visited.
+  const directory = await mkdtemp(join(tmpdir(), "oxc-tsrx-format-discovery-"));
+  await mkdir(join(directory, "src"), { recursive: true });
+  await mkdir(join(directory, "ignored/copy"), { recursive: true });
+  await mkdir(join(directory, "many"), { recursive: true });
+  await writeFile(join(directory, ".gitignore"), "ignored/\n");
+  await writeFile(join(directory, ".oxfmtrc.json"), "{}\n");
+  await writeFile(join(directory, "src/a.ts"), "export const a = 1;\n");
+  await writeFile(join(directory, "ignored/copy/b.tsrx"), "export function B(){<p>x</p>}\n");
+  const count = 1500;
+  await Promise.all(
+    Array.from({ length: count }, (_, index) =>
+      writeFile(join(directory, "many", `component-number-${index}.tsrx`), "export function Ok(){<p>ok</p>}\n"),
+    ),
+  );
+  const result = await runCompanion(directory, ["--check", "."]);
+  assert.equal(result.code, 1, result.stderr || result.stdout);
+  assert.equal((result.stdout.match(/^many\/component-number-\d+\.tsrx/gmu) ?? []).length, count, result.stdout.slice(0, 400));
+  assert.doesNotMatch(result.stdout, /ignored\//u);
+  // Every .tsrx file, plus src/a.ts and .oxfmtrc.json, which canonical Oxfmt formats too.
+  assert.match(result.stdout, new RegExp(`on ${count + 2} files`, "u"));
+  await rm(directory, { recursive: true, force: true });
 });

--- a/tests/config/native-lint-config.test.mjs
+++ b/tests/config/native-lint-config.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -953,4 +953,38 @@ test("oxc-tsrx accepts --help and --version instead of calling them unknown comm
   const unknown = await runProvider(["lint"]);
   assert.equal(unknown.code, 2, unknown.stdout);
   assert.match(unknown.stderr, /unknown command: lint/u, unknown.stderr);
+});
+
+test("the drop-in oxlint skips gitignored trees and survives a file list past the argument limit", async () => {
+  // A monorepo that keeps gitignored copies of itself (agent worktrees, build output) used to
+  // hand every copy to the native leaf on the command line: hundreds of thousands of paths,
+  // then spawn E2BIG. Discovery now walks with .gitignore honoured, and a long list travels in
+  // a file, which is also what keeps a few hundred paths under Windows's 32 KiB command line.
+  const directory = await mkdtemp(join(tmpdir(), "oxc-tsrx-discovery-launcher-"));
+  await mkdir(join(directory, "src"), { recursive: true });
+  await mkdir(join(directory, "ignored/copy"), { recursive: true });
+  await mkdir(join(directory, "many"), { recursive: true });
+  await writeFile(join(directory, ".gitignore"), "ignored/\n");
+  await writeFile(join(directory, ".oxlintrc.json"), '{ "rules": { "no-debugger": "error" } }\n');
+  const offending = "export function View() @{\n  debugger;\n  <p>hi</p>;\n}\n";
+  await writeFile(join(directory, "src/a.tsrx"), offending);
+  await writeFile(join(directory, "src/ordinary.ts"), "export const ordinary = 1;\n");
+  await writeFile(join(directory, "ignored/copy/b.tsrx"), offending);
+  const count = 1500;
+  await Promise.all(
+    Array.from({ length: count }, (_, index) =>
+      writeFile(join(directory, "many", `component-number-${index}.tsrx`), "export function Ok() @{\n  <p>ok</p>;\n}\n"),
+    ),
+  );
+  const listBytes = count * (join(directory, "many", "component-number-0000.tsrx").length + 1);
+  assert.ok(listBytes > 24_000, `the list must exceed the inline budget (${listBytes} bytes)`);
+
+  const result = await runCompanion(directory, ["--format=json", "."]);
+  assert.equal(result.code, 1, result.stderr || result.stdout);
+  const output = json(result);
+  assert.equal(output.number_of_files, count + 2, "every discovered file, and nothing from ignored/");
+  const files = new Set(output.diagnostics.map((item) => item.filename));
+  assert.equal(files.size, 1);
+  assert.ok([...files][0].endsWith("src/a.tsrx"), [...files][0]);
+  await rm(directory, { recursive: true, force: true });
 });

--- a/tests/native-format.test.mjs
+++ b/tests/native-format.test.mjs
@@ -385,3 +385,15 @@ test('a semi: false config lifts guards inside nested markup statements and unde
     assert.equal(again.stdout, first.stdout, endOfLine);
   }
 });
+
+test('--paths-file carries a file list the command line could not', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'oxc-tsrx-format-paths-'));
+  await writeFile(join(directory, 'a.tsrx'), 'export function A(){<p>a</p>}\n');
+  await writeFile(join(directory, 'b.tsrx'), 'export function B(){<p>b</p>}\n');
+  await writeFile(join(directory, 'paths.txt'), `${join(directory, 'a.tsrx')}\r\n\n${join(directory, 'b.tsrx')}\n`);
+  const result = await runFormat(['--check', '--paths-file', join(directory, 'paths.txt')]);
+  assert.equal(result.code, 1, result.stderr || result.stdout);
+  assert.match(result.stdout, /a\.tsrx/);
+  assert.match(result.stdout, /b\.tsrx/);
+  assert.match(result.stdout, /on 2 files/);
+});

--- a/tests/native-lint.test.mjs
+++ b/tests/native-lint.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { copyFile, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
@@ -305,4 +305,40 @@ test('the lint leaf answers --help in the shape its formatter sibling already do
   const bare = await run([]);
   assert.equal(bare.code, 2, bare.stdout);
   assert.match(bare.stderr, /at least one explicit source file is required/u, bare.stderr);
+});
+
+test('--discover walks with .gitignore honoured and --paths-file carries a list past the argument limit', async () => {
+  // The drop-in oxlint hands the leaf a discovered file list. On a monorepo that keeps
+  // gitignored copies of itself the old Node-side walk handed over every copy and the
+  // command line overflowed (spawn E2BIG). The leaf now walks on the same `ignore`
+  // crate canonical Oxlint uses, and takes a list from a file.
+  const directory = await mkdtemp(join(tmpdir(), 'oxc-tsrx-discover-'));
+  await mkdir(join(directory, 'src/deep'), { recursive: true });
+  await mkdir(join(directory, 'ignored/copy'), { recursive: true });
+  await mkdir(join(directory, 'node_modules/dep'), { recursive: true });
+  await writeFile(join(directory, '.gitignore'), 'ignored/\n');
+  const component = 'export function View() @{\n  debugger;\n  <p>hi</p>;\n}\n';
+  await writeFile(join(directory, 'src/a.tsrx'), component);
+  await writeFile(join(directory, 'src/deep/b.tsrx'), component);
+  await writeFile(join(directory, 'src/c.ts'), 'export const c = 1;\n');
+  await writeFile(join(directory, 'ignored/copy/d.tsrx'), component);
+  await writeFile(join(directory, 'node_modules/dep/e.tsrx'), component);
+
+  const discovered = await run(['--discover', directory]);
+  assert.equal(discovered.code, 0, discovered.stderr || discovered.stdout);
+  const files = JSON.parse(discovered.stdout).files.map((file) => file.slice(directory.length + 1));
+  assert.deepEqual(files.sort(), ['src/a.tsrx', 'src/deep/b.tsrx']);
+
+  // A file named outright is kept even inside an ignored directory, as canonical Oxlint keeps it.
+  const named = await run(['--discover', join(directory, 'ignored/copy/d.tsrx')]);
+  assert.equal(JSON.parse(named.stdout).files.length, 1);
+
+  const list = join(directory, 'paths.txt');
+  await writeFile(list, `${join(directory, 'src/a.tsrx')}\r\n\n${join(directory, 'src/deep/b.tsrx')}\n`);
+  const linted = await run(['--paths-file', list]);
+  assert.equal(linted.code, 0, linted.stderr || linted.stdout);
+  const report = JSON.parse(linted.stdout);
+  assert.equal(report.number_of_files, 2);
+  assert.equal(report.diagnostics.filter((item) => item.code.includes('no-debugger')).length, 2);
+  await rm(directory, { recursive: true, force: true });
 });


### PR DESCRIPTION
Found while wiring Markless (a Vite+ monorepo) onto 0.10.0: `vp lint` and `vp fmt` died with `spawn E2BIG`. Discovery returned 624,671 `.tsrx` paths (92 MB of arguments) because the Node-side walk skipped only `node_modules` and `.git`, so the gitignored agent-worktree copies of the repo under `.claude/` were all handed to the native leaf on the command line.

- Directories are now walked by the native leaf (`--discover`) on the same `ignore` crate canonical Oxlint uses, so `.gitignore` and `.ignore` are honoured with or without a `.git` directory (verified against stock Oxlint's behaviour); explicitly named files are kept as before; `node_modules` and `.git` are never entered. When no native package is installed, discovery falls back to the old glob so the run still reaches the error that names the missing package.
- A file list past 24 KiB travels in a `--paths-file` instead of argv, in the lint lane, the format lane, and the JS plugin projection. Both leaves accept `--paths-file`; both answer `--discover`.
- Tests: leaf-level `--discover`/`--paths-file` (Rust and Node), and launcher-level runs over a gitignored copy plus 1,500 files for both `oxlint` and `oxfmt`. Licence inventories and the VSIX bundle regenerated for the new `ignore` dependency in the CLI crate.

Follow-up noted, not fixed here: on a directory holding only `.tsrx` files, `oxlint --format=json .` fails because canonical Oxlint prints a non-JSON "no files" message for the empty ordinary half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Discovery and argv plumbing for every lint/format run changed; behavior should match Oxlint but edge cases (negative globs still use Node glob) remain.
> 
> **Overview**
> Fixes **`spawn E2BIG`** and runaway discovery on large monorepos by changing how `.tsrx` paths reach the native lint/format leaves.
> 
> **Native CLI** adds a shared `paths` module (via the `ignore` crate, aligned with Oxlint): **`--discover`** emits `{"files":[...]}` from directory walks that honor `.gitignore`/`.ignore`, skip `node_modules` and `.git`, and still accept explicitly named files; **`--paths-file`** loads one path per line. Both **`oxc-tsrx-lint`** and **`oxc-tsrx-fmt`** wire these flags through help and argument parsing.
> 
> **Node `oxlint`/`oxfmt` bridge** no longer globs directories alone for TSRX: it calls the native **`--discover`** walk when possible (falls back to the old glob if the native package is missing). Lists over ~24 KiB are written to a temp file and passed as **`--paths-file`** instead of argv—used for normal lint/format runs and JS plugin projection. Temp path files are cleaned up in `finally` blocks.
> 
> Docs, Rust license inventory, VSIX bundle hashes, and integration tests (gitignored trees + ~1500 files) are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1740850aa4880e20b6f5424c753818f253dc0e86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->