### PR TITLE
site: pin wasm demo engine 342aa8a

### DIFF
--- a/website-oxc/wasm-pin.json
+++ b/website-oxc/wasm-pin.json
@@ -1,10 +1,10 @@
 {
   "tag": "wasm-demo-latest",
-  "inputsHash": "2ff905c37706dda422ee64c299960e197da4f2625faa076182acef46b460d0f0",
-  "sourceCommit": "5382c0dd64927245ee434280eff0a816092b3753",
+  "inputsHash": "f4ec67e2a356409bec268faa722fdc1a4db1b2d0f8cae7e0bed9e5865544fbb2",
+  "sourceCommit": "342aa8a0b90cd2b3daca1472aa53e56357367770",
   "wasm": {
-    "sha256": "0c90bdddbb6f930b1aa30c11018a7148817a8362b57bceec93aa587fb3ab60af",
-    "bytes": 9556179
+    "sha256": "3eea3777f4f33175279db3ff725bc7b221b5a1685cc4debca03478a519639dd5",
+    "bytes": 9563442
   },
   "worker": {
     "sha256": "9e8064c5af1619769984b28fe66e5400cdf8b46ab4678f45cdb4f1b5a2441f47",


### PR DESCRIPTION
oxc.tsrx.dev is on its static preview: the site workflow re-uploaded the rolling `wasm-demo-latest` assets from the 0.11.0 tree, but its pin push to `main` is rejected by branch protection, so the Vercel build fetched bytes that no longer matched the pinned 0.9.0 engine, refused them (integrity is fail-closed), and dropped the demo. This is the pin the workflow computed for `main`; `node scripts/fetch-docs-wasm.ts` verifies and installs the engine with it. A follow-up makes this class of outage impossible and loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only pin bump for the demo WASM artifact; no application logic or security-sensitive code changes.
> 
> **Overview**
> **Re-aligns the docs site WASM demo with the current `wasm-demo-latest` release** so Vercel builds pass fail-closed integrity checks and the playground loads again.
> 
> `website-oxc/wasm-pin.json` is updated to source commit `342aa8a0b90cd2b3daca1472aa53e56357367770`, a new `inputsHash`, and new `wasm` `sha256` / `bytes` (worker pin unchanged). `pnpm run build` uses this file via `scripts/fetch-docs-wasm.ts` to download and verify the engine bytes against the pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9434376db29a6b7fbf530882e0630b262c3db136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->