### PR TITLE
site: immutable engine releases, a pin pull request, and red failures for the playground

### DIFF
--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -83,6 +83,9 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out the selected exact source revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -185,33 +188,31 @@ jobs:
           pnpm run docs:check
 
       # -----------------------------------------------------------------------
-      # Hand the engine just proved above to the build that cannot compile it.
+      # Deliver the proven engine to oxc.tsrx.dev.
       #
-      # https://oxc.tsrx.dev is a Vercel project rooted at website-oxc/, built by
-      # Vercel's git integration on Vercel's image: no cargo, no
-      # wasm32-wasip1-threads, no way to run `pnpm run docs:wasm`, and no Vercel
-      # credential in this repository to push a prebuilt artifact with. So the
-      # bytes travel by release instead. This job publishes them to the rolling
-      # `wasm-demo-latest` release and commits a pin naming their exact sha256s;
-      # scripts/fetch-docs-wasm.ts, which website-oxc's build script runs first,
-      # turns that pin back into files.
+      # The Git-connected Vercel project builds that site from every push to
+      # main, and website-oxc/package.json runs scripts/fetch-docs-wasm.ts
+      # first, which downloads the engine named by website-oxc/wasm-pin.json
+      # from a GitHub release and verifies every byte against the pin.
       #
-      # The pin commit is also the trigger: a push by GITHUB_TOKEN does not
-      # start another Actions run (no loop), but it does reach Vercel's webhook,
-      # which is precisely the delivery this needs.
+      # Two rules keep that from ever breaking the live site again:
       #
-      # Both steps run only after the artifact has been proved, only on main,
-      # and never fail this job -- see the continue-on-error note below.
+      # 1. Assets are immutable. Every engine is published under its own
+      #    release, wasm-demo-<inputs hash>, and never overwritten. A pin that
+      #    names such a release keeps resolving forever, so a pin that lands
+      #    late (or not at all) means an older engine stays live, not no
+      #    engine. The rolling wasm-demo-latest release is left as it is and
+      #    never written again: overwriting it under a pin that names it is
+      #    exactly how the demo went down.
+      # 2. The pin lands through a pull request. main is protected, so a push
+      #    from here is rejected (that is how the 0.9.0 pin outlived the 0.11.0
+      #    engine and took the demo down). The PR needs one approving review.
+      #
+      # Both steps fail this job when they fail: a red build here is the
+      # signal, and the live-engine-check job below is the other one.
       # -----------------------------------------------------------------------
-      - name: Publish the proven demo engine and pin it for oxc.tsrx.dev
-        # This whole path is additive: the compiled.run deploy (now a redirect
-        # to oxc.tsrx.dev plus /guessless) ships the artifact this job uploads
-        # and does not depend on any
-        # of it. A release API hiccup or a protected branch must therefore leave
-        # a warning, not a red build that blocks that deploy. The cost of a miss
-        # is bounded and self-correcting: oxc.tsrx.dev keeps serving its last
-        # good engine, and the next push to main pins again.
-        continue-on-error: true
+      - name: Publish the proven demo engine under an immutable release
+        id: engine
         if: >-
           github.repository == 'tsrx-org/oxc' &&
           github.ref_name == 'main' &&
@@ -222,10 +223,6 @@ jobs:
           set -euo pipefail
           wasm="docs/tools/demo-wasm/dist/demo-wasm.wasm"
           worker="docs/tools/demo-wasm/dist/wasi-worker-browser.mjs"
-
-          # The engine is two files and the worker is not optional: the bundled
-          # loader reaches it through a URL relative to the binary
-          # (docs/demo-wasm-engine-entry.mjs). Half an engine is worse than none.
           for file in "${wasm}" "${worker}"; do
             if [ ! -f "${file}" ]; then
               echo "::error::${file} is missing; the proven artifact is incomplete"
@@ -233,31 +230,37 @@ jobs:
             fi
           done
 
-          # One rolling release, replaced in place, so the site never has to
-          # discover which tag is current. `create` is expected to fail on every
-          # run after the first -- that failure is the steady state, and
-          # `upload --clobber` is what actually publishes.
-          gh release create wasm-demo-latest \
-            --title "wasm-demo-latest" \
-            --notes "Rolling WASM demo engine artifact for the oxc.tsrx.dev Vercel build. Not for installation." \
-            || true
-          gh release upload wasm-demo-latest "${wasm}" "${worker}" --clobber
-
-          # Computed by the same file the site build uses to check it, invoked
-          # here rather than reimplemented in shell: two definitions of "the
-          # sources this engine was built from" would eventually disagree, and
-          # the day they did, every site build would silently drop the engine.
           inputs_hash="$(node scripts/fetch-docs-wasm.ts --print-inputs-hash)"
+          tag="wasm-demo-${inputs_hash:0:12}"
 
+          # Same inputs, same release: the bytes CI proved first stay the bytes
+          # every pin naming this tag resolves to, even if a rebuild of the same
+          # sources is not bit-identical.
+          if gh release view "${tag}" > /dev/null 2>&1; then
+            echo "${tag} already exists; keeping its assets."
+          else
+            gh release create "${tag}" \
+              --title "${tag}" \
+              --notes "Demo engine for the oxc.tsrx.dev playground, built from ${GITHUB_SHA} (engine inputs ${inputs_hash}). Immutable; pinned by website-oxc/wasm-pin.json. Not for installation." \
+              "${wasm}" "${worker}"
+          fi
+          # wasm-demo-latest is deliberately no longer touched: a pin may still
+          # name it, and overwriting its assets under such a pin is the outage
+          # this step exists to prevent.
+
+          # The pin describes what the release serves, so it is computed from
+          # the release's own bytes, not from the local build.
+          served="$(mktemp -d)"
+          gh release download "${tag}" --dir "${served}" --pattern demo-wasm.wasm --pattern wasi-worker-browser.mjs
           pin="$(mktemp)"
           jq -n \
-            --arg tag "wasm-demo-latest" \
+            --arg tag "${tag}" \
             --arg inputsHash "${inputs_hash}" \
             --arg sourceCommit "${GITHUB_SHA}" \
-            --arg wasmSha "$(shasum -a 256 "${wasm}" | cut -d' ' -f1)" \
-            --argjson wasmBytes "$(stat -c%s "${wasm}")" \
-            --arg workerSha "$(shasum -a 256 "${worker}" | cut -d' ' -f1)" \
-            --argjson workerBytes "$(stat -c%s "${worker}")" \
+            --arg wasmSha "$(shasum -a 256 "${served}/demo-wasm.wasm" | cut -d' ' -f1)" \
+            --argjson wasmBytes "$(stat -c%s "${served}/demo-wasm.wasm")" \
+            --arg workerSha "$(shasum -a 256 "${served}/wasi-worker-browser.mjs" | cut -d' ' -f1)" \
+            --argjson workerBytes "$(stat -c%s "${served}/wasi-worker-browser.mjs")" \
             '{
               tag: $tag,
               inputsHash: $inputsHash,
@@ -267,50 +270,43 @@ jobs:
             }' > "${pin}"
 
           mkdir -p website-oxc
-          # sourceCommit is excluded from the comparison on purpose. It records
-          # which commit's build produced these bytes, so when the bytes and the
-          # inputs hash are unchanged the existing value is still the true
-          # answer and rewriting it would churn a commit -- and a Vercel rebuild
-          # -- on every push to main that cannot possibly change the engine.
           if [ -f website-oxc/wasm-pin.json ] &&
             [ "$(jq -S 'del(.sourceCommit)' website-oxc/wasm-pin.json 2>/dev/null)" = "$(jq -S 'del(.sourceCommit)' "${pin}")" ]; then
             echo "The published engine is unchanged; the existing pin still describes it."
           else
             cp "${pin}" website-oxc/wasm-pin.json
-            echo "Pinned wasm-demo-latest at inputs hash ${inputs_hash}"
+            echo "Pinned ${tag} (inputs ${inputs_hash})"
           fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
 
-      - name: Commit the pin when it changed
-        # Same reasoning as above, and one more: main can be protected or can
-        # have moved on. Neither is this job's business to turn red.
-        continue-on-error: true
+      - name: Open the pin pull request when the pin changed
         if: >-
           github.repository == 'tsrx-org/oxc' &&
           github.ref_name == 'main' &&
           hashFiles('docs/tools/demo-wasm/dist/demo-wasm.wasm') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.engine.outputs.tag }}
         run: |
           set -euo pipefail
           git add website-oxc/wasm-pin.json
-          # Staged first so this is one question, not two: an unchanged pin and
-          # a pin that does not exist in the tree yet both answer it correctly.
           if git diff --cached --quiet -- website-oxc/wasm-pin.json; then
-            echo "The pin is unchanged; nothing to commit, and nothing to rebuild."
+            echo "The pin is unchanged; nothing to open."
             exit 0
           fi
-
-          # Substituted before the commit exists, so this names the source
-          # commit whose build produced the engine, not the pin commit itself.
           short="$(git rev-parse --short HEAD)"
+          branch="site/wasm-pin-${short}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "site: pin wasm demo engine ${short}"
+          git push --force origin "HEAD:refs/heads/${branch}"
+          if gh pr list --head "${branch}" --state open --json number --jq 'length' | grep -q '^0$'; then
+            gh pr create --base main --head "${branch}" \
+              --title "site: pin wasm demo engine ${short}" \
+              --body "Pins the demo engine built from ${GITHUB_SHA} (release ${TAG}) for oxc.tsrx.dev. Until this merges the site keeps serving the previously pinned engine, which stays available because engine releases are immutable. Opened by site-artifact.yml; needs one approving review."
+          fi
+          echo "::notice::pin pull request open on ${branch}; oxc.tsrx.dev serves the previous engine until it merges"
 
-          # Losing a race with another push to main is ordinary, not
-          # exceptional. This commit touches one file that nothing else writes,
-          # so replaying it on top of whatever landed is always safe.
-          git fetch origin main
-          git rebase FETCH_HEAD
-          git push origin HEAD:main
 
       - name: Fetch and embed Guessless docs
         run: |
@@ -611,3 +607,42 @@ jobs:
           else
             echo "::warning::https://oxc.tsrx.dev returned ${status}; add the domain and DNS record per docs/releasing/site-oxc-tsrx-dev.md"
           fi
+
+  # The signal the owner asked for after the 0.11.0 outage: the live site is
+  # asked whether the playground engine it serves is the one main pins, and
+  # this job is red when it is not. Nothing here deploys; it only looks. The
+  # Git-connected Vercel project builds from this same push, so the answer is
+  # polled for a while before it is believed.
+  live-engine-check:
+    name: Live engine check (oxc.tsrx.dev)
+    needs: build
+    if: github.repository == 'tsrx-org/oxc' && github.ref_name == 'main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the pin main carries
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Prove oxc.tsrx.dev serves the pinned engine
+        run: |
+          set -euo pipefail
+          expected="$(jq -r .wasm.sha256 website-oxc/wasm-pin.json)"
+          base="https://oxc.tsrx.dev/assets/demo-wasm"
+          deadline=$((SECONDS + 1200))
+          while :; do
+            engine="$(curl -s -o /dev/null -w '%{http_code}' "${base}/engine.js")"
+            worker="$(curl -s -o /dev/null -w '%{http_code}' "${base}/wasi-worker-browser.mjs")"
+            wasm="$(curl -s -o /tmp/served.wasm -w '%{http_code}' "${base}/demo-wasm.wasm32-wasi.wasm")"
+            served="$(sha256sum /tmp/served.wasm | cut -d' ' -f1)"
+            if [ "${engine}" = "200" ] && [ "${worker}" = "200" ] && [ "${wasm}" = "200" ] && [ "${served}" = "${expected}" ]; then
+              echo "::notice::oxc.tsrx.dev serves the pinned engine ${expected:0:12}"
+              exit 0
+            fi
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::oxc.tsrx.dev is not serving the pinned engine: engine.js ${engine}, worker ${worker}, wasm ${wasm} (sha ${served:0:12}, pin ${expected:0:12}). The playground is on its static preview or an unexpected engine."
+              exit 1
+            fi
+            sleep 30
+          done

--- a/docs/releasing/site-oxc-tsrx-dev.md
+++ b/docs/releasing/site-oxc-tsrx-dev.md
@@ -168,3 +168,34 @@ full list of accounts, tokens, and identities a transfer has to re-establish.
 The two publications are independent by design: neither deploy job depends on
 the other, and either can be broken, disabled, or removed without affecting the
 other.
+
+## How the playground engine reaches oxc.tsrx.dev
+
+Rewritten 2026-09-07, after the 0.11.0 release took the playground down for an
+afternoon with every check green.
+
+The Vercel project builds the site from every push to `main`, and
+`website-oxc/package.json` runs `scripts/fetch-docs-wasm.ts` first. That script
+downloads the engine named by `website-oxc/wasm-pin.json` from a GitHub release
+and verifies every byte against the pin. Three rules now hold:
+
+- **Engine releases are immutable.** `site-artifact.yml` publishes each proven
+  engine under its own release, `wasm-demo-<12 hex of the inputs hash>`, and
+  never overwrites one. A pin that names such a release resolves forever, so a
+  pin that lands late means an older engine stays live, never no engine. The
+  rolling `wasm-demo-latest` release is never written again; overwriting it
+  under a pin that named it is what caused the outage.
+- **The pin lands through a pull request.** `main` is protected, so the
+  workflow's old direct push was rejected every time. It now pushes
+  `site/wasm-pin-<sha>` and opens a PR, which needs one approving review. Until
+  it merges, the site serves the previous engine.
+- **Failure is red, not static.** `fetch-docs-wasm.ts` exits non-zero when the
+  pinned bytes do not verify, which fails the Vercel build and leaves the
+  previous deployment live. `tests/site/wasm-pin.test.mjs` asks GitHub for the
+  committed pin's bytes on every pull request. The `live-engine-check` job asks
+  `https://oxc.tsrx.dev/assets/demo-wasm/` for the engine after every push to
+  `main` and fails when the served wasm is not the pinned one.
+
+A stale pin (engine older than the checkout) still installs, with a warning:
+that was the owner's 2026-08-29 directive and it stands. Only bytes that do not
+match the pin refuse.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "docs:serve": "node docs/serve.mjs",
     "docs:verify": "node docs/verify.mjs",
     "docs:check": "node scripts/check-docs-fresh.ts",
-    "test:site:unit": "node --test tests/site/benchmark-sections.test.mjs tests/site/benchmark-chart-parity.test.mjs tests/site/launch-build.test.mjs tests/site/fragment-links.test.mjs tests/site/documented-version-pin.test.mjs tests/site/platform-support-matrix.test.mjs tests/site/stale-pin-fallback.test.mjs",
+    "test:site:unit": "node --test tests/site/benchmark-sections.test.mjs tests/site/benchmark-chart-parity.test.mjs tests/site/launch-build.test.mjs tests/site/fragment-links.test.mjs tests/site/documented-version-pin.test.mjs tests/site/platform-support-matrix.test.mjs tests/site/stale-pin-fallback.test.mjs tests/site/wasm-pin.test.mjs",
     "test:site:static": "node tests/site/verify-static.mjs",
     "test:site:wasm": "pnpm run docs:wasm && node tests/site/verify-static.mjs --require-wasm",
     "test:site": "pnpm run test:site:unit && pnpm run test:site:static",

--- a/scripts/fetch-docs-wasm.ts
+++ b/scripts/fetch-docs-wasm.ts
@@ -17,13 +17,13 @@
 // Three rules shape everything below.
 //
 // It never fails the site build. A missing pin, a download that will not come,
-// bytes that do not match their hash: each one prints one line and exits 0.
-// docs/build.mjs detects the engine by the presence of
-// docs/tools/demo-wasm/dist/demo-wasm.wasm and renders the static preview
-// contract without it (docs/build.mjs, `wasmDemo`), so the correct degradation
-// is a site that builds and says the demo is unavailable -- never a red deploy.
-// The exit code matters: website-oxc/package.json runs this script and the site
-// build in one `&&` chain, so a non-zero exit here is a failed deploy.
+// bytes that do not match their hash: each one prints one line and exits 1.
+// website-oxc/package.json runs this script and the site build in one `&&`
+// chain, so a non-zero exit here is a failed Vercel deploy, and a failed deploy
+// leaves the previous deployment live. That is the point (owner directive,
+// 2026-09-07, after the 0.11.0 outage): a site that quietly renders the static
+// preview looked healthy to every check while the playground was gone. A red
+// deploy is seen; the last good engine stays up meanwhile.
 //
 // It refuses bytes that do not match the pin, and only those. sha256 and byte
 // length are checked on every download and a mismatch installs nothing --
@@ -254,11 +254,14 @@ if (printInputsHash) {
   try {
     await fetchPinnedEngine();
   } catch (error) {
-    // Reaching here now means the pin is unusable or its bytes did not verify,
-    // never that the pin is merely old. Exit 0 all the same: the site must
-    // build and say the demo is unavailable rather than fail the deploy.
+    // Reaching here means the pin is unusable or its bytes did not verify,
+    // never that the pin is merely old. Fail the build: the previous
+    // deployment stays live, and the failure is red where someone sees it.
     const reason = error instanceof Skip ? error.message : `unexpected failure: ${describe(error)}`;
-    console.log(`fetch-docs-wasm: no demo engine, ${reason}`);
-    console.log("fetch-docs-wasm: the playground will render its static preview instead.");
+    console.error(`fetch-docs-wasm: REFUSED -- no demo engine, ${reason}`);
+    console.error(
+      "fetch-docs-wasm: failing this build so the previous deployment stays live; fix the pin (website-oxc/wasm-pin.json) or the release it names.",
+    );
+    process.exitCode = 1;
   }
 }

--- a/tests/site/stale-pin-fallback.test.mjs
+++ b/tests/site/stale-pin-fallback.test.mjs
@@ -178,21 +178,23 @@ test("a stale pin installs the pinned engine and says so loudly", async (t) => {
   assert.doesNotMatch(run.output, /static preview/);
 });
 
-test("a stale pin whose bytes do not match their sha256 installs nothing", async (t) => {
+test("a stale pin whose bytes do not match their sha256 installs nothing and fails the build", async (t) => {
   const root = await makeFixtureRoot(t);
   await writePin(root, { wasm: { sha256: "b".repeat(64), bytes: 41 } });
   const release = await serveRelease(t);
 
   const run = await runScript(root, { base: release.base });
 
-  assert.equal(run.code, 0, `a refusal is still a green build: ${run.output}`);
+  // A refusal is a red build: the previous deployment stays live and someone
+  // sees it, instead of a green build that quietly renders the static preview.
+  assert.notEqual(run.code, 0, `a refusal must fail the build: ${run.output}`);
   assertNothingInstalled(root);
-  assert.match(run.output, /no demo engine/);
-  assert.match(run.output, /static preview/);
+  assert.match(run.output, /REFUSED -- no demo engine/);
+  assert.match(run.output, /previous deployment stays live/);
   assert.doesNotMatch(run.output, /demo engine in place/);
 });
 
-test("a fresh pin whose bytes are the wrong length installs nothing", async (t) => {
+test("a fresh pin whose bytes are the wrong length installs nothing and fails the build", async (t) => {
   const root = await makeFixtureRoot(t);
   const inputsHash = (await runScript(root, { args: ["--print-inputs-hash"] })).stdout.trim();
   await writePin(root, {
@@ -203,19 +205,19 @@ test("a fresh pin whose bytes are the wrong length installs nothing", async (t) 
 
   const run = await runScript(root, { base: release.base });
 
-  assert.equal(run.code, 0);
+  assert.notEqual(run.code, 0, run.output);
   assertNothingInstalled(root);
   assert.match(run.output, /bytes, the pin says 999999/);
 });
 
-test("a pin whose release will not serve the bytes installs nothing", async (t) => {
+test("a pin whose release will not serve the bytes installs nothing and fails the build", async (t) => {
   const root = await makeFixtureRoot(t);
   await writePin(root, { tag: "wasm-demo-missing" });
   const release = await serveRelease(t);
 
   const run = await runScript(root, { base: release.base });
 
-  assert.equal(run.code, 0);
+  assert.notEqual(run.code, 0, run.output);
   assertNothingInstalled(root);
   assert.match(run.output, /responded 404/);
 });

--- a/tests/site/wasm-pin.test.mjs
+++ b/tests/site/wasm-pin.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import test from "node:test";
+
+// The committed pin is what oxc.tsrx.dev builds from. This asks GitHub for the
+// release it names and checks every byte against it, so a pin that no longer
+// resolves is red in CI before it is a static preview in production. It needs
+// the network: that is the property under test.
+const repoRoot = resolve(import.meta.dirname, "../..");
+const releaseBase =
+  process.env.OXC_TSRX_WASM_RELEASE_BASE || "https://github.com/tsrx-org/oxc/releases/download";
+
+test("the committed wasm pin resolves to the exact bytes it names", async () => {
+  const pin = JSON.parse(await readFile(join(repoRoot, "website-oxc/wasm-pin.json"), "utf8"));
+  assert.match(pin.tag, /^wasm-demo-/u, "the pin names a demo engine release");
+  for (const [field, name] of [["wasm", "demo-wasm.wasm"], ["worker", "wasi-worker-browser.mjs"]]) {
+    const url = `${releaseBase}/${pin.tag}/${name}`;
+    const response = await fetch(url, { redirect: "follow", signal: AbortSignal.timeout(120_000) });
+    assert.equal(response.status, 200, `${url} responded ${response.status}`);
+    const bytes = Buffer.from(await response.arrayBuffer());
+    assert.equal(bytes.length, pin[field].bytes, `${name} length`);
+    assert.equal(createHash("sha256").update(bytes).digest("hex"), pin[field].sha256, `${name} sha256`);
+  }
+});


### PR DESCRIPTION
Why the playground went down with the 0.11.0 release, and the fix so it cannot happen silently again.

**What broke.** The site workflow overwrote the rolling `wasm-demo-latest` release assets from the 0.11.0 tree. Its pin push to `main` was rejected by branch protection, as it always is (the fetch script's own comments record this). The Vercel build then fetched bytes that no longer matched the 0.9.0 pin, refused them (integrity is fail-closed), exited 0, and rendered the static preview. Every check stayed green. #77 restored the site with a corrected pin.

**What changes.**
- Every proven engine is published under its own immutable release, `wasm-demo-<inputs hash>`, and never overwritten. A pin resolves however late it lands; a late pin means an older engine, never no engine. `wasm-demo-latest` is never written again.
- The pin lands through a pull request (`site/wasm-pin-<sha>`, needs one approving review) instead of a rejected push. Both steps now fail the build when they fail.
- `scripts/fetch-docs-wasm.ts` exits non-zero when pinned bytes do not verify, so a bad pin is a failed Vercel deploy that leaves the previous deployment live, not a green build with no engine. A stale-but-valid pin still installs with a warning, per the 2026-08-29 directive.
- New `live-engine-check` job: after every push to `main`, polls `https://oxc.tsrx.dev/assets/demo-wasm/` and fails red unless the served wasm hashes to the pin.
- New `tests/site/wasm-pin.test.mjs`: on every PR, asks GitHub for the committed pin's bytes and compares them.

Site-tests job run locally: docs build, 44 unit tests, 207 static checks, all green. Workflow YAML parsed and job graph verified. Runbook section added to `docs/releasing/site-oxc-tsrx-dev.md`.

Note for the first run after merge: the publish step will create `wasm-demo-f4ec67e2a356` and open a pin PR moving the pin off `wasm-demo-latest`; the site keeps serving the current engine until that PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production delivery for the live playground (release tags, pin workflow, and Vercel fail-closed behavior) and adds a flaky-prone post-deploy poll; mistakes could block merges or leave CI red until pin PRs land.
> 
> **Overview**
> Fixes the silent playground outage after 0.11.0 by changing how the demo WASM engine is published, pinned, and verified for **oxc.tsrx.dev**.
> 
> **CI publishing (`site-artifact.yml`)** stops overwriting the rolling `wasm-demo-latest` release and instead publishes each proven engine under an immutable tag `wasm-demo-<12-char inputs hash>`, reusing an existing release when the tag already exists. The pin in `website-oxc/wasm-pin.json` is derived from bytes downloaded from that release (not the local build), and updates land via a bot PR on `site/wasm-pin-<sha>` instead of a direct push to protected `main`. Publish and pin steps no longer use `continue-on-error`; failures fail the job. The build job gains `pull-requests: write`.
> 
> **Build behavior** — `scripts/fetch-docs-wasm.ts` now exits **1** when the pin is missing or bytes fail verification, so a bad pin fails the Vercel build and leaves the previous deployment live (stale-but-valid pins still install with a warning).
> 
> **New checks** — `live-engine-check` polls production for up to ~20 minutes and fails if served WASM does not match the pin on `main`. PR CI adds `tests/site/wasm-pin.test.mjs` (committed pin must resolve on GitHub Releases). Stale-pin unit tests expect a red build on integrity refusal.
> 
> **Docs** — `docs/releasing/site-oxc-tsrx-dev.md` documents the immutable-release + pin-PR + red-failure model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027286e0cc3e964c3a5bf5216705f6838fb919ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->