### PR TITLE
fix(lint): a file OXC cannot parse is a named, positioned error, not a batch failure

### DIFF
--- a/crates/oxc_adapter/Cargo.toml
+++ b/crates/oxc_adapter/Cargo.toml
@@ -19,6 +19,7 @@ parser = [
 ]
 toolchain = [
   "dep:oxc_config",
+  "dep:oxc_diagnostics",
   "dep:oxc_formatter",
   "dep:oxc_formatter_core",
   "dep:oxc_linter",

--- a/crates/oxc_adapter/src/toolchain/diagnostics.rs
+++ b/crates/oxc_adapter/src/toolchain/diagnostics.rs
@@ -1,5 +1,6 @@
 //! The project-owned diagnostic vocabulary, and the mapping from canonical OXC messages onto it.
 
+use oxc_diagnostics::OxcDiagnostic;
 use oxc_linter::{FixKind, Message, PossibleFixes};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +50,28 @@ pub(super) fn map_message(message: &Message) -> EngineDiagnostic {
         message: message.error.message.to_string(),
         labels,
         fixes: fixes(&message.fixes),
+    }
+}
+
+/// A parser or semantic diagnostic, which has no rule and no fix: its labels address the
+/// source the engine was handed, so a projected buffer's spans still need mapping back.
+pub(super) fn map_oxc_diagnostic(error: &OxcDiagnostic) -> EngineDiagnostic {
+    EngineDiagnostic {
+        rule: None,
+        plugin: None,
+        code: error.code.to_string(),
+        severity: format!("{:?}", error.severity).to_ascii_lowercase(),
+        message: error.message.to_string(),
+        labels: error
+            .labels
+            .iter()
+            .map(|label| EngineSpan {
+                offset: label.offset(),
+                length: label.len(),
+                message: label.label().map(ToString::to_string),
+            })
+            .collect(),
+        fixes: Vec::new(),
     }
 }
 

--- a/crates/oxc_adapter/src/toolchain/session.rs
+++ b/crates/oxc_adapter/src/toolchain/session.rs
@@ -19,7 +19,7 @@ use oxc_semantic::SemanticBuilder;
 use rustc_hash::FxHashMap;
 
 use super::config::ConfigError;
-use super::diagnostics::{EngineDiagnostic, map_message};
+use super::diagnostics::{EngineDiagnostic, map_message, map_oxc_diagnostic};
 use super::engine::{LintEngine, LintEngineOptions};
 use super::timings::{EngineTimings, elapsed_ns};
 use super::tsgolint::{
@@ -34,10 +34,12 @@ use crate::{DynamicTagContract, DynamicTagError, SourceKind, validate_dynamic_ta
 pub enum LintError {
     /// The request's fix mode does not match the mode the session was compiled with.
     FixModeMismatch,
-    /// Canonical OXC could not parse the projected source. Holds its joined diagnostic text.
-    Parse { detail: String },
-    /// Canonical OXC could not build semantics. Holds its joined diagnostic text.
-    Semantic { detail: String },
+    /// Canonical OXC could not parse the projected source. Holds its joined diagnostic text and
+    /// the diagnostics themselves, whose labels address the parsed buffer, so a caller that
+    /// projected that buffer can map them back and report the failure at a real position.
+    Parse { detail: String, diagnostics: Vec<EngineDiagnostic> },
+    /// Canonical OXC could not build semantics. Same shape as `Parse`.
+    Semantic { detail: String, diagnostics: Vec<EngineDiagnostic> },
     /// The TSRX dynamic-tag scaffold did not survive the parse.
     DynamicTags(DynamicTagError),
     /// The single-shot [`lint`] entry point could not compile a configuration first.
@@ -50,8 +52,8 @@ impl fmt::Display for LintError {
             Self::FixModeMismatch => {
                 formatter.write_str("lint request fix mode differs from the compiled lint session")
             }
-            Self::Parse { detail } => write!(formatter, "OXC parse failed: {detail}"),
-            Self::Semantic { detail } => {
+            Self::Parse { detail, .. } => write!(formatter, "OXC parse failed: {detail}"),
+            Self::Semantic { detail, .. } => {
                 write!(formatter, "OXC semantic analysis failed: {detail}")
             }
             Self::DynamicTags(error) => error.fmt(formatter),
@@ -220,7 +222,8 @@ impl LintEngine {
         if !parsed.diagnostics.is_empty() {
             let detail =
                 parsed.diagnostics.iter().map(ToString::to_string).collect::<Vec<_>>().join("; ");
-            return Err(LintError::Parse { detail });
+            let diagnostics = parsed.diagnostics.iter().map(map_oxc_diagnostic).collect();
+            return Err(LintError::Parse { detail, diagnostics });
         }
         validate_dynamic_tags(&parsed.program, request.dynamic_tags)?;
         let parse_ns = elapsed_ns(started);
@@ -239,7 +242,8 @@ impl LintEngine {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join("; ");
-            return Err(LintError::Semantic { detail });
+            let diagnostics = semantic_return.diagnostics.iter().map(map_oxc_diagnostic).collect();
+            return Err(LintError::Semantic { detail, diagnostics });
         }
         let semantic = semantic_return.semantic;
 

--- a/crates/oxc_tsrx_cli/src/lsp.rs
+++ b/crates/oxc_tsrx_cli/src/lsp.rs
@@ -967,6 +967,12 @@ fn parse_error_diagnostic(source: &str, error: &LintError) -> EditorDiagnostic {
     let positioned = match error {
         LintError::Projection(error) => error.byte_offset(),
         LintError::Syntax(EngineLintError::DynamicTags(error)) => error.byte_offset(),
+        LintError::Unparsed(unparsed) => unparsed
+            .diagnostics
+            .iter()
+            .flat_map(|diagnostic| diagnostic.labels.iter())
+            .map(|label| label.offset)
+            .next(),
         LintError::UnreadableSource { .. }
         | LintError::UnwritableSource { .. }
         | LintError::TextLintWithFixes

--- a/crates/tsrx_lint/src/error.rs
+++ b/crates/tsrx_lint/src/error.rs
@@ -6,7 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use oxc_adapter::{ConfigError, LintError as EngineLintError, SourceKindError, TypeLintError};
+use oxc_adapter::{
+    ConfigError, EngineDiagnostic, LintError as EngineLintError, SourceKindError, TypeLintError,
+};
 use tsrx_syntax::ProjectionError;
 
 /// Why a native lint run produced no report.
@@ -36,6 +38,21 @@ pub enum LintError {
     Syntax(EngineLintError),
     /// The type-aware lane failed.
     TypeAware(TypeLintError),
+    /// Canonical OXC refused the projected copy of one file. The diagnostics are the parser's
+    /// own, already mapped back to authored offsets where the projection could, so a batch
+    /// reports this file by name and position and goes on to the next one (tsrx-org/oxc#79).
+    Unparsed(Box<UnparsedFile>),
+}
+
+/// What canonical OXC said about one file it could not parse, in authored coordinates.
+#[derive(Debug)]
+pub struct UnparsedFile {
+    pub path: PathBuf,
+    /// `OXC parse failed` or `OXC semantic analysis failed`: the engine error's own headline.
+    pub headline: String,
+    /// The joined engine text, for the one-line form.
+    pub detail: String,
+    pub diagnostics: Vec<EngineDiagnostic>,
 }
 
 impl LintError {
@@ -68,6 +85,13 @@ impl fmt::Display for LintError {
             Self::Config(error) => error.fmt(formatter),
             Self::Syntax(error) => error.fmt(formatter),
             Self::TypeAware(error) => error.fmt(formatter),
+            Self::Unparsed(unparsed) => write!(
+                formatter,
+                "{}: {}: {}",
+                unparsed.path.display(),
+                unparsed.headline,
+                unparsed.detail
+            ),
         }
     }
 }
@@ -83,7 +107,7 @@ impl Error for LintError {
             Self::Config(error) => Some(error),
             Self::Syntax(error) => Some(error),
             Self::TypeAware(error) => Some(error),
-            Self::TextLintWithFixes | Self::CodeActionsWithoutFixes => None,
+            Self::TextLintWithFixes | Self::CodeActionsWithoutFixes | Self::Unparsed(_) => None,
         }
     }
 }

--- a/crates/tsrx_lint/src/lib.rs
+++ b/crates/tsrx_lint/src/lib.rs
@@ -7,7 +7,7 @@ mod report;
 mod session;
 mod translate;
 
-pub use error::LintError;
+pub use error::{LintError, UnparsedFile};
 pub use oxc_adapter::{RuleFilter as ConfigRuleFilter, RuleSeverity as ConfigRuleSeverity};
 pub use report::{
     DiagnosticOutput, EditorFix, FileCounts, FixOutput, LabelOutput, Metadata, Output, SpanOutput,

--- a/crates/tsrx_lint/src/pipeline.rs
+++ b/crates/tsrx_lint/src/pipeline.rs
@@ -8,19 +8,19 @@ use std::{
 };
 
 use oxc_adapter::{
-    DynamicTagContract, EngineDiagnostic, LintRequest, LintResult, OXC_REVISION, SourceKind,
-    TypeBatchFile,
+    DynamicTagContract, EngineDiagnostic, LintError as EngineLintError, LintRequest, LintResult,
+    OXC_REVISION, SourceKind, TypeBatchFile,
 };
 use tsrx_syntax::{
     MappedProjection, TypeProjection, project_for_lint, project_for_types, scan_for_parser,
 };
 
 use crate::{
-    error::LintError,
+    error::{LintError, UnparsedFile},
     fixes::{AppliedFixes, apply_safe_fixes},
     report::{
         FileCounts, FixOutput, Metadata, Output, TimingOutput, map_diagnostics,
-        projection_failure_output,
+        parse_failure_output, projection_failure_output,
     },
     session::LintSession,
     translate::{translate_diagnostics, translate_type_diagnostics},
@@ -65,6 +65,7 @@ pub(crate) fn lint_loaded_file(
 ) -> Result<Output, LintError> {
     match lint_loaded_source(session, path, source, allow_writes) {
         Err(LintError::Projection(error)) => Ok(projection_failure_output(session, path, &error)),
+        Err(LintError::Unparsed(unparsed)) => Ok(parse_failure_output(session, &unparsed)),
         result => result,
     }
 }
@@ -130,7 +131,7 @@ pub(crate) fn run_syntax_lint(
 ) -> Result<(PreparedSource, LintResult), LintError> {
     let prepared = prepare_source(path, source, session.engine.type_aware_enabled())?;
     let parse_source = prepared.parse_source(source);
-    let syntax = session.engine.lint(&LintRequest {
+    let request = LintRequest {
         path,
         original_source: source,
         parse_source,
@@ -142,8 +143,38 @@ pub(crate) fn run_syntax_lint(
                 DynamicTagContract { prefix, count, original_offsets }
             })
         }),
-    })?;
+    };
+    let syntax = match session.engine.lint(&request) {
+        Ok(syntax) => syntax,
+        // The projection is still in hand here, which is the only place the parser's spans can
+        // be mapped back to what the user wrote. A span the projection cannot map is dropped
+        // rather than invented; the file is still named, and the batch still continues.
+        Err(EngineLintError::Parse { detail, diagnostics }) => {
+            return Err(unparsed(path, "OXC parse failed", detail, diagnostics, &prepared));
+        }
+        Err(EngineLintError::Semantic { detail, diagnostics }) => {
+            let headline = "OXC semantic analysis failed";
+            return Err(unparsed(path, headline, detail, diagnostics, &prepared));
+        }
+        Err(error) => return Err(error.into()),
+    };
     Ok((prepared, syntax))
+}
+
+fn unparsed(
+    path: &Path,
+    headline: &str,
+    detail: String,
+    diagnostics: Vec<EngineDiagnostic>,
+    prepared: &PreparedSource,
+) -> LintError {
+    let translated = translate_diagnostics(diagnostics, prepared.projection.as_ref());
+    LintError::Unparsed(Box::new(UnparsedFile {
+        path: path.to_path_buf(),
+        headline: headline.to_string(),
+        detail,
+        diagnostics: translated.diagnostics,
+    }))
 }
 
 #[expect(

--- a/crates/tsrx_lint/src/report.rs
+++ b/crates/tsrx_lint/src/report.rs
@@ -9,7 +9,7 @@ use oxc_adapter::{EngineDiagnostic, OXC_REVISION};
 use serde::Serialize;
 use tsrx_syntax::ProjectionError;
 
-use crate::session::LintSession;
+use crate::{error::UnparsedFile, session::LintSession};
 
 #[derive(Debug, Serialize)]
 pub struct SpanOutput {
@@ -209,8 +209,9 @@ pub(crate) fn projection_failure_output(
         .map(|offset| LabelOutput { span: SpanOutput { offset, length: 0 }, message: None })
         .into_iter()
         .collect();
-    Output {
-        diagnostics: vec![DiagnosticOutput {
+    failure_shell(
+        session,
+        vec![DiagnosticOutput {
             filename: path.to_string_lossy().into_owned(),
             rule: String::new(),
             code: String::new(),
@@ -218,6 +219,13 @@ pub(crate) fn projection_failure_output(
             message: error.to_string(),
             labels,
         }],
+    )
+}
+
+/// The one-file report shell shared by every failure that stands in for a lint result.
+fn failure_shell(session: &LintSession, diagnostics: Vec<DiagnosticOutput>) -> Output {
+    Output {
+        diagnostics,
         number_of_files: 1,
         number_of_rules: session.engine.number_of_rules(),
         threads_count: 1,
@@ -242,6 +250,47 @@ pub(crate) fn projection_failure_output(
             type_aware_processes: 0,
         },
     }
+}
+
+/// The report for a file canonical OXC could not parse: one `error` per parser diagnostic,
+/// named by file and positioned where the projection could map the parser's span back to the
+/// authored source. Same rule-less, code-less shape as a projection failure, because the
+/// failure is the source itself. When no span maps, the joined engine text stands alone so the
+/// file is still named.
+pub(crate) fn parse_failure_output(session: &LintSession, unparsed: &UnparsedFile) -> Output {
+    let filename = unparsed.path.to_string_lossy().into_owned();
+    let mut diagnostics = unparsed
+        .diagnostics
+        .iter()
+        .map(|diagnostic| DiagnosticOutput {
+            filename: filename.clone(),
+            rule: String::new(),
+            code: String::new(),
+            severity: "error".to_string(),
+            message: format!("{}: {}", unparsed.headline, diagnostic.message),
+            labels: diagnostic
+                .labels
+                .iter()
+                .map(|label| LabelOutput {
+                    span: SpanOutput { offset: label.offset, length: label.length },
+                    message: label.message.clone(),
+                })
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    if diagnostics.is_empty() {
+        diagnostics.push(DiagnosticOutput {
+            filename,
+            rule: String::new(),
+            code: String::new(),
+            severity: "error".to_string(),
+            message: format!("{}: {}", unparsed.headline, unparsed.detail),
+            labels: Vec::new(),
+        });
+    }
+    let mut output = failure_shell(session, diagnostics);
+    output.metadata.parse_count = 1;
+    output
 }
 
 pub(crate) fn map_diagnostics(

--- a/crates/tsrx_lint/src/session.rs
+++ b/crates/tsrx_lint/src/session.rs
@@ -17,7 +17,9 @@ use crate::{
         PendingBatchFile, finish_lint, lint_loaded_file, lint_loaded_source, run_syntax_lint,
         run_type_lint, virtual_type_path,
     },
-    report::{EditorFix, Output, aggregate_outputs, projection_failure_output},
+    report::{
+        EditorFix, Output, aggregate_outputs, parse_failure_output, projection_failure_output,
+    },
     translate::{translate_diagnostics, translate_type_diagnostics},
 };
 
@@ -170,6 +172,9 @@ impl LintSession {
                 }),
                 Err(LintError::Projection(error)) => {
                     ordered[slot] = Some(projection_failure_output(self, path, &error));
+                }
+                Err(LintError::Unparsed(unparsed)) => {
+                    ordered[slot] = Some(parse_failure_output(self, &unparsed));
                 }
                 Err(error) => return Err(error),
             }

--- a/crates/tsrx_lint/tests/parse_failure.rs
+++ b/crates/tsrx_lint/tests/parse_failure.rs
@@ -1,0 +1,64 @@
+//! tsrx-org/oxc#79: a file canonical OXC cannot parse is one named, positioned error in the
+//! batch, not a batch-wide failure with no file name.
+
+use std::{fs, path::PathBuf};
+
+use tsrx_lint::{LintError, LintSession};
+
+fn scratch(name: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!("tsrx-lint-{name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&directory);
+    fs::create_dir_all(&directory).unwrap();
+    directory
+}
+
+const PROBE: &str = "export function Probe() @{\n\tconst element = document.createElement('div');\n\tdocument./*completion*/;\n\t<div>{element.dataset}</div>\n}\n";
+const CLEAN: &str = "export function Clean() @{\n\tvar count = 0;\n\t<p>{count}</p>\n}\n";
+
+#[test]
+fn an_unparsable_file_is_a_named_positioned_error_and_the_batch_continues() {
+    let directory = scratch("parse-failure");
+    fs::write(directory.join(".oxlintrc.json"), r#"{ "rules": { "no-var": "error" } }"#).unwrap();
+    let probe = directory.join("probe.tsrx");
+    let clean = directory.join("clean.tsrx");
+    fs::write(&probe, PROBE).unwrap();
+    fs::write(&clean, CLEAN).unwrap();
+
+    let session = LintSession::new(&directory, None, &[], false).unwrap();
+    let outputs = session.lint_files(&[probe.clone(), clean]).unwrap();
+    assert_eq!(outputs.len(), 2, "both files report");
+
+    let failed = &outputs[0];
+    assert_eq!(failed.diagnostics.len(), 1, "{:?}", failed.diagnostics);
+    let diagnostic = &failed.diagnostics[0];
+    assert!(diagnostic.filename.ends_with("probe.tsrx"), "{}", diagnostic.filename);
+    assert_eq!(diagnostic.severity, "error");
+    assert!(diagnostic.message.starts_with("OXC parse failed: "), "{}", diagnostic.message);
+    // The parser's span, mapped back onto the authored line that holds the incomplete access.
+    let line_start = PROBE.find("\tdocument./*").unwrap();
+    let line_end = PROBE[line_start..].find('\n').unwrap() + line_start;
+    let offset = diagnostic.labels.first().map(|label| label.span.offset as usize);
+    assert!(
+        offset.is_some_and(|offset| (line_start..=line_end).contains(&offset)),
+        "the diagnostic must land on the authored line ({line_start}..{line_end}), got {offset:?}"
+    );
+
+    let linted = &outputs[1];
+    assert!(
+        linted.diagnostics.iter().any(|item| item.code.contains("no-var")),
+        "the clean file still linted: {:?}",
+        linted.diagnostics
+    );
+
+    // The in-memory lane hands the same facts to the editor as an error it can position.
+    let error = session.lint_text(&probe, PROBE).unwrap_err();
+    match error {
+        LintError::Unparsed(unparsed) => {
+            assert!(unparsed.path.ends_with("probe.tsrx"));
+            assert_eq!(unparsed.headline, "OXC parse failed");
+            assert!(!unparsed.diagnostics.is_empty());
+        }
+        other => panic!("expected Unparsed, got {other:?}"),
+    }
+    let _ = fs::remove_dir_all(directory);
+}

--- a/tests/config/native-lint-config.test.mjs
+++ b/tests/config/native-lint-config.test.mjs
@@ -988,3 +988,24 @@ test("the drop-in oxlint skips gitignored trees and survives a file list past th
   assert.ok([...files][0].endsWith("src/a.tsrx"), [...files][0]);
   await rm(directory, { recursive: true, force: true });
 });
+
+test("the drop-in oxlint names and positions a file OXC cannot parse and keeps the batch", async () => {
+  // tsrx-org/oxc#79: the whole run used to exit 2 with an unattributed parse failure.
+  const directory = await mkdtemp(join(tmpdir(), "oxc-tsrx-parse-failure-launcher-"));
+  await mkdir(join(directory, "src"), { recursive: true });
+  await writeFile(join(directory, ".oxlintrc.json"), '{ "rules": { "no-debugger": "error" } }\n');
+  await writeFile(
+    join(directory, "src/Probe.tsrx"),
+    "export function Probe() @{\n\tconst element = document.createElement('div');\n\tdocument./*completion*/;\n\t<div>{element.dataset}</div>\n}\n",
+  );
+  await writeFile(join(directory, "src/Clean.tsrx"), "export function Clean() @{\n\tdebugger;\n\t<p>hi</p>\n}\n");
+  await writeFile(join(directory, "src/ordinary.ts"), "export const ordinary = 1;\n");
+
+  const result = await runCompanion(directory, ["."]);
+  assert.equal(result.code, 1, `errors exit 1, never the tool-failure 2: ${result.stderr || result.stdout}`);
+  assert.doesNotMatch(result.stderr, /OXC parse failed/u, "the failure is a diagnostic, not a stderr abort");
+  assert.match(result.stdout, /src\/Probe\.tsrx:3:\d+: error: OXC parse failed: /u, result.stdout);
+  assert.match(result.stdout, /src\/Clean\.tsrx:2:\d+: error eslint\(no-debugger\)/u, result.stdout);
+  assert.match(result.stdout, /on 3 files/u, result.stdout);
+  await rm(directory, { recursive: true, force: true });
+});

--- a/tests/native-lint.test.mjs
+++ b/tests/native-lint.test.mjs
@@ -342,3 +342,27 @@ test('--discover walks with .gitignore honoured and --paths-file carries a list 
   assert.equal(report.diagnostics.filter((item) => item.code.includes('no-debugger')).length, 2);
   await rm(directory, { recursive: true, force: true });
 });
+
+test('a file OXC cannot parse is a named, positioned error and the rest of the batch still reports', async () => {
+  // tsrx-org/oxc#79: an editor-completion probe with an incomplete member access used to abort
+  // the whole batch with "OXC parse failed: Unexpected token" and no file name.
+  const directory = await mkdtemp(join(tmpdir(), 'oxc-tsrx-parse-failure-'));
+  const probe = "export function Probe() @{\n\tconst element = document.createElement('div');\n\tdocument./*completion*/;\n\t<div>{element.dataset}</div>\n}\n";
+  await writeFile(join(directory, 'probe.tsrx'), probe);
+  await writeFile(join(directory, 'clean.tsrx'), "export function Clean() @{\n\tdebugger;\n\t<p>hi</p>\n}\n");
+  const result = await run([join(directory, 'probe.tsrx'), join(directory, 'clean.tsrx')]);
+  // Error diagnostics exit 1, as for any lint error; the tool-failure exit 2 is what went away.
+  assert.equal(result.code, 1, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.number_of_files, 2);
+  const failures = report.diagnostics.filter((item) => item.filename.endsWith('probe.tsrx'));
+  assert.equal(failures.length, 1, JSON.stringify(report.diagnostics));
+  assert.equal(failures[0].severity, 'error');
+  assert.match(failures[0].message, /^OXC parse failed: /u);
+  const lineStart = probe.indexOf('\tdocument./*');
+  const lineEnd = probe.indexOf('\n', lineStart);
+  const offset = failures[0].labels[0]?.span.offset;
+  assert.ok(offset >= lineStart && offset <= lineEnd, `offset ${offset} not on the authored line ${lineStart}..${lineEnd}`);
+  assert.ok(report.diagnostics.some((item) => item.filename.endsWith('clean.tsrx') && item.code.includes('no-debugger')), 'the other file still reports');
+  await rm(directory, { recursive: true, force: true });
+});


### PR DESCRIPTION
Fixes #79.

An editor-completion probe like `document./*M3_DOM*/;` made `oxlint .` exit 2 with only `OXC parse failed: Unexpected token`, after every other file had already linted clean, and without naming the file.

- The adapter's `LintError::Parse` (and `Semantic`) now carries the parser's own diagnostics with their projected spans instead of a joined string.
- `run_syntax_lint` maps those spans back to the authored source while it still holds the projection and returns a new `LintError::Unparsed`, which both batch entry points turn into a per-file report: one rule-less `error` per parser diagnostic, named and positioned, exactly as a scanner failure is reported today. The batch continues; the exit code is the ordinary 1 for errors.
- The language server positions the same error in the buffer.

Tests: a crate-level integration test (`crates/tsrx_lint/tests/parse_failure.rs`), a leaf test in `tests/native-lint.test.mjs`, and a launcher test in `tests/config/native-lint-config.test.mjs` (`src/Probe.tsrx:3:N: error: OXC parse failed: …`, the sibling file still reports, `on 3 files`, exit 1, nothing on stderr). Full chain green: cargo workspace, 224 Node tests, 124 packaging tests, licences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lint error handling and batch continuation on parse/semantic failure; behavior is well-tested but touches adapter, pipeline, LSP positioning, and exit-code semantics.
> 
> **Overview**
> Fixes **tsrx-org/oxc#79**: when canonical OXC rejects a projected file (e.g. an editor completion stub like `document./*…*/`), lint no longer aborts the whole run with exit **2** and an unattributed `OXC parse failed` on stderr.
> 
> **Adapter:** `LintError::Parse` and `Semantic` now carry structured `EngineDiagnostic` values (via `map_oxc_diagnostic`) in addition to the joined detail string, so callers can map parser spans off the projected buffer.
> 
> **Orchestration:** The syntax pipeline catches those engine errors, translates labels back to authored coordinates while the projection is still available, and surfaces **`LintError::Unparsed`** instead of a batch-stopping syntax failure. Filesystem and batch entry points turn that into a per-file report (`parse_failure_output`), same spirit as projection failures—the batch continues and exit code stays **1** for diagnostics.
> 
> **LSP:** `parse_error_diagnostic` uses the first label offset from `Unparsed` so the editor can squiggle the real line.
> 
> Integration tests cover Rust batch behavior, the native JSON CLI, and the drop-in `oxlint` launcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abb8c034055800ca54881b385e2df9f094902399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->