### PR TITLE
chore: release v0.12.0

### DIFF
--- a/.github/workflows/site-artifact.yml
+++ b/.github/workflows/site-artifact.yml
@@ -622,13 +622,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check out the pin main carries
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
+      # No checkout and no build here, by contract: everything after the deploy
+      # job only looks. The pin this push carries is read straight from the API.
       - name: Prove oxc.tsrx.dev serves the pinned engine
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          expected="$(jq -r .wasm.sha256 website-oxc/wasm-pin.json)"
+          expected="$(gh api "repos/${GITHUB_REPOSITORY}/contents/website-oxc/wasm-pin.json?ref=${GITHUB_SHA}" --jq .content | base64 -d | jq -r .wasm.sha256)"
+          echo "pin at ${GITHUB_SHA:0:7}: ${expected:0:12}"
           base="https://oxc.tsrx.dev/assets/demo-wasm"
           deadline=$((SECONDS + 1200))
           while :; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_adapter"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "oxc-miette",
  "oxc_allocator",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_tsrx_benchmark"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "memory-stats",
  "oxc_adapter",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_tsrx_cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ignore",
  "oxc_adapter",
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "oxc_tsrx_format_benchmark"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "memory-stats",
  "oxc_adapter",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "parser_napi_binding"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "mimalloc-safe",
  "napi",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_format"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "globset",
  "ignore",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_lint"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "oxc_adapter",
  "serde",
@@ -2041,7 +2041,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_parser_engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "oxc_adapter",
  "tsrx_syntax",
@@ -2052,14 +2052,14 @@ dependencies = [
 
 [[package]]
 name = "tsrx_syntax"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "unicode-id-start",
 ]
 
 [[package]]
 name = "tsrx_tape_schema"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "unicode-id"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/tsrx-org/oxc"

--- a/docs/generate-transcripts.mjs
+++ b/docs/generate-transcripts.mjs
@@ -381,7 +381,7 @@ const scaffoldPackageJson = `${JSON.stringify(
     private: true,
     type: 'module',
     devDependencies: {
-      '@tsrx/oxc': '0.11.0',
+      '@tsrx/oxc': '0.12.0',
       '@types/react': '^19.2.17',
       typescript: '~6.0.2',
       'vite-plus': '^0.2.6',

--- a/docs/tools/demo-wasm/Cargo.lock
+++ b/docs/tools/demo-wasm/Cargo.lock
@@ -813,12 +813,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_adapter"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_config",
+ "oxc_diagnostics",
  "oxc_formatter",
  "oxc_formatter_core",
  "oxc_linter",
@@ -1770,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_format"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "globset",
  "ignore",
@@ -1783,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_lint"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "oxc_adapter",
  "serde",
@@ -1792,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_syntax"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "unicode-id-start",
 ]

--- a/docs/tools/projection-dump/Cargo.lock
+++ b/docs/tools/projection-dump/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "tsrx_syntax"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "unicode-id-start",
 ]

--- a/licenses/RUST_DEPENDENCIES.md
+++ b/licenses/RUST_DEPENDENCIES.md
@@ -6,7 +6,7 @@ build dependency closure of the three binaries in `oxc_tsrx_cli` and the
 native addon in `parser_napi_binding`; benchmark and development-only
 dependencies are excluded.
 
-- Cargo.lock SHA-256: `09e50333fd0320ede9862b96131599906721463cf72c739fe17c2a097a8ca40e`
+- Cargo.lock SHA-256: `56ac85d85771fdb54d8632a738b5fa38c402ed091215ada334eca5c8a4b1f26c`
 - Canonical OXC revision: `8e0ed2ebb96137fb1611cdbd5742d5cb46037d40`
 - Shipping third-party packages: 220
 - Accepted license policy: `licenses/allowed-rust-license-expressions.json`

--- a/licenses/rust-dependencies.json
+++ b/licenses/rust-dependencies.json
@@ -2,10 +2,10 @@
   "schemaVersion": 2,
   "generatedBy": "scripts/generate-rust-license-inventory.ts",
   "rootPackages": [
-    "oxc_tsrx_cli@0.11.0",
-    "parser_napi_binding@0.11.0"
+    "oxc_tsrx_cli@0.12.0",
+    "parser_napi_binding@0.12.0"
   ],
-  "cargoLockSha256": "09e50333fd0320ede9862b96131599906721463cf72c739fe17c2a097a8ca40e",
+  "cargoLockSha256": "56ac85d85771fdb54d8632a738b5fa38c402ed091215ada334eca5c8a4b1f26c",
   "oxcRevision": "8e0ed2ebb96137fb1611cdbd5742d5cb46037d40",
   "licenseSelectionPolicy": "Each Cargo expression is reviewed; selectedDistributionLicense records the basis used for binary distribution.",
   "packageCount": 220,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsrx/oxc-monorepo",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The official OXC integration for TSRX",
   "private": true,
   "keywords": [

--- a/packages/toolchain/dist/parser.js
+++ b/packages/toolchain/dist/parser.js
@@ -3,7 +3,7 @@ import { isTsrxBinaryProgram, parseTrustedTsrxProgram, parseTsrxProgram } from "
 import { createRequire } from "node:module";
 //#region src/parser.ts
 const require = createRequire(import.meta.url);
-const PACKAGE_VERSION = "0.11.0";
+const PACKAGE_VERSION = "0.12.0";
 const parserManifest = Object.freeze({
 	name: "@tsrx/oxc",
 	version: PACKAGE_VERSION,

--- a/packages/toolchain/package.json
+++ b/packages/toolchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsrx/oxc",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The official OXC integration for TSRX — Rust-native Oxlint and Oxfmt for .tsrx, JavaScript, TypeScript, and JSX",
   "keywords": [
     "formatter",
@@ -128,14 +128,14 @@
     "tinyglobby": "0.2.17"
   },
   "optionalDependencies": {
-    "@tsrx/oxc-darwin-arm64": "0.11.0",
-    "@tsrx/oxc-darwin-x64": "0.11.0",
-    "@tsrx/oxc-linux-arm64-gnu": "0.11.0",
-    "@tsrx/oxc-linux-arm64-musl": "0.11.0",
-    "@tsrx/oxc-linux-x64-gnu": "0.11.0",
-    "@tsrx/oxc-linux-x64-musl": "0.11.0",
-    "@tsrx/oxc-win32-arm64-msvc": "0.11.0",
-    "@tsrx/oxc-win32-x64-msvc": "0.11.0"
+    "@tsrx/oxc-darwin-arm64": "0.12.0",
+    "@tsrx/oxc-darwin-x64": "0.12.0",
+    "@tsrx/oxc-linux-arm64-gnu": "0.12.0",
+    "@tsrx/oxc-linux-arm64-musl": "0.12.0",
+    "@tsrx/oxc-linux-x64-gnu": "0.12.0",
+    "@tsrx/oxc-linux-x64-musl": "0.12.0",
+    "@tsrx/oxc-win32-arm64-msvc": "0.12.0",
+    "@tsrx/oxc-win32-x64-msvc": "0.12.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/toolchain/src/parser.ts
+++ b/packages/toolchain/src/parser.ts
@@ -7,7 +7,7 @@ import {
 import { NATIVE_TARGETS, nativePackageName, nativeTargetForHost } from "./native-targets.js";
 
 const require = createRequire(import.meta.url);
-const PACKAGE_VERSION = "0.11.0";
+const PACKAGE_VERSION = "0.12.0";
 const parserManifest = Object.freeze({
   name: "@tsrx/oxc",
   version: PACKAGE_VERSION,

--- a/packages/tsrx-core-compat/package.json
+++ b/packages/tsrx-core-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tsrx/oxc-core-compat",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A dependency-light @tsrx/core parser facade powered by @tsrx/oxc/parser",
   "keywords": [
     "oxc",
@@ -42,7 +42,7 @@
   "sideEffects": false,
   "dependencies": {
     "@oxc-project/types": "0.140.0",
-    "@tsrx/oxc": "0.11.0"
+    "@tsrx/oxc": "0.12.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/packages/vscode/licenses/BUNDLE_DEPENDENCIES.md
+++ b/packages/vscode/licenses/BUNDLE_DEPENDENCIES.md
@@ -11,7 +11,7 @@ Rolldown resolves these modules from. `lockKey` is the matching
 
 - Bundle: `packages/vscode/dist/extension.bundle.cjs`
 - Bundle SHA-256: `0835f22e5066d4f6d6d2e3d6d287bdb6a8658b820eb7807970529ff1037742ec`
-- pnpm-lock.yaml SHA-256: `e359efd124ef9233bb758cc5c12eb09e151243e5e16a90d0109f95d3350c2e45`
+- pnpm-lock.yaml SHA-256: `c63690e38b4915613f87cce6ad24e58a5c736eaee7114349b0662f9fa59e70e7`
 - Bundled third-party packages: 12
 
 Every listed license/copyright text is shipped byte-exactly below

--- a/packages/vscode/licenses/bundle-dependencies.json
+++ b/packages/vscode/licenses/bundle-dependencies.json
@@ -3,7 +3,7 @@
   "generatedBy": "scripts/generate-vscode-license-inventory.ts",
   "bundle": "packages/vscode/dist/extension.bundle.cjs",
   "bundleSha256": "0835f22e5066d4f6d6d2e3d6d287bdb6a8658b820eb7807970529ff1037742ec",
-  "lockfileSha256": "e359efd124ef9233bb758cc5c12eb09e151243e5e16a90d0109f95d3350c2e45",
+  "lockfileSha256": "c63690e38b4915613f87cce6ad24e58a5c736eaee7114349b0662f9fa59e70e7",
   "packageCount": 12,
   "packages": [
     {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oxc-tsrx-vscode",
   "displayName": "OXC for TSRX",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Official OXC editor support for TSRX",
   "homepage": "https://oxc.tsrx.dev",
   "publisher": "thejackshelton",
@@ -58,7 +58,7 @@
     "THIRD_PARTY_NOTICES.md"
   ],
   "dependencies": {
-    "@tsrx/oxc": "0.11.0",
+    "@tsrx/oxc": "0.12.0",
     "vscode-languageclient": "10.1.0"
   },
   "contributes": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,13 +111,13 @@ importers:
         specifier: 0.140.0
         version: 0.140.0
       '@tsrx/oxc':
-        specifier: 0.11.0
+        specifier: 0.12.0
         version: link:../toolchain
 
   packages/vscode:
     dependencies:
       '@tsrx/oxc':
-        specifier: 0.11.0
+        specifier: 0.12.0
         version: link:../toolchain
       vscode-languageclient:
         specifier: 10.1.0

--- a/tests/editor/official-oxc-toolchain-run.mjs
+++ b/tests/editor/official-oxc-toolchain-run.mjs
@@ -363,7 +363,7 @@ async function runPatchedHostSession({
         name: "oxc-tsrx-patched-host-discovery-proof",
         private: true,
         type: "module",
-        dependencies: { "@tsrx/oxc": "0.11.0" },
+        dependencies: { "@tsrx/oxc": "0.12.0" },
       },
       null,
       2,
@@ -881,7 +881,7 @@ async function main() {
           name: "oxc-tsrx-official-extension-proof",
           private: true,
           type: "module",
-          dependencies: { "@tsrx/oxc": "0.11.0" },
+          dependencies: { "@tsrx/oxc": "0.12.0" },
         },
         null,
         2,
@@ -907,7 +907,7 @@ async function main() {
     const directDependencies = JSON.parse(
       await readFile(join(consumer, "package.json"), "utf8"),
     ).dependencies;
-    assert.deepEqual(directDependencies, { "@tsrx/oxc": "0.11.0" });
+    assert.deepEqual(directDependencies, { "@tsrx/oxc": "0.12.0" });
 
     const { ordinaryPath, tsrxPath } = await writeWorkspaceFixtures(consumer, {
       "oxc.enable.oxlint": true,
@@ -948,7 +948,7 @@ async function main() {
           name: "oxc-tsrx-install-only-discovery-proof",
           private: true,
           type: "module",
-          dependencies: { "@tsrx/oxc": "0.11.0" },
+          dependencies: { "@tsrx/oxc": "0.12.0" },
         },
         null,
         2,

--- a/tests/editor/oxlint-multiplexer.test.mjs
+++ b/tests/editor/oxlint-multiplexer.test.mjs
@@ -685,7 +685,7 @@ test("the real entry point discovers the index and still starts only canonical O
   context.after(() => rm(project, { recursive: true, force: true }));
   await writeFile(
     join(project, "package.json"),
-    `${JSON.stringify({ name: "host", private: true, dependencies: { "@tsrx/oxc": "0.11.0" } })}\n`,
+    `${JSON.stringify({ name: "host", private: true, dependencies: { "@tsrx/oxc": "0.12.0" } })}\n`,
   );
   await mkdir(join(project, "node_modules/@tsrx"), { recursive: true });
   await symlink(toolchainRoot, join(project, "node_modules/@tsrx/oxc"), "dir");
@@ -733,7 +733,7 @@ test("a project's own official Oxlint is the canonical upstream when the launche
   context.after(() => rm(project, { recursive: true, force: true }));
   await writeFile(
     join(project, "package.json"),
-    `${JSON.stringify({ name: "host", private: true, dependencies: { "@tsrx/oxc": "0.11.0", oxlint: "1.81.0" } })}\n`,
+    `${JSON.stringify({ name: "host", private: true, dependencies: { "@tsrx/oxc": "0.12.0", oxlint: "1.81.0" } })}\n`,
   );
   await mkdir(join(project, "node_modules/@tsrx"), { recursive: true });
   await symlink(toolchainRoot, join(project, "node_modules/@tsrx/oxc"), "dir");

--- a/tests/editor/package.test.mjs
+++ b/tests/editor/package.test.mjs
@@ -33,7 +33,7 @@ test("editor package is additive, workspace-native, bundled, and VSIX-packaged",
     "onLanguage:tsrx",
     "workspaceContains:**/*.tsrx",
   ]);
-  assert.equal(manifest.dependencies["@tsrx/oxc"], "0.11.0");
+  assert.equal(manifest.dependencies["@tsrx/oxc"], "0.12.0");
 
   const directory = await mkdtemp(join(tmpdir(), "oxc-tsrx-vsix-"));
   const output = join(directory, "oxc-tsrx-vscode.vsix");

--- a/tests/editor/vscode-run.mjs
+++ b/tests/editor/vscode-run.mjs
@@ -163,7 +163,7 @@ async function runInstallOnlyDiscoverySession() {
           name: "oxc-tsrx-own-client-discovery-proof",
           private: true,
           type: "module",
-          dependencies: { "@tsrx/oxc": "0.11.0" },
+          dependencies: { "@tsrx/oxc": "0.12.0" },
         },
         null,
         2,

--- a/tests/markless-dropin/facade.test.mjs
+++ b/tests/markless-dropin/facade.test.mjs
@@ -879,10 +879,10 @@ test("the package is a publishable, dependency-light compatibility facade", asyn
   const manifest = JSON.parse(await readFile(manifestUrl, "utf8"));
 
   assert.equal(manifest.name, "@tsrx/oxc-core-compat");
-  assert.equal(manifest.version, "0.11.0");
+  assert.equal(manifest.version, "0.12.0");
   assert.equal(manifest.type, "module");
   assert.equal(manifest.sideEffects, false);
-  assert.equal(manifest.dependencies["@tsrx/oxc"], "0.11.0");
+  assert.equal(manifest.dependencies["@tsrx/oxc"], "0.12.0");
   assert.equal(manifest.dependencies["@tsrx/core"], undefined);
   assert.deepEqual(Object.keys(manifest.exports).sort(), [
     ".",

--- a/tests/packaging/clean-install.test.mjs
+++ b/tests/packaging/clean-install.test.mjs
@@ -127,7 +127,7 @@ test("untouched tarballs run the complete supported workflow from an empty consu
     private: true,
     type: "module",
     dependencies: {
-      "@tsrx/oxc": "0.11.0",
+      "@tsrx/oxc": "0.12.0",
       "vite-plus": "0.2.4",
     },
   };

--- a/tests/packaging/native-package.test.mjs
+++ b/tests/packaging/native-package.test.mjs
@@ -194,7 +194,7 @@ function packedEntry(target) {
   return {
     id: `${nativePackageName(target)}@0.1.0`,
     name: nativePackageName(target),
-    version: "0.11.0",
+    version: "0.12.0",
     size: 6426070,
     unpackedSize: 14097905,
     shasum: "62e463f312886399ada17ae8cbbc6b0288856690",
@@ -270,7 +270,7 @@ test("current native release stages a complete, checksummed, npm-installable pla
     "--allow-missing-parser-addon",
   ]);
   const packaged = JSON.parse(stdout);
-  assert.equal(packaged.version, "0.11.0");
+  assert.equal(packaged.version, "0.12.0");
   assert.equal(packaged.target, hostTarget());
   assert.match(packaged.packageName, /^@tsrx\/oxc-/);
   assert.equal(resolve(packaged.tarball).startsWith(resolve(artifacts)), true);
@@ -291,7 +291,7 @@ test("current native release stages a complete, checksummed, npm-installable pla
   const packageRoot = join(consumer, "node_modules", ...packaged.packageName.split("/"));
   assert.equal((await realpath(packageRoot)).startsWith(await realpath(consumer)), true);
   const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
-  assert.equal(manifest.version, "0.11.0");
+  assert.equal(manifest.version, "0.12.0");
   assert.equal(manifest.oxcTsrx.target, hostTarget());
   assert.equal(manifest.oxcTsrx.oxcRevision, "8e0ed2ebb96137fb1611cdbd5742d5cb46037d40");
   assert.equal(manifest.scripts, undefined);
@@ -407,7 +407,7 @@ test("canonical parser packaging adds one verified schema-2 addon without changi
   assert.equal(record.apiVersion, 1);
   assert.equal(record.transportAbi, 1);
   assert.equal(record.nodeApi, 8);
-  assert.equal(record.packageVersion, "0.11.0");
+  assert.equal(record.packageVersion, "0.12.0");
   assert.equal(record.target, hostTarget());
   assert.equal(record.oxcRevision, "8e0ed2ebb96137fb1611cdbd5742d5cb46037d40");
   assert.deepEqual(record.capabilities, {

--- a/tests/packaging/native-version.test.mjs
+++ b/tests/packaging/native-version.test.mjs
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 const root = resolve(import.meta.dirname, "../..");
-const version = "0.11.0";
+const version = "0.12.0";
 const revision = "8e0ed2ebb96137fb1611cdbd5742d5cb46037d40";
 
 function run(executable, args) {

--- a/tests/packaging/provider-discovery.test.mjs
+++ b/tests/packaging/provider-discovery.test.mjs
@@ -388,7 +388,7 @@ test(
     };
 
     await context.test("npm: one declared dependency and no activation step", async () => {
-      const app = await consumer("npm-consumer", { "@tsrx/oxc": "0.11.0" });
+      const app = await consumer("npm-consumer", { "@tsrx/oxc": "0.12.0" });
       await mustRun(
         npm,
         ["install", "--ignore-scripts", "--no-audit", "--no-fund", `--registry=${registry.url}`],
@@ -485,7 +485,7 @@ test(
         subtest.skip("pnpm is not installed");
         return;
       }
-      const app = await consumer("pnpm-consumer", { "@tsrx/oxc": "0.11.0" });
+      const app = await consumer("pnpm-consumer", { "@tsrx/oxc": "0.12.0" });
       await mustRun(
         pnpm,
         ["install", "--ignore-scripts", `--registry=${registry.url}`],
@@ -524,7 +524,7 @@ test(
       async () => {
         const app = await consumer("mixed-consumer", {
           "demo-language-provider": "1.0.0",
-          "@tsrx/oxc": "0.11.0",
+          "@tsrx/oxc": "0.12.0",
         });
         await mustRun(
           npm,
@@ -625,7 +625,7 @@ test("the providers report is a read-only audit that fails loudly", async (conte
   };
 
   await context.test("a clean project reports every declared capability", async () => {
-    const project = await fixture("solo", { "@tsrx/oxc": "0.11.0" }, {});
+    const project = await fixture("solo", { "@tsrx/oxc": "0.12.0" }, {});
     const before = await snapshot(project);
     const result = await run(process.execPath, [cli, "providers", "--json", "--project", project]);
     assert.equal(result.status, 0, result.stderr);
@@ -640,7 +640,7 @@ test("the providers report is a read-only audit that fails loudly", async (conte
 
     const text = await run(process.execPath, [cli, "providers", "--project", project]);
     assert.equal(text.status, 0, text.stderr);
-    assert.match(text.stdout, /@tsrx\/oxc@0\.11\.0 \(provider tsrx, protocol 1\)/u);
+    assert.match(text.stdout, /@tsrx\/oxc@0\.12\.0 \(provider tsrx, protocol 1\)/u);
     assert.match(text.stdout, /language tsrx: \.tsrx/u);
     assert.match(text.stdout, /routed extensions: \.tsrx -> @tsrx\/oxc/u);
   });
@@ -648,7 +648,7 @@ test("the providers report is a read-only audit that fails loudly", async (conte
   await context.test("two providers claiming one extension fail loudly", async () => {
     const project = await fixture(
       "conflict",
-      { "@tsrx/oxc": "0.11.0", "rival-language-provider": "1.0.0" },
+      { "@tsrx/oxc": "0.12.0", "rival-language-provider": "1.0.0" },
       { "rival-language-provider": providerStub("rival-language-provider", "rival", ".tsrx") },
     );
     const result = await run(process.execPath, [cli, "providers", "--json", "--project", project]);

--- a/tests/packaging/provider-matrix.test.mjs
+++ b/tests/packaging/provider-matrix.test.mjs
@@ -545,7 +545,7 @@ test(
         ...NATIVE_TARGETS.map((platform) => [
           `native-${platform.packageSuffix}`,
           nativePackageName(platform),
-          "0.11.0",
+          "0.12.0",
         ]),
       ].map(([directory, name, version]) =>
         writePackage(
@@ -578,7 +578,7 @@ test(
       const directory = join(temporary, name);
       await writePackage(
         directory,
-        { name, private: true, type: "module", ...manifest, dependencies: { "@tsrx/oxc": "0.11.0" } },
+        { name, private: true, type: "module", ...manifest, dependencies: { "@tsrx/oxc": "0.12.0" } },
         files,
       );
       consumers.add(directory);
@@ -952,7 +952,7 @@ test(
         ...NATIVE_TARGETS.map((platform) => [
           `native-${platform.packageSuffix}`,
           nativePackageName(platform),
-          "0.11.0",
+          "0.12.0",
         ]),
       ].map(([directory, name, version]) =>
         writePackage(
@@ -991,7 +991,7 @@ test(
     const app = join(temporary, "mixed-consumer");
     await writePackage(
       app,
-      { name: "mixed-consumer", private: true, type: "module", dependencies: { "@tsrx/oxc": "0.11.0" } },
+      { name: "mixed-consumer", private: true, type: "module", dependencies: { "@tsrx/oxc": "0.12.0" } },
       files,
     );
 

--- a/tests/packaging/public-package-metadata.test.mjs
+++ b/tests/packaging/public-package-metadata.test.mjs
@@ -49,7 +49,7 @@ test("@tsrx/oxc is the complete public toolchain boundary", async () => {
   const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8"));
 
   assert.equal(manifest.name, "@tsrx/oxc");
-  assert.equal(manifest.version, "0.11.0");
+  assert.equal(manifest.version, "0.12.0");
   assert.deepEqual(manifest.bin, {
     "oxc-tsrx": "./bin/oxc-tsrx",
     oxlint: "./bin/oxlint",
@@ -71,14 +71,14 @@ test("@tsrx/oxc is the complete public toolchain boundary", async () => {
   // The eight-platform split is what makes a user download one binary instead
   // of eight, and this package is now the only place that declares it.
   assert.deepEqual(Object.entries(manifest.optionalDependencies), [
-    ["@tsrx/oxc-darwin-arm64", "0.11.0"],
-    ["@tsrx/oxc-darwin-x64", "0.11.0"],
-    ["@tsrx/oxc-linux-arm64-gnu", "0.11.0"],
-    ["@tsrx/oxc-linux-arm64-musl", "0.11.0"],
-    ["@tsrx/oxc-linux-x64-gnu", "0.11.0"],
-    ["@tsrx/oxc-linux-x64-musl", "0.11.0"],
-    ["@tsrx/oxc-win32-arm64-msvc", "0.11.0"],
-    ["@tsrx/oxc-win32-x64-msvc", "0.11.0"],
+    ["@tsrx/oxc-darwin-arm64", "0.12.0"],
+    ["@tsrx/oxc-darwin-x64", "0.12.0"],
+    ["@tsrx/oxc-linux-arm64-gnu", "0.12.0"],
+    ["@tsrx/oxc-linux-arm64-musl", "0.12.0"],
+    ["@tsrx/oxc-linux-x64-gnu", "0.12.0"],
+    ["@tsrx/oxc-linux-x64-musl", "0.12.0"],
+    ["@tsrx/oxc-win32-arm64-msvc", "0.12.0"],
+    ["@tsrx/oxc-win32-x64-msvc", "0.12.0"],
   ]);
   assert.deepEqual(Object.keys(manifest.exports), [
     ".",

--- a/tests/packaging/released-host-install.test.mjs
+++ b/tests/packaging/released-host-install.test.mjs
@@ -415,7 +415,7 @@ test(
     await context.test(
       "the default install path: node_modules/.bin intact, PATH untouched, no setup",
       async () => {
-        const { consumer, environment, bin } = await install("default", { "@tsrx/oxc": "0.11.0" });
+        const { consumer, environment, bin } = await install("default", { "@tsrx/oxc": "0.12.0" });
 
         // Nothing ran but the install, so none of the compatibility bridge's
         // package-name facades can exist.
@@ -492,7 +492,7 @@ test(
         assert.equal(await exists(join(consumer, "node_modules/.bin/oxlint")), true);
         assert.deepEqual(
           JSON.parse(await readFile(join(consumer, "package.json"), "utf8")).dependencies,
-          { "@tsrx/oxc": "0.11.0" },
+          { "@tsrx/oxc": "0.12.0" },
         );
       },
     );
@@ -501,7 +501,7 @@ test(
       "Vite+ keeps working on ordinary files and still cannot see .tsrx",
       async () => {
         const { consumer, environment, bin } = await install("vite-plus", {
-          "@tsrx/oxc": "0.11.0",
+          "@tsrx/oxc": "0.12.0",
           "vite-plus": VITE_PLUS,
         });
         await writeFile(
@@ -652,7 +652,7 @@ test(
     let npmWinner;
     await context.test("a project that also pins official oxlint and oxfmt keeps them", async () => {
       const consumer = await install("collision", {
-        "@tsrx/oxc": "0.11.0",
+        "@tsrx/oxc": "0.12.0",
         oxlint: OFFICIAL_OXLINT,
         oxfmt: OFFICIAL_OXFMT,
       });
@@ -668,7 +668,7 @@ test(
         }
         const consumer = await install(
           "collision-pnpm",
-          { "@tsrx/oxc": "0.11.0", oxlint: OFFICIAL_OXLINT, oxfmt: OFFICIAL_OXFMT },
+          { "@tsrx/oxc": "0.12.0", oxlint: OFFICIAL_OXLINT, oxfmt: OFFICIAL_OXFMT },
           "pnpm",
         );
         const pnpmWinner = await assertPinnedToolsUnchanged(consumer, "pnpm");
@@ -683,7 +683,7 @@ test(
 
     await context.test("a declared but uninstalled official package fails loudly", async () => {
       const { consumer, environment, bin } = await install("declared-missing", {
-        "@tsrx/oxc": "0.11.0",
+        "@tsrx/oxc": "0.12.0",
       });
       const manifest = JSON.parse(await readFile(join(consumer, "package.json"), "utf8"));
       manifest.dependencies.oxlint = OFFICIAL_OXLINT;

--- a/tests/packaging/toolchain-compat.test.mjs
+++ b/tests/packaging/toolchain-compat.test.mjs
@@ -155,7 +155,7 @@ test(
             name: `oxc-tsrx-${manager.name}-consumer`,
             private: true,
             type: "module",
-            devDependencies: { "@tsrx/oxc": "0.11.0" },
+            devDependencies: { "@tsrx/oxc": "0.12.0" },
           };
           await writeFile(
             join(consumer, "package.json"),
@@ -274,7 +274,7 @@ test(
             assert.deepEqual(facade.oxcTsrxCompatibility, {
               schemaVersion: 1,
               provider: "oxc-tsrx",
-              providerVersion: "0.11.0",
+              providerVersion: "0.12.0",
               capability,
             });
           }
@@ -465,7 +465,7 @@ test(
               name: `oxc-tsrx-${manager.name}-direct-consumer`,
               private: true,
               type: "module",
-              devDependencies: { "@tsrx/oxc": "0.11.0", oxlint: officialVersion },
+              devDependencies: { "@tsrx/oxc": "0.12.0", oxlint: officialVersion },
             },
             null,
             2,

--- a/tests/packaging/toolchain-package.test.mjs
+++ b/tests/packaging/toolchain-package.test.mjs
@@ -263,7 +263,7 @@ test("an isolated consumer resolves every public export and bin from the package
         name: "clean-oxc-tsrx-consumer",
         private: true,
         type: "module",
-        devDependencies: { "@tsrx/oxc": "0.11.0" },
+        devDependencies: { "@tsrx/oxc": "0.12.0" },
       }, null, 2)}\n`,
     );
 
@@ -541,7 +541,7 @@ test("the canonical command names arbitrate from the project manifest alone", as
   try {
     // Nothing declared: the launcher keeps the name, which is the only reason a
     // plain install reaches a released host at all.
-    const plain = await project("plain", { "@tsrx/oxc": "0.11.0" });
+    const plain = await project("plain", { "@tsrx/oxc": "0.12.0" });
     assert.deepEqual(await decideCanonicalCommand("oxlint", { cwd: plain }), {
       command: "oxlint",
       owner: "@tsrx/oxc",
@@ -552,13 +552,13 @@ test("the canonical command names arbitrate from the project manifest alone", as
     // A transitive official package is not a statement about the command name,
     // so an installed-but-undeclared `oxlint` changes nothing. This is the case
     // every Vite+ project is in.
-    const transitive = await project("transitive", { "@tsrx/oxc": "0.11.0" }, { oxlint: officialOxlint });
+    const transitive = await project("transitive", { "@tsrx/oxc": "0.12.0" }, { oxlint: officialOxlint });
     assert.equal((await decideCanonicalCommand("oxlint", { cwd: transitive })).owner, "@tsrx/oxc");
 
     // A direct declaration is such a statement, and it wins outright.
     const pinned = await project(
       "pinned",
-      { "@tsrx/oxc": "0.11.0", oxlint: "1.72.0" },
+      { "@tsrx/oxc": "0.12.0", oxlint: "1.72.0" },
       { oxlint: officialOxlint },
     );
     const deferred = await decideCanonicalCommand("oxlint", { cwd: pinned });
@@ -579,7 +579,7 @@ test("the canonical command names arbitrate from the project manifest alone", as
     // nearest project root, so a nested directory inherits it.
     const development = await project(
       "development",
-      { "@tsrx/oxc": "0.11.0" },
+      { "@tsrx/oxc": "0.12.0" },
       { oxlint: officialOxlint },
     );
     const developmentManifest = JSON.parse(
@@ -599,17 +599,17 @@ test("the canonical command names arbitrate from the project manifest alone", as
     // Deferring to it would re-enter this launcher without bound, so it does not.
     const bridged = await project(
       "bridged",
-      { "@tsrx/oxc": "0.11.0", oxlint: "1.72.0" },
+      { "@tsrx/oxc": "0.12.0", oxlint: "1.72.0" },
       {
         oxlint: {
           manifest: {
             name: "oxlint",
-            version: "0.11.0",
+            version: "0.12.0",
             bin: { oxlint: "./bin/oxlint" },
             oxcTsrxCompatibility: {
               schemaVersion: 1,
               provider: "oxc-tsrx",
-              providerVersion: "0.11.0",
+              providerVersion: "0.12.0",
               capability: "lint",
             },
           },
@@ -624,7 +624,7 @@ test("the canonical command names arbitrate from the project manifest alone", as
     // Genuinely ambiguous: the project named a package that is not there. There
     // is no safe guess, so it refuses instead of quietly linting with the wrong
     // tool.
-    const missing = await project("missing", { "@tsrx/oxc": "0.11.0", oxfmt: "0.44.0" });
+    const missing = await project("missing", { "@tsrx/oxc": "0.12.0", oxfmt: "0.44.0" });
     await assert.rejects(
       () => decideCanonicalCommand("oxfmt", { cwd: missing }),
       /declares the official oxfmt package in dependencies.*not installed/su,
@@ -792,7 +792,7 @@ async function providerFixture(temporary, name, { ownsLinterShim }) {
         name: basename(name),
         private: true,
         type: "module",
-        devDependencies: { "@tsrx/oxc": "0.11.0" },
+        devDependencies: { "@tsrx/oxc": "0.12.0" },
       },
       null,
       2,
@@ -800,7 +800,7 @@ async function providerFixture(temporary, name, { ownsLinterShim }) {
   );
   await writeFile(
     join(provider, "package.json"),
-    `${JSON.stringify({ name: "@tsrx/oxc", version: "0.11.0", bin: { oxlint: "./bin/oxlint" } }, null, 2)}\n`,
+    `${JSON.stringify({ name: "@tsrx/oxc", version: "0.12.0", bin: { oxlint: "./bin/oxlint" } }, null, 2)}\n`,
   );
   await writeFile(join(provider, "bin", "oxlint"), "#!/usr/bin/env node\n");
 
@@ -1465,7 +1465,7 @@ test("unnecessary is proven from every folder that might be opened, not assumed"
     await mkdir(join(monorepo, "node_modules", ".bin"), { recursive: true });
     await writeFile(
       join(hoisted, "package.json"),
-      `${JSON.stringify({ name: "@tsrx/oxc", version: "0.11.0", bin: { oxlint: "./bin/oxlint" } }, null, 2)}\n`,
+      `${JSON.stringify({ name: "@tsrx/oxc", version: "0.12.0", bin: { oxlint: "./bin/oxlint" } }, null, 2)}\n`,
     );
     await writeFile(join(hoisted, "bin", "oxlint"), "#!/usr/bin/env node\n");
     const rootShim = join(monorepo, "node_modules", ".bin", "oxlint");

--- a/tests/packaging/vite-plus-matrix.test.mjs
+++ b/tests/packaging/vite-plus-matrix.test.mjs
@@ -286,7 +286,7 @@ async function exerciseLane(lane, artifacts, environment) {
       type: "module",
       dependencies: {
         "@tsrx/vite-plugin-react": "0.0.72",
-        "@tsrx/oxc": "0.11.0",
+        "@tsrx/oxc": "0.12.0",
         react: "19.2.7",
         "react-dom": "19.2.7",
         "vite-plus": lane.vitePlusVersion,

--- a/tests/packaging/vscode-artifact.test.mjs
+++ b/tests/packaging/vscode-artifact.test.mjs
@@ -85,7 +85,7 @@ test("platform VSIX embeds exactly the matching native language server and notic
   assert.equal(packaged.target, hostTarget());
   assert.equal(packaged.extensionId, "thejackshelton.oxc-tsrx-vscode");
   assert.equal(packaged.vsixVerification.extensionId, packaged.extensionId);
-  assert.equal(packaged.vsixVerification.version, "0.11.0");
+  assert.equal(packaged.vsixVerification.version, "0.12.0");
   assert.equal(packaged.vsixVerification.target, packaged.target);
   assert.equal(packaged.vsixVerification.vscodeTarget, packaged.vscodeTarget);
   assert.equal(packaged.vsixVerification.nativeLspSha256, packaged.lspSha256);

--- a/tests/plugins/custom-js-plugins-doc.test.mjs
+++ b/tests/plugins/custom-js-plugins-doc.test.mjs
@@ -428,7 +428,7 @@ async function makeWalkthroughProject() {
   await writeFile(
     join(project, "package.json"),
     `${JSON.stringify(
-      { name: "my-app", private: true, type: "module", devDependencies: { "@tsrx/oxc": "0.11.0" } },
+      { name: "my-app", private: true, type: "module", devDependencies: { "@tsrx/oxc": "0.12.0" } },
       null,
       2,
     )}\n`,

--- a/tests/vite/physical-consumer.mjs
+++ b/tests/vite/physical-consumer.mjs
@@ -163,7 +163,7 @@ export async function installPhysicalToolPackages(modules, vitePlusPackage) {
   const projectManifest = JSON.parse(await readFile(projectManifestPath, "utf8"));
   projectManifest.devDependencies = {
     ...projectManifest.devDependencies,
-    "@tsrx/oxc": "0.11.0",
+    "@tsrx/oxc": "0.12.0",
   };
   await writeFile(projectManifestPath, `${JSON.stringify(projectManifest, null, 2)}\n`);
   await setupCompatibility({ projectRoot });


### PR DESCRIPTION
The v0.12.0 cut: a file OXC cannot parse is a named, positioned per-file error instead of a batch failure (#79, #81), plus the live engine check reading the pin through the API to satisfy the launch contract. Produced with the Manual Release workflow's own steps on this branch. Tag v0.12.0 points at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and lockfile updates plus a CI-only pin lookup change; no runtime product logic changes in this diff.
> 
> **Overview**
> **v0.12.0 release cut** — bumps the workspace and every published surface (`@tsrx/oxc`, native optional packages, VS Code extension, `@tsrx/oxc-core-compat`, Rust crates, docs scaffold pins) from **0.11.0** to **0.12.0**, with matching updates to `Cargo.lock`, `pnpm-lock.yaml`, generated Rust/VS Code license inventories, and packaging/editor tests that assert version strings.
> 
> The **live engine check** on `main` no longer checks out the repo to read `website-oxc/wasm-pin.json`. It fetches the pin for **`GITHUB_SHA`** via the GitHub Contents API (`gh api` + `GH_TOKEN`) and still polls `oxc.tsrx.dev` until the served WASM SHA matches—aligning post-deploy verification with the “look only, no build” contract.
> 
> The demo WASM subtree lockfile refresh adds **`oxc_diagnostics`** to `oxc_adapter`'s dependency list at the new crate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4fad5c5b98839d2cd6dc9b96e4b6f0c6b4fb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->