### PR TITLE
test(lint): accept the annotation reporter in the parse-failure launcher test

### DIFF
--- a/tests/config/native-lint-config.test.mjs
+++ b/tests/config/native-lint-config.test.mjs
@@ -1004,8 +1004,26 @@ test("the drop-in oxlint names and positions a file OXC cannot parse and keeps t
   const result = await runCompanion(directory, ["."]);
   assert.equal(result.code, 1, `errors exit 1, never the tool-failure 2: ${result.stderr || result.stdout}`);
   assert.doesNotMatch(result.stderr, /OXC parse failed/u, "the failure is a diagnostic, not a stderr abort");
-  assert.match(result.stdout, /src\/Probe\.tsrx:3:\d+: error: OXC parse failed: /u, result.stdout);
-  assert.match(result.stdout, /src\/Clean\.tsrx:2:\d+: error eslint\(no-debugger\)/u, result.stdout);
+  // Whichever reporter this environment selects: a GitHub runner gets annotations, a terminal
+  // gets the positioned line. A rule-less diagnostic is titled `oxlint` by the annotation
+  // reporter, as canonical Oxlint titles its own parse errors.
+  assert.match(
+    result.stdout,
+    composedReporter === "github"
+      ? /^::error file=src\/Probe\.tsrx,line=3,endLine=\d+,col=\d+,endColumn=\d+,title=oxlint::OXC parse failed: /mu
+      : /^src\/Probe\.tsrx:3:\d+: error: OXC parse failed: /mu,
+    result.stdout,
+  );
+  assert.match(
+    result.stdout,
+    diagnosticPattern(composedReporter, {
+      file: "src/Clean.tsrx",
+      line: 2,
+      severity: "error",
+      code: "eslint(no-debugger)",
+    }),
+    result.stdout,
+  );
   assert.match(result.stdout, /on 3 files/u, result.stdout);
   await rm(directory, { recursive: true, force: true });
 });


### PR DESCRIPTION
CI on main failed in the launcher test added by #81: on a GitHub runner the drop-in oxlint prints annotations (`::error file=…`), and the test asserted only the terminal form. It now selects the pattern by the ambient reporter like the neighbouring syntax-error test, and passes under both locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production lint or reporter behavior is modified.
> 
> **Overview**
> Fixes CI failures on GitHub Actions where the drop-in `oxlint` wrapper emits workflow annotations (`::error file=…`) instead of terminal `file:line:col` lines.
> 
> The **parse-failure launcher** test (`the drop-in oxlint names and positions a file OXC cannot parse`) no longer hardcodes only the terminal stdout shape. It now picks assertions from `composedReporter`, matching the neighbouring syntax-error and fidelity tests: GitHub gets an annotation regex with `title=oxlint` for rule-less OXC parse errors, and the `eslint(no-debugger)` hit on `Clean.tsrx` goes through `diagnosticPattern`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83951a8f41674a346e375e104dc85ccb9a267585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->